### PR TITLE
Integrate a --refactor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ The first suggestion is marked as an error, because using `concatMap` in prefere
 
 **Bug reports:** The suggested replacement should be equivalent - please report all incorrect suggestions not mentioned as known limitations.
 
+### Automatically Applying Hints
+
+By supplying the `--refactor` flag hlint can automatically apply most suggestions. Instead of a list of hints, hlint will instead output the refactored file on stdout. In order to do this a file `hlint.refact` will be created before `refactor` (an executable provided by the [`apply-refact`](https://github.com/mpickering/apply-refact) package) is used to perform the hints.
+
+Additional configuration can be passed to `refactor` with the `--refactor-options` flag. Some useful flags include `-i` which replaces the original file and `-s` which asks for confirmation before performing a hint.
+
+There are no plans to support the duplication nor the renaming hints.
+
 ### Reports
 
 HLint can generate a lot of information, making it difficult to search for particular types of errors. The `--report` flag will cause HLint to generate a report file in HTML, which can be viewed interactively. Reports are recommended when there are more than a handful of hints.
@@ -109,16 +117,6 @@ This will suggest eta reduction to `concat . map op`, and then after making that
 * Some people only make use of some of the suggestions. In the above example using concatMap is a good idea, but sometimes eta reduction isn't. By suggesting them separately, people can pick and choose.
 * Sometimes a transformed expression will be large, and a further hint will apply to some small part of the result, which appears confusing.
 * Consider `f $ (a b)`. There are two valid hints, either remove the $ or remove the brackets, but only one can be applied.
-
-### Why aren't the suggestions automatically applied?
-
-If you want to automatically apply suggestions, the [Emacs integration](https://rawgithub.com/ndmitchell/hlint/master/hlint.htm#emacs) offers such a feature. However, there are a number of reasons that HLint itself doesn't have an option to automatically apply suggestions:
-
-* The underlying Haskell parser library makes it hard to modify the code, then print it similarly to the original.
-* Sometimes multiple transformations may apply.
-* After applying one transformation, others that were otherwise suggested may become inappropriate.
-
-I am intending to develop such a feature, but the above reasons mean it is likely to take some time.
 
 ### Why doesn't the compiler automatically apply the optimisations?
 

--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -92,6 +92,9 @@ data Cmd
         ,cmdJson :: Bool                -- ^ display hint data as JSON
         ,cmdNoSummary :: Bool           -- ^ do not show the summary info
         ,cmdSerialise :: Bool           -- ^ Display hints in serialisation format
+        ,cmdRefactor :: Bool            -- ^ Run the `refactor` executable to automatically perform hints
+        ,cmdRefactorOptions :: String   -- ^ Options to pass to the `refactor` executable.
+        ,cmdWithRefactor :: FilePath    -- ^ Path to refactor tool
         }
     | CmdGrep
         {cmdFiles :: [FilePath]    -- ^ which files to run it on, nothing = none given
@@ -148,6 +151,9 @@ mode = cmdArgsMode $ modes
         ,cmdJson = nam_ "json" &= help "Display hint data as JSON"
         ,cmdNoSummary = nam_ "no-summary" &= help "Do not show summary information"
         ,cmdSerialise = nam_ "serialise" &= help "Serialise hint data for consumption by apply-refact"
+        ,cmdRefactor = nam_ "refactor" &= help "Automatically invoke `refactor` to apply hints"
+        ,cmdRefactorOptions = nam_ "refactor-options" &= typ "OPTIONS" &= help "Options to pass to the `refactor` executable"
+        , cmdWithRefactor = nam_ "with-refactor" &= help "Give the path to refactor"
         } &= auto &= explicit &= name "lint"
     ,CmdGrep
         {cmdFiles = def &= args &= typ "FILE/DIR"
@@ -202,13 +208,13 @@ cmdUseColour cmd = case cmdColor cmd of
 x <\> y = x </> y
 
 
-resolveFile :: Cmd -> Maybe (FilePath, Handle) -> FilePath -> IO [FilePath]
+resolveFile :: Cmd -> Maybe FilePath -> FilePath -> IO [FilePath]
 resolveFile cmd = getFile (cmdPath cmd) (cmdExtension cmd)
 
 
-getFile :: [FilePath] -> [String] -> Maybe (FilePath, Handle) -> FilePath -> IO [FilePath]
-getFile path _ (Just (tmpfile, thandle)) "-" =
-  getContents >>= hPutStr thandle >> hClose thandle >> return [tmpfile]
+getFile :: [FilePath] -> [String] -> Maybe FilePath -> FilePath -> IO [FilePath]
+getFile path _ (Just tmpfile) "-" =
+  getContents >>= writeFile tmpfile >> return [tmpfile]
 getFile path _ Nothing "-" = return ["-"]
 getFile [] exts _ file = error $ "Couldn't find file: " ++ file
 getFile (p:ath) exts t file = do

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -90,7 +90,7 @@ hlintGrep cmd@CmdGrep{..} = do
     if null cmdFiles then
         exitWithHelp
      else do
-        files <- concatMapM (resolveFile cmd) cmdFiles
+        files <- concatMapM (resolveFile cmd Nothing) cmdFiles
         if null files then
             error "No files found"
          else
@@ -98,15 +98,16 @@ hlintGrep cmd@CmdGrep{..} = do
 
 hlintMain :: Cmd -> IO [Suggestion]
 hlintMain cmd@CmdMain{..} = do
+    let resolver = resolveFile cmd Nothing
     encoding <- if cmdUtf8 then return utf8 else readEncoding cmdEncoding
     let flags = parseFlagsSetExtensions (cmdExtensions cmd) $ defaultParseFlags{cppFlags=cmdCpp cmd, encoding=encoding}
     if null cmdFiles && not (null cmdFindHints) then do
-        hints <- concatMapM (resolveFile cmd) cmdFindHints
+        hints <- concatMapM resolver cmdFindHints
         mapM_ (\x -> putStrLn . fst =<< findSettings2 flags x) hints >> return []
      else if null cmdFiles then
         exitWithHelp
      else do
-        files <- concatMapM (resolveFile cmd) cmdFiles
+        files <- concatMapM resolver cmdFiles
         if null files then
             error "No files found"
          else

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -192,7 +192,7 @@ checkRefactor rpath = do
   mexc <- findExecutable excPath
   case mexc of
     Just exc ->  do
-      vers <- readP_to_S parseVersion . tail <$> (readProcess "refactor" ["--version"] "")
+      vers <- readP_to_S parseVersion . tail <$> (readProcess exc ["--version"] "")
       case vers of
         [] -> putStrLn "Unabled to determine version of refactor" >> (return exc)
         (last -> (version, _)) -> if versionBranch version >= [0,1,0,0]

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -13,7 +13,7 @@ import System.IO.Extra
 import Prelude
 
 import Data.Version
-import System.Process
+import System.Process.Extra
 import Data.Maybe
 import System.Directory
 import Text.ParserCombinators.ReadP
@@ -174,7 +174,7 @@ runHints cmd@CmdMain{..} flags = do
     return $ map Suggestion showideas
 
 runRefactoring :: FilePath -> FilePath -> String -> IO ()
-runRefactoring rpath fin opts = callCommand (unwords [rpath, fin, "--refact-file", "hlint.refact", "-v0", opts])
+runRefactoring rpath fin opts = system_ (unwords [rpath, fin, "--refact-file", "hlint.refact", "-v0", opts])
 
 
 checkRefactor :: Maybe FilePath -> IO FilePath

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards, ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 
 module HLint(hlint, Suggestion, suggestionLocation, suggestionSeverity, Severity(..)) where
@@ -9,7 +9,14 @@ import System.Console.CmdArgs.Verbosity
 import Data.List
 import System.Exit
 import System.IO
+import System.IO.Extra
 import Prelude
+
+import Data.Version
+import System.Process
+import Data.Maybe
+import System.Directory
+import Text.ParserCombinators.ReadP
 
 import CmdLine
 import Settings
@@ -98,20 +105,23 @@ hlintGrep cmd@CmdGrep{..} = do
 
 hlintMain :: Cmd -> IO [Suggestion]
 hlintMain cmd@CmdMain{..} = do
-    let resolver = resolveFile cmd Nothing
     encoding <- if cmdUtf8 then return utf8 else readEncoding cmdEncoding
     let flags = parseFlagsSetExtensions (cmdExtensions cmd) $ defaultParseFlags{cppFlags=cmdCpp cmd, encoding=encoding}
     if null cmdFiles && not (null cmdFindHints) then do
-        hints <- concatMapM resolver cmdFindHints
+        hints <- concatMapM (resolveFile cmd Nothing) cmdFindHints
         mapM_ (\x -> putStrLn . fst =<< findSettings2 flags x) hints >> return []
      else if null cmdFiles then
         exitWithHelp
-     else do
-        files <- concatMapM resolver cmdFiles
-        if null files then
-            error "No files found"
-         else
-            runHints cmd{cmdFiles=files} flags
+     else if cmdRefactor then do
+         withTempFile (\t ->  runHlintMain cmd (Just t) flags)
+     else runHlintMain cmd Nothing flags
+
+runHlintMain :: Cmd -> Maybe FilePath -> ParseFlags -> IO [Suggestion]
+runHlintMain cmd@(CmdMain{..}) fp flags = do
+  files <- concatMapM (resolveFile cmd fp) cmdFiles
+  if null files
+    then error "No files found"
+    else runHints cmd{cmdFiles=files} flags
 
 readAllSettings :: Cmd -> ParseFlags -> IO [Setting]
 readAllSettings cmd@CmdMain{..} flags = do
@@ -138,6 +148,17 @@ runHints cmd@CmdMain{..} flags = do
         else if cmdSerialise then do
           hSetBuffering stdout NoBuffering
           print $ map (\i -> (show i, ideaRefactoring i)) showideas
+        else if cmdRefactor then do
+          case cmdFiles of
+            [file] -> do
+              -- Ensure that we can find the executable
+              path <- checkRefactor (if cmdWithRefactor == "" then Nothing else Just cmdWithRefactor)
+              writeFile "hlint.refact" (show $ map (\i -> (show i, ideaRefactoring i)) showideas)
+              runRefactoring path file cmdRefactorOptions
+              -- Overwrite exit code as it is 1 when there are suggestions
+              exitSuccess
+            _ -> error "Refactor flag can only be used with an individual file"
+
         else do
             mapM_ (outStrLn . showItem) showideas
             if null showideas then
@@ -151,6 +172,25 @@ runHints cmd@CmdMain{..} flags = do
                     (let i = length showideas in if i == 0 then "No suggestions" else show i ++ " suggestion" ++ ['s' | i/=1]) ++
                     (let i = length hideideas in if i == 0 then "" else " (" ++ show i ++ " ignored)")
     return $ map Suggestion showideas
+
+runRefactoring :: FilePath -> FilePath -> String -> IO ()
+runRefactoring rpath fin opts = callCommand (unwords [rpath, fin, "--refact-file", "hlint.refact", "-v0", opts])
+
+
+checkRefactor :: Maybe FilePath -> IO FilePath
+checkRefactor rpath = do
+  let excPath = (fromMaybe "refactor" rpath)
+  mexc <- findExecutable excPath
+  case mexc of
+    Just exc ->  do
+      vers <- readP_to_S parseVersion . tail <$> (readProcess "refactor" ["--version"] "")
+      case vers of
+        [] -> putStrLn "Unabled to determine version of refactor" >> (return exc)
+        (last -> (version, _)) -> if versionBranch version >= [0,1,0,0]
+                                    then return exc
+                                    else error "Your version of refactor is too old, please upgrade to the latest version"
+    Nothing ->  error $ unlines ["Could not find refactor"
+                                , "Tried with: " ++ excPath ]
 
 evaluateList :: [a] -> IO [a]
 evaluateList xs = length xs `seq` return xs


### PR DESCRIPTION
Is this like what you had in mind? 

Using a temporary file rather than dealing with stdin later means that you can use a filter in vim to process the file to apply refactorings. This plays much nicer in my brief experience writing vimscript but I'm not sure it's a good idea.