### PR TITLE
Add a --no-summary option for cmdline output

### DIFF
--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -75,6 +75,7 @@ data Cmd
         ,cmdCppSimple :: Bool
         ,cmdCppAnsi :: Bool
         ,cmdJson :: Bool                -- ^ display hint data as JSON
+        ,cmdNoSummary :: Bool           -- ^ do not show the summary info
         }
     | CmdGrep
         {cmdFiles :: [FilePath]    -- ^ which files to run it on, nothing = none given
@@ -127,6 +128,7 @@ mode = cmdArgsMode $ modes
         ,cmdCppSimple = nam_ "cpp-simple" &= help "Use a simple CPP (strip # lines)"
         ,cmdCppAnsi = nam_ "cpp-ansi" &= help "Use CPP in ANSI compatibility mode"
         ,cmdJson = nam_ "json" &= help "Display hint data as JSON"
+        ,cmdNoSummary = nam_ "no-summary" &= help "Do not show summary information"
         } &= auto &= explicit &= name "lint"
     ,CmdGrep
         {cmdFiles = def &= args &= typ "FILE/DIR"

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -139,7 +139,8 @@ runHints cmd@CmdMain{..} flags = do
                 forM_ cmdReports $ \x -> do
                     outStrLn $ "Writing report to " ++ x ++ " ..."
                     writeReport cmdDataDir x showideas
-            outStrLn $
-                (let i = length showideas in if i == 0 then "No suggestions" else show i ++ " suggestion" ++ ['s'|i/=1]) ++
-                (let i = length hideideas in if i == 0 then "" else " (" ++ show i ++ " ignored)")
+            unless cmdNoSummary $
+                outStrLn $
+                    (let i = length showideas in if i == 0 then "No suggestions" else show i ++ " suggestion" ++ ['s'|i/=1]) ++
+                    (let i = length hideideas in if i == 0 then "" else " (" ++ show i ++ " ignored)")
     return $ map Suggestion showideas

--- a/tests/flag-no-summary.test
+++ b/tests/flag-no-summary.test
@@ -1,0 +1,18 @@
+---------------------------------------------------------------------
+RUN tests/flag-no-summary1.hs --no-summary
+FILE tests/flag-no-summary1.hs
+main = map f $ map g xs
+OUTPUT
+tests/flag-no-summary1.hs:1:8: Warning: Use map once
+Found:
+  map f $ map g xs
+Why not:
+  map (f . g) xs
+
+EXIT 1
+---------------------------------------------------------------------
+RUN tests/flag-no-summary2.hs --no-summary
+FILE tests/flag-no-summary2.hs
+main = return ()
+OUTPUT
+EXIT 0


### PR DESCRIPTION
Currently, the cmdline output is pretty regular, with the exception of the
summary information ("No suggestions", "n suggestions."). In order to simplify
a bit the parsing of cmdline output (where full power of json is not needed), a
--no-summary flag is added that skips this last bit. This fixes #67.

Tests are added as well, although this test suite format is a bit strange and
I'm not sure I did the right thing.
