### PR TITLE
Avoid Alt ambiguity on base-4.8.0.0 and above

### DIFF
--- a/src/HSE/FreeVars.hs
+++ b/src/HSE/FreeVars.hs
@@ -3,7 +3,7 @@
 module HSE.FreeVars(FreeVars, freeVars, vars, varss, pvars, declBind) where
 
 import HSE.Type
-import Data.Monoid
+import Data.Monoid (Monoid(..))
 import qualified Data.Set as Set
 import Data.Set(Set)
 


### PR DESCRIPTION
Since `Data.Monoid` exports an `Alt` type in `base-4.8.0.0` and above, explicitly import the `Monoid` functions to avoid creating a naming conflict with HSE's `Alt`.