### PR TITLE
Updated newtype hint to account for unboxed types

### DIFF
--- a/src/Hint/NewType.hs
+++ b/src/Hint/NewType.hs
@@ -20,6 +20,7 @@ data A = A {b :: !C} -- newtype A = A {b :: C}
 module Hint.NewType (newtypeHint) where
 
 import Hint.Type
+import Util
 
 newtypeHint :: DeclHint
 newtypeHint _ _ = newtypeHintDecl
@@ -36,7 +37,9 @@ singleSimpleField :: Decl_ -> Maybe (DataOrNew S, Type_, DataOrNew S -> Type_ ->
 singleSimpleField (DataDecl x1 dt x2 x3 [QualConDecl y1 Nothing y2 ctor] x4)
     | Just (t, ft) <- f ctor = Just (dt, t, \dt t -> DataDecl x1 dt x2 x3 [QualConDecl y1 Nothing y2 $ ft t] x4)
     where
-        f (ConDecl x1 x2 [t]) = Just (t, \t -> ConDecl x1 x2 [t])
+        f (ConDecl x1 x2 [t])
+          | isUnboxedTyCon t = Nothing
+          | otherwise = Just (t, \t -> ConDecl x1 x2 [t])
         f (RecDecl x1 x2 [FieldDecl y1 [y2] t]) = Just (t, \t -> RecDecl x1 x2 [FieldDecl y1 [y2] t])
         f _ = Nothing
 singleSimpleField _ = Nothing

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -4,7 +4,8 @@ module Util(
     defaultExtensions,
     Encoding, defaultEncoding, readFileEncoding', readEncoding, useEncoding,
     gzip, universeParentBi, descendIndex,
-    exitMessage
+    exitMessage,
+    isUnboxedTyCon
     ) where
 
 import Control.Monad.Trans.State
@@ -18,6 +19,7 @@ import Unsafe.Coerce
 import Data.Data
 import Data.Generics.Uniplate.Operations
 import Language.Haskell.Exts.Extension
+import Language.Haskell.Exts.Syntax
 
 
 ---------------------------------------------------------------------
@@ -135,3 +137,20 @@ badExtensions =
     ,DoRec, RecursiveDo -- breaks rec
     ,TypeApplications -- HSE fails on @ patterns
     ]
+
+---------------------------------------------------------------------
+-- LANGUAGE.HASKELL.EXTS.SYNTAX
+
+isUnboxedTyCon :: Type l -> Bool
+isUnboxedTyCon (TyParen _ t) = isUnboxedTyCon t
+isUnboxedTyCon (TyApp _ (TyCon _ qname) _) = not (null name) || last name == '#'
+  where name = case qname of
+          Qual _ _ n -> nameString n
+          UnQual _ n -> nameString n
+          _ -> ""
+
+        nameString :: Name l -> String
+        nameString (Ident _ n) = n
+        nameString (Symbol _ n) = n
+isUnboxedTyCon _ = False
+


### PR DESCRIPTION
The program

```haskell
{-# LANGUAGE MagicHash #-}
import GHC.Prim

data X = X Int#
```

will give the suggestion that you should declare `X` as a newtype, which is incorrect. While the style of definition above is very rare in Haskell, it's quite common in Eta when declaring wrappers for Java objects so in bindings to Java libraries, you'll be flooded with the incorrect hint above.

This change assumes that all types ending in `#` are unboxed, which is a reasonable assumption make.