### PR TITLE
fromJust shouldn't exist in polished code

### DIFF
--- a/data/Default.hs
+++ b/data/Default.hs
@@ -455,6 +455,10 @@ error "Use Foldable.forM_" = (case m of Nothing -> return (); Just x -> f x) ==>
 error "Use Foldable.forM_" = when (isJust m) (f (fromJust m)) ==> Data.Foldable.forM_ m f
     where _ = noQuickCheck
 
+-- PARTIALS
+
+error "fromJust is partial" = fromJust ==> fromMaybe (error "Impossible! This should never happen.")
+
 -- EVALUATE
 
 -- TODO: These should be moved in to HSE\Evaluate.hs and applied


### PR DESCRIPTION
Related to https://mail.haskell.org/pipermail/libraries/2015-February/025010.html

```
% cat testi.hs 
import Data.Maybe

foo :: Maybe Int -> Int
foo x = if isJust x then fromJust x else 0

bar :: Maybe Int -> Int
bar x = 1 + fromJust x

% cabal run testi.hs 
Preprocessing executable 'hlint' for hlint-1.9.16...
Running hlint...
testi.hs:4:9: Error: Use fromMaybe
Found:
  if isJust x then fromJust x else 0
Why not:
  fromMaybe 0 x

testi.hs:4:26: Error: Use fromMaybe
Found:
  fromJust
Why not:
  fromMaybe (error "Impossible! This should never happen.")

testi.hs:7:13: Error: Use fromMaybe
Found:
  fromJust
Why not:
  fromMaybe (error "Impossible! This should never happen.")

3 suggestions
```