### PR TITLE
Add hints for compare x y == EQ, compare x y /= EQ

### DIFF
--- a/data/Default.hs
+++ b/data/Default.hs
@@ -61,6 +61,8 @@ error = compare x y /= GT ==> x <= y
 error = compare x y == LT ==> x < y
 error = compare x y /= LT ==> x >= y
 error = compare x y == GT ==> x > y
+error = compare x y == EQ ==> x == y
+error = compare x y /= EQ ==> x /= y
 --warning = x == a || x == b || x == c ==> x `elem` [a,b,c] where note = ValidInstance "Eq" x
 --warning = x /= a && x /= b && x /= c ==> x `notElem` [a,b,c] where note = ValidInstance "Eq" x
 --error = compare (f x) (f y) ==> Data.Ord.comparing f x y -- not that great


### PR DESCRIPTION
I don't recall to have seen `compare x y == EQ` in any code, but since all other `==`/`/=` and `Ordering` combinations are already there, I don't think it will cause any harm.