### PR TITLE
Get executable to compile when gpl flag is disabled

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -114,3 +114,5 @@ executable hlint
     if flag(threaded)
         ghc-options:    -threaded
 
+    if !flag(gpl)
+        cpp-options: -DGPL_SCARES_ME


### PR DESCRIPTION
I can sometimes get hlint to compile without this patch, but I'm not sure why. This seems to get things working reliably. An alternative patch which may be better is at:

https://github.com/fpco/hlint/commit/808b7b00f7cb30a7f68f94cc96a210c4f718d36b

I can update my pull request to use that if you prefer.
