### PR TITLE
Change colour output behaviour

### DIFF
--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -131,7 +131,8 @@ runHints cmd@CmdMain{..} flags = do
     if cmdJson
         then putStrLn . showIdeasJson $ showideas
         else do
-            showItem <- if cmdColor then showANSI else return show
+            usecolour <- cmdUseColour cmd
+            showItem <- if usecolour then showANSI else return show
             mapM_ (outStrLn . showItem) showideas
             if null showideas then
                 when (cmdReports /= []) $ outStrLn "Skipping writing reports"


### PR DESCRIPTION
See the commit description for details. I don't have a Windows ghc installation, so I can't test that it indeed does the right thing there, so beware. I added the ColourMode type since CmdArgs doesn't seem to have an on/off/auto type parameter (Maybe Bool is not good, since you can't explicitly pass Nothing - any passed value is a Just). The Windows-vs-Linux handling is done via different defaults (off on Windows, auto on non-Windows).

Let me know if you'd prefer a different way to handle this. And thanks for reviewing!
