### PR TITLE
Added FlexibleContexts flag required by ghc-7.9

### DIFF
--- a/src/Hint/List.hs
+++ b/src/Hint/List.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ViewPatterns, PatternGuards #-}
+{-# LANGUAGE ViewPatterns, PatternGuards, FlexibleContexts #-}
 
 {-
     Find and match:

--- a/src/Hint/Match.hs
+++ b/src/Hint/Match.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE PatternGuards, ViewPatterns, RelaxedPolyRec, RecordWildCards #-}
+{-# LANGUAGE PatternGuards, ViewPatterns, RelaxedPolyRec, RecordWildCards, FlexibleContexts #-}
 
 {-
 The matching does a fairly simple unification between the two terms, treating

--- a/src/Test/Proof.hs
+++ b/src/Test/Proof.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, PatternGuards #-}
+{-# LANGUAGE RecordWildCards, PatternGuards, FlexibleContexts #-}
 
 -- | Check the coverage of the hints given a list of Isabelle theorems
 module Test.Proof(proof) where


### PR DESCRIPTION
Hlint does not not compile under ghc-7.9 without FlexibleContexts flag. I added it.
