### PR TITLE
Use ansi-terminal's new "hSupportsANSI" function

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -50,7 +50,8 @@ library
         cpphs >= 1.18.1,
         cmdargs >= 0.10,
         haskell-src-exts >= 1.16 && < 1.17,
-        uniplate >= 1.5
+        uniplate >= 1.5,
+        ansi-terminal >= 0.6.2
 
     if flag(gpl)
         build-depends: hscolour >= 1.17

--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -5,12 +5,13 @@ module CmdLine(Cmd(..), cmdCpp, CppFlags(..), getCmd, cmdExtensions, cmdHintFile
 
 import Data.Char
 import Data.List
+import System.Console.ANSI (hSupportsANSI)
 import System.Console.CmdArgs.Implicit
 import System.Console.CmdArgs.Explicit(helpText, HelpFormat(..))
 import System.Directory
 import System.Exit
 import System.FilePath
-import System.IO (hIsTerminalDevice, stdout)
+import System.IO (stdout)
 import Language.Preprocessor.Cpphs
 import Language.Haskell.Exts.Extension
 import System.Environment
@@ -192,11 +193,7 @@ cmdUseColour :: Cmd -> IO Bool
 cmdUseColour cmd = case cmdColor cmd of
   Always -> return True
   Never  -> return False
-  Auto   -> do
-    stdoutIsTerminal <- hIsTerminalDevice stdout
-    termType         <- lookup "TERM" `fmap` getEnvironment
-    return $ stdoutIsTerminal && maybe False isColorTerm termType
-    where isColorTerm t = t == "ansi" || "xterm" `isPrefixOf` t || "xvt" `isSuffixOf` t
+  Auto   -> hSupportsANSI stdout
 
 
 "." <\> x = x


### PR DESCRIPTION
Re. https://github.com/feuerbach/ansi-terminal/issues/4, as fixed by https://github.com/feuerbach/ansi-terminal/commit/c7ed522d00442a7af1b0a0370eb2cc47cd532478 and now already used [elsewhere](https://github.com/feuerbach/tasty/commit/6f0e0a3f1050659ef9241af179da35453676d61d).
