### PR TITLE
Find unused hidden expressions (addresses part of #338)

### DIFF
--- a/src/Hint/Import.hs
+++ b/src/Hint/Import.hs
@@ -33,6 +33,73 @@ import qualified List -- import qualified Data.List as List
 import Char(foo) -- import Data.Char(foo)
 import IO(foo)
 import IO as X -- import System.IO as X; import System.IO.Error as X; import Control.Exception  as X (bracket,bracket_)
+import A hiding (a) -- import A
+import A hiding (a, b); foo = a -- import A hiding (a)
+import A hiding (a, b); foo = A.a -- import A hiding (a)
+import A as B hiding (a) -- import A as B
+import A as B hiding (a, b); foo = a -- import A as B hiding (a)
+import A as B hiding (a, b); foo = B.a -- import A as B hiding (a)
+import qualified A hiding (a) -- import qualified A
+import qualified A hiding (a, b); foo = A.a -- import qualified A hiding (a)
+import qualified A as B hiding (a, b); foo = B.a -- import qualified A as B hiding (a)
+import A hiding ((+)) -- import A
+import A hiding ((+), (*)); foo = (+) -- import A hiding ((+))
+import A hiding ((+), (*)); foo = (+x) -- import A hiding ((+))
+import A hiding ((+), (*)); foo = (x+) -- import A hiding ((+))
+import A hiding ((+), (*)); foo = x+y -- import A hiding ((+))
+import A hiding ((+), (*)); foo = (A.+) -- import A hiding ((+))
+import A hiding ((+), (*)); foo = (A.+ x) -- import A hiding ((+))
+import A hiding ((+), (*)); foo = (x A.+) -- import A hiding ((+))
+import A hiding ((+), (*)); foo = x A.+ y -- import A hiding ((+))
+import A as B hiding ((+)) -- import A as B
+import A as B hiding ((+), (*)); foo = (+) -- import A as B hiding ((+))
+import A as B hiding ((+), (*)); foo = (x+) -- import A as B hiding ((+))
+import A as B hiding ((+), (*)); foo = (+x) -- import A as B hiding ((+))
+import A as B hiding ((+), (*)); foo = x+y -- import A as B hiding ((+))
+import A as B hiding ((+), (*)); foo = (B.+) -- import A as B hiding ((+))
+import A as B hiding ((+), (*)); foo = (x B.+) -- import A as B hiding ((+))
+import A as B hiding ((+), (*)); foo = (B.+ x) -- import A as B hiding ((+))
+import A as B hiding ((+), (*)); foo = x B.+ y -- import A as B hiding ((+))
+import qualified A hiding ((+)) -- import qualified A
+import qualified A hiding ((+), (*)); foo = (A.+) -- import qualified A hiding ((+))
+import qualified A hiding ((+), (*)); foo = (x A.+) -- import qualified A hiding ((+))
+import qualified A hiding ((+), (*)); foo = (A.+ x) -- import qualified A hiding ((+))
+import qualified A hiding ((+), (*)); foo = x A.+ y -- import qualified A hiding ((+))
+import qualified A as B hiding ((+), (*)); foo = (B.+) -- import qualified A as B hiding ((+))
+import qualified A as B hiding ((+), (*)); foo = (x B.+) -- import qualified A as B hiding ((+))
+import qualified A as B hiding ((+), (*)); foo = (B.+ x) -- import qualified A as B hiding ((+))
+import qualified A as B hiding ((+), (*)); foo = x B.+ y -- import qualified A as B hiding ((+))
+module Foo (a) where; import A hiding (a)
+module Foo (a) where; import A hiding (a, b) -- import A hiding (a)
+module Foo (A.a) where; import A hiding (a, b) -- import A hiding (a)
+module Foo (a) where; import A as B hiding (a)
+module Foo (a) where; import A as B hiding (a, b) -- import A as B hiding (a)
+module Foo (B.a) where; import A as B hiding (a, b) -- import A as B hiding (a)
+module Foo (a) where; import qualified A hiding (a) -- import qualified A
+module Foo (A.a) where; import qualified A hiding (a, b) -- import qualified A hiding (a)
+module Foo (B.a) where; import qualified A as B hiding (a, b) -- import qualified A as B hiding (a)
+module Foo (module A) where; import A hiding (a, b, c)
+module Foo (module B) where; import A as B hiding (a, b, c)
+module Foo (module A) where; import qualified A hiding (a, b, c) -- import qualified A
+module Foo (module B) where; import qualified A as B hiding (a, b, c) -- import qualified A as B
+module Foo ((+)) where; import A hiding ((+))
+module Foo ((+)) where; import A hiding ((+), (*)) -- import A hiding ((+))
+module Foo ((A.+)) where; import A hiding ((+), (*)) -- import A hiding ((+))
+module Foo ((+)) where; import A as B hiding ((+))
+module Foo ((+)) where; import A as B hiding ((+), (*)) -- import A as B hiding ((+))
+module Foo ((B.+)) where; import A as B hiding ((+), (*)) -- import A as B hiding ((+))
+module Foo ((+)) where; import qualified A hiding ((+)) -- import qualified A
+module Foo ((A.+)) where; import qualified A hiding ((+), (*)) -- import qualified A hiding ((+))
+module Foo ((B.+)) where; import qualified A as B hiding ((+), (*)) -- import qualified A as B hiding ((+))
+module Foo (module A) where; import A hiding ((+), (*), (/))
+module Foo (module B) where; import A as B hiding ((+), (*), (/))
+module Foo (module A) where; import qualified A hiding ((+), (*), (/)) -- import qualified A
+module Foo (module B) where; import qualified A as B hiding ((+), (*), (/)) -- import qualified A as B
+{-# LANGUAGE QuasiQuotes #-}; import A hiding (a); [a||]
+{-# LANGUAGE QuasiQuotes #-}; import A hiding (a); [A.a||]
+{-# LANGUAGE QuasiQuotes #-}; import A as B hiding (a); [B.a||]
+{-# LANGUAGE QuasiQuotes #-}; import qualified A hiding (a); [A.a||]
+{-# LANGUAGE QuasiQuotes #-}; import qualified A as B hiding (a); [B.a||]
 </TEST>
 -}
 
@@ -45,15 +112,52 @@ import Hint.Type
 import Refact.Types hiding (ModuleName)
 import qualified Refact.Types as R
 import Data.List.Extra
+import Data.Either (partitionEithers)
 import Data.Maybe
 import Prelude
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 
 
 importHint :: ModuHint
 importHint _ x = concatMap (wrap . snd) (groupSort
                  [((fromNamed $ importModule i,importPkg i),i) | i <- universeBi x, not $ importSrc i]) ++
-                 concatMap (\x -> hierarchy x ++ combine1 x) (universeBi x)
+                 concatMap (\x -> hierarchy x ++ combine1 x ++ hidden reexported unqual quals x) (universeBi x)
+    where
+        -- Names of all re-exported modules
+        reexported :: Set String
+        reexported = Set.fromList [ fromModuleName n | EModuleContents _ n <- universeBi x ]
 
+        -- Unqualified expressions and exported expressions
+        unqual :: Set String
+        unqual = Set.fromList (mapMaybe f qnames) `Set.union` Set.fromList qqUnqual
+            where f :: QName S -> Maybe String
+                  f (UnQual _ n) = Just (fromNamed n)
+                  f _ = Nothing
+
+        -- Qualified expressions and exported expressions
+        quals :: Map String (Set String)
+        quals = Map.fromListWith Set.union (map (second Set.singleton) qqQuals ++ mapMaybe f qnames)
+            where f (Qual _ m n) = Just (fromModuleName m, Set.singleton (fromNamed n))
+                  f _ = Nothing
+
+        -- Unqualified quasi-quoters like [foo|...|]
+        qqUnqual :: [String]
+        -- Qualified quasi-quoters like [Foo.bar|...|]
+        qqQuals :: [(String, String)]
+        (qqUnqual, qqQuals) = partitionEithers [ f n | QuasiQuote (_ :: S) n _ <- universeBi x ]
+            where f :: String -> Either String (String, String)
+                  f n = maybe (Left n) Right (stripInfixEnd "." n)
+
+        qnames :: [QName S]
+        qnames = concat
+            [ [ n | Var      (_ :: S) n <- universeBi x ]
+            , [ n | VarQuote (_ :: S) n <- universeBi x ]
+            , [ n | QVarOp   (_ :: S) n <- universeBi x ]
+            , [ n | EVar     (_ :: S) n <- universeBi x ]
+            ]
 
 wrap :: [ImportDecl S] -> [Idea]
 wrap o = [ rawIdea Warning "Use fewer imports" (srcInfoSpan $ ann $ head o) (f o) (Just $ f x) [] rs
@@ -95,7 +199,6 @@ combine x y | qual, as, specs = Just (x, [Delete Import (toSS y)])
         specs = importSpecs x `eqMaybe` importSpecs y
 
 combine _ _ = Nothing
-
 
 combine1 :: ImportDecl S -> [Idea]
 combine1 i@ImportDecl{..}
@@ -144,3 +247,36 @@ hierarchy _ = []
 desugarQual :: ImportDecl S -> ImportDecl S
 desugarQual x | importQualified x && isNothing (importAs x) = x{importAs=Just (importModule x)}
               | otherwise = x
+
+-- Suggest removing unnecessary "hiding" clauses in imports. Currently this only
+-- works for expressions.
+hidden :: Set String -> Set String -> Map String (Set String) -> ImportDecl S -> [Idea]
+hidden reexported unqual quals i@ImportDecl{importSpecs = Just (ImportSpecList loc True xs)}
+    -- If the module is re-exported and not imported qualified, we can't prune
+    -- any identifiers from the hiding clause
+    | not (importQualified i) && as `Set.member` reexported = []
+    | otherwise =
+        case partition isUsed xs of
+            (_, []) -> []
+            ([], _) -> [suggest "Unnecessary hiding" i i{importSpecs = Nothing} [Delete Import (toSS i)]]
+            (xs, _) ->
+                let newImp = i{importSpecs = Just (ImportSpecList loc True xs)}
+                in [suggest "Unnecessary hiding" i newImp [Replace Import (toSS i) [] (prettyPrint newImp)]]
+    where
+        isUsed :: ImportSpec S -> Bool
+        isUsed (IVar _ n) = Set.member (fromNamed n) vars
+        isUsed _ = True
+
+        vars :: Set String
+        vars =
+          if importQualified i
+            then qual
+            else qual `Set.union` unqual
+
+        qual :: Set String
+        qual = fromMaybe Set.empty (Map.lookup as quals)
+
+        as :: String
+        as = fromModuleName (fromMaybe (importModule i) (importAs i))
+
+hidden _ _ _ _ = []


### PR DESCRIPTION
I took a stab at #338, but stopped only after identifying unused expressions, as they seem much simpler to spot than the other cases. For example, in `import Foo hiding (Bar)`, `Bar` could be a data constructor, type class, type synonym, type family, or perhaps something I'm forgetting.

Also, unfortunately wildcard syntax (`import Foo hiding Bar(..)`) prevents this particular hint as we don't know what that `..` is!

Anywho, this seemed like a good enough place to start. Please let me know if I've provided enough testing - cheers!
