### PR TITLE
Add --numeric-version flag.

### DIFF
--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE PatternGuards, RecordWildCards, DeriveDataTypeable #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
 
-module CmdLine(Cmd(..), cmdCpp, CppFlags(..), getCmd, cmdExtensions, cmdHintFiles, exitWithHelp, resolveFile) where
+module CmdLine(Cmd(..), cmdCpp, CppFlags(..), getCmd, cmdExtensions, cmdHintFiles, exitWithHelp, exitWithNumericVersion, resolveFile) where
 
 import Data.Char
 import Data.List
@@ -44,6 +44,10 @@ exitWithHelp = do
     putStr $ show $ helpText [] HelpFormatAll mode
     exitSuccess
 
+exitWithNumericVersion :: IO a
+exitWithNumericVersion = do
+    putStrLn $ showVersion version
+    exitSuccess
 
 -- | What C pre processor should be used.
 data CppFlags
@@ -54,7 +58,8 @@ data CppFlags
 
 data Cmd
     = CmdMain
-        {cmdFiles :: [FilePath]    -- ^ which files to run it on, nothing = none given
+        {cmdNumericVersion :: Bool       -- ^ Display numeric version and exit
+        ,cmdFiles :: [FilePath]          -- ^ which files to run it on, nothing = none given
         ,cmdReports :: [FilePath]        -- ^ where to generate reports
         ,cmdGivenHints :: [FilePath]     -- ^ which settignsfiles were explicitly given
         ,cmdWithHints :: [String]        -- ^ hints that are given on the command line
@@ -106,7 +111,8 @@ data Cmd
 
 mode = cmdArgsMode $ modes
     [CmdMain
-        {cmdFiles = def &= args &= typ "FILE/DIR"
+        {cmdNumericVersion = nam_ "numeric-version" &= help "Print numeric version and exit"
+        ,cmdFiles = def &= args &= typ "FILE/DIR"
         ,cmdReports = nam "report" &= opt "report.html" &= typFile &= help "Generate a report in HTML"
         ,cmdGivenHints = nam "hint" &= typFile &= help "Hint/ignore file to use"
         ,cmdWithHints = nam "with" &= typ "HINT" &= help "Extra hints to use"

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -98,17 +98,19 @@ hlintMain :: Cmd -> IO [Suggestion]
 hlintMain cmd@CmdMain{..} = do
     encoding <- readEncoding cmdEncoding
     let flags = parseFlagsSetExtensions (cmdExtensions cmd) $ defaultParseFlags{cppFlags=cmdCpp cmd, encoding=encoding}
-    if null cmdFiles && notNull cmdFindHints then do
-        hints <- concatMapM (resolveFile cmd) cmdFindHints
-        mapM_ (\x -> putStrLn . fst =<< findSettings2 flags x) hints >> return []
-     else if null cmdFiles then
-        exitWithHelp
-     else do
-        files <- concatMapM (resolveFile cmd) cmdFiles
-        if null files then
-            error "No files found"
-         else
-            runHints cmd{cmdFiles=files} flags
+    if cmdNumericVersion then
+        exitWithNumericVersion
+     else if null cmdFiles && notNull cmdFindHints then do
+         hints <- concatMapM (resolveFile cmd) cmdFindHints
+         mapM_ (\x -> putStrLn . fst =<< findSettings2 flags x) hints >> return []
+      else if null cmdFiles then
+         exitWithHelp
+      else do
+         files <- concatMapM (resolveFile cmd) cmdFiles
+         if null files then
+             error "No files found"
+          else
+             runHints cmd{cmdFiles=files} flags
 
 readAllSettings :: Cmd -> ParseFlags -> IO [Setting]
 readAllSettings cmd@CmdMain{..} flags = do


### PR DESCRIPTION
The json output flag just added is meant for other tools. Adding `--numeric-version`, which is also meant for tools, in the same release seems reasonable. This change allows HLint to preserve the numeric-version behaviour across different releases of cmdargs. 

I hacked the flag into main mode. I'm not sure if it should go elsewhere--it's definitely a common flag. Setting the group name for the flag alters the group name for the entire mode rather than putting the numeric-version flag in the common section. 

I still have the TODO for cmdargs support on my list, but haven't gotten around to that yet. 
