### PR TITLE
Use .hs and .lhs as default file extension

### DIFF
--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -24,6 +24,7 @@ automatic :: Cmd -> IO Cmd
 automatic Cmd{..} = do
     cmdDataDir <- if cmdDataDir == "" then getDataDir else return cmdDataDir
     cmdPath <- return $ if null cmdPath then ["."] else cmdPath
+    cmdExtension <- return $ if null cmdExtension then ["hs", "lhs"] else cmdExtension
     return Cmd{..}
 
 


### PR DESCRIPTION
With a96570b, `hlint some-directory` didn't work anymore. This is because by
default, the list of file extensions was empty.
