### PR TITLE
Enable TypeSynonymInstances to satisfy GHC 7.0

### DIFF
--- a/src/HSE/FreeVars.hs
+++ b/src/HSE/FreeVars.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
 
 module HSE.FreeVars(FreeVars, freeVars, vars, varss, pvars, declBind) where
 


### PR DESCRIPTION
Otherwise GHC would complain about

```
src/HSE/FreeVars.hs:69:10:
    Illegal instance declaration for `FreeVars Exp_'
      (All instance types must be of the form (T t1 ... tn)
       where T is not a synonym.
       Use -XTypeSynonymInstances if you want to disable this.)
    In the instance declaration for `FreeVars Exp_'

src/HSE/FreeVars.hs:89:10:
    Illegal instance declaration for `AllVars Pat_'
      (All instance types must be of the form (T t1 ... tn)
       where T is not a synonym.
       Use -XTypeSynonymInstances if you want to disable this.)
    In the instance declaration for `AllVars Pat_'
```
