### PR TITLE
Extend 'Default' hints to complain when people reinvent the Either a fun...

### DIFF
--- a/data/Default.hs
+++ b/data/Default.hs
@@ -396,6 +396,7 @@ warn "Too strict maybe" = maybe (f x) (f . g) ==> f . maybe x g where note = Inc
 
 error = [a | Left a <- a] ==> lefts a
 error = [a | Right a <- a] ==> rights a
+error = either Left (Right . f) ==> fmap f
 
 -- INFIX
 


### PR DESCRIPTION
...ctor

I just noticed that I accidentally reimplemented the 'Either a' functor
in my code, having

  compile = either Left (Right . optimize) . parse

Let hlint detect this case, suggesting to just use

  compile = fmap optimize . parse

instead; the Functor instance for 'Either a' does just what we want.
