### PR TITLE
Adapt to new haskell-src-exts API.

### DIFF
--- a/src/HSE/Scope.hs
+++ b/src/HSE/Scope.hs
@@ -97,8 +97,8 @@ possImport i (UnQual _ x) = not (importQualified i) && maybe True f (importSpecs
             where ms = map g xs
 
         g :: ImportSpec S -> Maybe Bool -- does this import cover the name x
-        g (IVar _ _ y) = Just $ x =~= y
-        g (IAbs _ y) = Just $ x =~= y
+        g (IVar _ y) = Just $ x =~= y
+        g (IAbs _ _ y) = Just $ x =~= y
         g (IThingAll _ y) = if x =~= y then Just True else Nothing
         g (IThingWith _ y ys) = Just $ x `elem_` (y : map fromCName ys)
 

--- a/src/Hint/Import.hs
+++ b/src/Hint/Import.hs
@@ -139,7 +139,7 @@ hierarchy i@ImportDecl{importModule=ModuleName _ "IO", importSpecs=Nothing,impor
     = [rawIdeaN Warning "Use hierarchical imports" (toSrcSpan $ ann i) (trimStart $ prettyPrint i) (
           Just $ unlines $ map (trimStart . prettyPrint)
           [f "System.IO" Nothing, f "System.IO.Error" Nothing
-          ,f "Control.Exception" $ Just $ ImportSpecList an False [IVar an (NoNamespace an) $ toNamed x | x <- ["bracket","bracket_"]]]) []]
+          ,f "Control.Exception" $ Just $ ImportSpecList an False [IVar an $ toNamed x | x <- ["bracket","bracket_"]]]) []]
     where f a b = (desugarQual i){importModule=ModuleName an a, importSpecs=b}
 
 hierarchy _ = []


### PR DESCRIPTION
The IVar namespace argument has moved to IAbs as of HSE b0527bf.