### PR TITLE
Allow hlint to function as a CC engine

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+engines:
+  hlint:
+    enabled: true
+
+exclude_paths:
+  - data/HLint_TypeCheck.hs

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,5 @@
 dist/
 
 cc/*
-!cc/engine.hs
+!cc/*.cabal
+!cc/*.hs

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+.stack-work/
+dist/
+
+cc/*
+!cc/engine.hs

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /.hpc/
 /.stack-work/
 /issues/
-stack.yaml

--- a/cc/Dockerfile
+++ b/cc/Dockerfile
@@ -1,0 +1,53 @@
+#
+# Build stage
+#
+FROM fpco/stack-build:lts as builder
+MAINTAINER Pat Brisbin <pbrisbin@gmail.com>
+
+ENV LANG en_US.UTF-8
+ENV PATH /root/.local/bin:$PATH
+
+RUN mkdir -p /src
+WORKDIR /src
+
+COPY stack.yaml /src/
+RUN stack setup
+
+COPY hlint.cabal /src/
+RUN stack install --dependencies-only
+
+COPY ./src /src/src
+COPY ./data /src/data
+COPY ./cc/engine.hs /src/cc/engine.hs
+COPY ./LICENSE /src/LICENSE
+RUN stack install
+
+#
+# Runtime
+#
+FROM fpco/stack-run:lts
+MAINTAINER Pat Brisbin <pbrisbin@gmail.com>
+
+ENV LANG en_US.UTF-8
+
+# Install jq, for reading /config.json
+RUN \
+  curl -L -O "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64" && \
+  chmod +x jq-linux64 && \
+  mv jq-linux64 /usr/bin/jq
+
+# Executables from build stage
+COPY --from=builder /root/.local/bin/hlint /usr/bin/hlint
+COPY --from=builder /root/.local/bin/cc-engine /usr/bin/engine
+COPY data /opt/hlint
+
+RUN mkdir -p /code
+VOLUME /code
+WORKDIR /code
+
+RUN useradd app --uid 9000
+USER app
+
+# Reset fpco/stack-run's dumb ENTRYPOINT
+ENTRYPOINT []
+CMD ["/usr/bin/engine"]

--- a/cc/Dockerfile
+++ b/cc/Dockerfile
@@ -10,17 +10,25 @@ ENV PATH /root/.local/bin:$PATH
 RUN mkdir -p /src
 WORKDIR /src
 
+# Install appropriate GHC
 COPY stack.yaml /src/
 RUN stack setup
 
+# Install HLint
 COPY hlint.cabal /src/
 RUN stack install --dependencies-only
-
 COPY ./src /src/src
 COPY ./data /src/data
-COPY ./cc/engine.hs /src/cc/engine.hs
 COPY ./LICENSE /src/LICENSE
-RUN stack install --flag hlint:cc
+RUN stack install
+
+# Install CC/Engine executable
+RUN mkdir -p /cc
+WORKDIR /cc
+COPY ./cc/engine.cabal /cc/engine.cabal
+RUN stack init && stack install --dependencies-only
+COPY ./cc/Engine.hs /cc/Engine.hs
+RUN stack install
 
 #
 # Runtime
@@ -32,8 +40,8 @@ ENV LANG en_US.UTF-8
 
 # Executables from build stage
 COPY --from=builder /root/.local/bin/hlint /usr/bin/hlint
-COPY --from=builder /root/.local/bin/cc-engine /usr/bin/engine
-COPY data /opt/hlint
+COPY --from=builder /root/.local/bin/engine /usr/bin/engine
+COPY --from=builder /src/data /opt/hlint
 
 RUN mkdir -p /code
 VOLUME /code

--- a/cc/Dockerfile
+++ b/cc/Dockerfile
@@ -20,7 +20,7 @@ COPY ./src /src/src
 COPY ./data /src/data
 COPY ./cc/engine.hs /src/cc/engine.hs
 COPY ./LICENSE /src/LICENSE
-RUN stack install
+RUN stack install --flag hlint:cc
 
 #
 # Runtime

--- a/cc/Dockerfile
+++ b/cc/Dockerfile
@@ -30,12 +30,6 @@ MAINTAINER Pat Brisbin <pbrisbin@gmail.com>
 
 ENV LANG en_US.UTF-8
 
-# Install jq, for reading /config.json
-RUN \
-  curl -L -O "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64" && \
-  chmod +x jq-linux64 && \
-  mv jq-linux64 /usr/bin/jq
-
 # Executables from build stage
 COPY --from=builder /root/.local/bin/hlint /usr/bin/hlint
 COPY --from=builder /root/.local/bin/cc-engine /usr/bin/engine

--- a/cc/Engine.hs
+++ b/cc/Engine.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Main where
+module Main (main) where
 
 import Data.Aeson
 import Data.List (isSuffixOf)
@@ -64,8 +64,8 @@ main = do
 
     callProcess "hlint" $
         [ "lint"
+        , "--cc"
         , "--datadir", "/opt/hlint"
-        , "--json-cc"
         , "--no-exit-code"
         ]
         ++ cExtraFlags c

--- a/cc/README.md
+++ b/cc/README.md
@@ -1,0 +1,57 @@
+# The `codeclimate-hlint` Engine
+
+## Building
+
+To build the `codeclimate/codeclimate-hlint` engine from source:
+
+```console
+./cc/build
+```
+
+The built image will now be used by the `codeclimate` CLI.
+
+## Usage
+
+Add the following to `.codeclimate.yml`:
+
+```yaml
+engines:
+  hlint:
+    enabled: true
+```
+
+## Configuration
+
+To pass additional flags to `hlint`:
+
+```yaml
+engines:
+  hlint:
+    enabled: true
+    config:
+      flags:
+        - --hint
+        - my-hints.yml
+```
+
+See `hlint lint --help`.
+
+To exclude files from analysis, use the `exclude_paths` options
+
+```yaml
+# Exclude from all engines
+engines:
+  # ...
+
+exclude_paths:
+  - problematic-file.hs
+
+# Exclude from just hlint
+engines:
+  hlint:
+    # ...
+    exclude_paths:
+      - problematic-file.hs
+```
+
+See https://docs.codeclimate.com/docs/excluding-files-and-folders.

--- a/cc/build
+++ b/cc/build
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+docker build \
+  --file cc/Dockerfile \
+  --tag codeclimate/codeclimate-hlint .

--- a/cc/engine.cabal
+++ b/cc/engine.cabal
@@ -1,0 +1,21 @@
+cabal-version:      >= 1.18
+build-type:         Simple
+name:               engine
+version:            0.0.1
+category:           Development
+author:             Patrick Brisbin <pbrisbin@gmail.com>
+maintainer:         Patrick Brisbin <pbrisbin@gmail.com>
+copyright:          Neil Mitchell 2006-2017
+synopsis:           Run HLint as a Code Climate engine
+description:        Run HLint as a Code Climate engine
+homepage:           https://github.com/ndmitchell/hlint#readme
+bug-reports:        https://github.com/ndmitchell/hlint/issues
+
+executable engine
+    default-language:   Haskell2010
+    build-depends:      base
+                      , aeson
+                      , bytestring
+                      , process
+    main-is:            Engine.hs
+    ghc-options:        -rtsopts -threaded

--- a/cc/engine.hs
+++ b/cc/engine.hs
@@ -63,7 +63,8 @@ main = do
     c <- readConfig "/config.json"
 
     callProcess "hlint" $
-        [ "--datadir", "/opt/hlint"
+        [ "lint"
+        , "--datadir", "/opt/hlint"
         , "--json-cc"
         , "--no-exit-code"
         ]

--- a/cc/engine.hs
+++ b/cc/engine.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Data.Aeson
+import Data.List (isSuffixOf)
+import System.Process (callProcess)
+import System.IO (hPutStrLn, stderr)
+
+import qualified Data.ByteString.Lazy.Char8 as C8
+
+data Config = Config
+    { cIncludePaths :: [FilePath]
+    , cExtraFlags :: [String]
+    }
+
+instance FromJSON Config where
+    parseJSON = withObject "Config" $ \o -> Config
+        <$> o .: "include_paths"
+        <*> pure [] -- TODO: optional config.flags
+
+main :: IO ()
+main = do
+    ec <- eitherDecode <$> C8.readFile "/config.json"
+    options <- case ec of
+        Left ex -> do
+            hPutStrLn stderr $ "Ignoring invalid /config.json: " ++ ex
+            return ["."]
+        Right c -> return $ cExtraFlags c ++ filter include (cIncludePaths c)
+
+    callProcess "hlint" $
+        ["--datadir"
+        , "/opt/hlint"
+        , "--json-cc"
+        , "--no-exit-code"
+        ] ++ options
+
+  where
+    -- Return true for directories as well, so they are included
+    include :: FilePath -> Bool
+    include p = any (`isSuffixOf` p) ["/", ".hs", ".lhs"]

--- a/cc/engine.hs
+++ b/cc/engine.hs
@@ -15,6 +15,42 @@ data Config = Config
     }
 
 instance FromJSON Config where
+    -- Given a source tree:
+    --
+    -- > ./
+    -- >   a.hs
+    -- >   b.hs
+    -- >   c/
+    -- >     d.hs
+    --
+    -- And .codeclimate.yml:
+    --
+    -- > engines:
+    -- >   hlint:
+    -- >     enabled: true
+    -- >     config:
+    -- >       flags:
+    -- >         - --foo
+    -- >         - --bar
+    -- >
+    -- > exclude_paths:
+    -- >   - b.hs
+    --
+    -- We will find a /config.json like:
+    --
+    -- > {
+    -- >   "include_paths": [
+    -- >     "a.hs",
+    -- >     "c/"
+    -- >   ],
+    -- >   "config": {
+    -- >     "flags": [
+    -- >       "--foo",
+    -- >       "--bar",
+    -- >     ]
+    -- >   }
+    -- > }
+    --
     parseJSON = withObject "Config" $ \o -> Config
         <$> o .: "include_paths"
         <*> do

--- a/cc/engine.hs
+++ b/cc/engine.hs
@@ -32,7 +32,7 @@ main = do
         Right c -> return $ cExtraFlags c ++ filter include (cIncludePaths c)
 
     callProcess "hlint" $
-        ["--datadir"
+        [ "--datadir"
         , "/opt/hlint"
         , "--json-cc"
         , "--no-exit-code"

--- a/cc/engine.hs
+++ b/cc/engine.hs
@@ -3,6 +3,7 @@ module Main where
 
 import Data.Aeson
 import Data.List (isSuffixOf)
+import Data.Maybe (fromMaybe)
 import System.Process (callProcess)
 import System.IO (hPutStrLn, stderr)
 
@@ -16,7 +17,10 @@ data Config = Config
 instance FromJSON Config where
     parseJSON = withObject "Config" $ \o -> Config
         <$> o .: "include_paths"
-        <*> pure [] -- TODO: optional config.flags
+        <*> do
+            mc <- o .:? "config"
+            mf <- maybe (pure Nothing) (.:? "flags") mc
+            pure $ fromMaybe [] mf
 
 main :: IO ()
 main = do

--- a/cc/engine.hs
+++ b/cc/engine.hs
@@ -39,6 +39,5 @@ main = do
         ] ++ options
 
   where
-    -- Return true for directories as well, so they are included
     include :: FilePath -> Bool
     include p = any (`isSuffixOf` p) ["/", ".hs", ".lhs"]

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -56,7 +56,8 @@ library
         uniplate >= 1.5,
         ansi-terminal >= 0.6.2,
         extra >= 1.4.9,
-        refact >= 0.3
+        refact >= 0.3,
+        aeson >= 1.1.2.0
 
     if flag(gpl)
         build-depends: hscolour >= 1.21
@@ -79,6 +80,7 @@ library
         Util
         Parallel
         Refact
+        CC
         Config.All
         Config.Compute
         Config.Haskell
@@ -122,6 +124,19 @@ executable hlint
     default-language:   Haskell2010
     build-depends:      base, hlint
     main-is:            src/Main.hs
+
+    ghc-options:        -rtsopts
+    if flag(threaded)
+        ghc-options:    -threaded
+
+executable cc-engine
+    default-language:   Haskell2010
+    build-depends:      base
+                      , aeson
+                      , bytestring
+                      , process
+    main-is:            engine.hs
+    hs-source-dirs:     cc
 
     ghc-options:        -rtsopts
     if flag(threaded)

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -43,11 +43,6 @@ flag gpl
     manual: True
     description: Use GPL libraries, specifically hscolour
 
-flag cc
-    default: False
-    manual: True
-    description: Build the Code Climate engine executable
-
 library
     default-language:   Haskell2010
     build-depends:
@@ -129,22 +124,6 @@ executable hlint
     default-language:   Haskell2010
     build-depends:      base, hlint
     main-is:            src/Main.hs
-
-    ghc-options:        -rtsopts
-    if flag(threaded)
-        ghc-options:    -threaded
-
-executable cc-engine
-    if !flag(cc)
-        buildable: False
-
-    default-language:   Haskell2010
-    build-depends:      base
-                      , aeson
-                      , bytestring
-                      , process
-    main-is:            engine.hs
-    hs-source-dirs:     cc
 
     ghc-options:        -rtsopts
     if flag(threaded)

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -43,6 +43,11 @@ flag gpl
     manual: True
     description: Use GPL libraries, specifically hscolour
 
+flag cc
+    default: False
+    manual: True
+    description: Build the Code Climate engine executable
+
 library
     default-language:   Haskell2010
     build-depends:
@@ -130,6 +135,9 @@ executable hlint
         ghc-options:    -threaded
 
 executable cc-engine
+    if !flag(cc)
+        buildable: False
+
     default-language:   Haskell2010
     build-depends:      base
                       , aeson

--- a/src/CC.hs
+++ b/src/CC.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+-- |
+--
+-- Utility for formatting @'Idea'@ data in accordance with the Code Climate
+-- spec: <https://github.com/codeclimate/spec>
+--
+module CC
+    ( printIssue
+    , fromIdea
+    ) where
+
+import Data.Aeson (ToJSON(..), (.=), encode, object)
+import Data.Char (toUpper)
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import Language.Haskell.Exts.SrcLoc (SrcSpan(..))
+
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as C8
+
+import Idea (Idea(..), Severity(..))
+
+data Issue = Issue
+    { issueType :: Text
+    , issueCheckName :: Text
+    , issueDescription :: Text
+    , issueContent :: Text -- TODO: Markdown type?
+    , issueCategories :: [Text]
+    , issueLocation :: Location
+    , issueRemediationPoints :: Int
+    }
+
+data Location = Location FilePath Position Position
+data Position = Position Int Int
+
+instance ToJSON Issue where
+    toJSON Issue{..} = object
+        [ "type" .= issueType
+        , "check_name" .= issueCheckName
+        , "description" .= issueDescription
+        , "content" .= object
+            [ "body" .= issueContent
+            ]
+        , "categories" .= issueCategories
+        , "location" .= issueLocation
+        , "remediation_points" .= issueRemediationPoints
+        ]
+
+instance ToJSON Location where
+    toJSON (Location path begin end) = object
+        [ "path" .= path
+        , "positions" .= object
+            [ "begin" .= begin
+            , "end" .= end
+            ]
+        ]
+
+instance ToJSON Position where
+    toJSON (Position line column) = object
+        [ "line" .= line
+        , "column" .= column
+        ]
+
+-- | Print an @'Issue'@ with trailing null-terminator and newline
+--
+-- The trailing newline will be ignored, but makes the output more readable
+--
+printIssue :: Issue -> IO ()
+printIssue = C8.putStrLn . (<> "\0") . encode
+
+-- | Convert an hlint @'Idea'@ to a datatype more easily serialized for CC
+fromIdea :: Idea -> Issue
+fromIdea Idea{..} = Issue
+    { issueType = "issue"
+    , issueCheckName = "HLint/" <> T.pack (camelize ideaHint)
+    , issueDescription = T.pack ideaHint
+    , issueContent = content ideaFrom ideaTo
+    , issueCategories = categories ideaHint
+    , issueLocation = fromSrcSpan ideaSpan
+    , issueRemediationPoints = points ideaSeverity
+    }
+
+  where
+    content from Nothing = T.unlines
+        [ "Found"
+        , ""
+        , "```"
+        , T.pack from
+        , "```"
+        , ""
+        , "remove it."
+        ]
+
+    content from (Just to) = T.unlines
+        [ "Found"
+        , ""
+        , "```"
+        , T.pack from
+        , "```"
+        , ""
+        , "Why not"
+        , ""
+        , "```"
+        , T.pack to
+        , "```"
+        ]
+
+    categories _ = ["Style"]
+
+    points Ignore = 0
+    points Suggestion = basePoints
+    points Warning = 5 * basePoints
+    points Error = 10 * basePoints
+
+fromSrcSpan :: SrcSpan -> Location
+fromSrcSpan SrcSpan{..} = Location
+    (locationFileName srcSpanFilename)
+    (Position srcSpanStartLine srcSpanStartColumn)
+    (Position srcSpanEndLine srcSpanEndColumn)
+  where
+    locationFileName ('.':'/':x) = x
+    locationFileName x = x
+
+camelize :: String -> String
+camelize = concatMap capitalize . words
+
+capitalize :: String -> String
+capitalize [] = []
+capitalize (c:rest) = toUpper c : rest
+
+-- "The baseline remediation points value is 50,000, which is the time it takes
+-- to fix a trivial code style issue like a missing semicolon on a single line,
+-- including the time for the developer to open the code, make the change, and
+-- confidently commit the fix. All other remediation points values are expressed
+-- in multiples of that Basic Remediation Point Value."
+basePoints :: Int
+basePoints = 50000

--- a/src/CC.hs
+++ b/src/CC.hs
@@ -25,7 +25,7 @@ data Issue = Issue
     { issueType :: Text
     , issueCheckName :: Text
     , issueDescription :: Text
-    , issueContent :: Text -- TODO: Markdown type?
+    , issueContent :: Text
     , issueCategories :: [Text]
     , issueLocation :: Location
     , issueRemediationPoints :: Int
@@ -75,7 +75,7 @@ fromIdea Idea{..} = Issue
     { issueType = "issue"
     , issueCheckName = "HLint/" <> T.pack (camelize ideaHint)
     , issueDescription = T.pack ideaHint
-    , issueContent = content ideaFrom ideaTo
+    , issueContent = content ideaFrom ideaTo <> listNotes ideaNote
     , issueCategories = categories ideaHint
     , issueLocation = fromSrcSpan ideaSpan
     , issueRemediationPoints = points ideaSeverity
@@ -105,6 +105,13 @@ fromIdea Idea{..} = Issue
         , T.pack to
         , "```"
         ]
+
+    listNotes [] = ""
+    listNotes notes = T.unlines $
+        [ ""
+        , "Applying this change:"
+        , ""
+        ] ++ map (("* " <>) . T.pack . show) notes
 
     categories _ = ["Style"]
 

--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -114,6 +114,7 @@ data Cmd
         ,cmdCppSimple :: Bool
         ,cmdCppAnsi :: Bool
         ,cmdJson :: Bool                -- ^ display hint data as JSON
+        ,cmdJsonCC :: Bool              -- ^ display hint data as Code Climate Issues
         ,cmdNoSummary :: Bool           -- ^ do not show the summary info
         ,cmdOnly :: [String]            -- ^ specify which hints explicitly
         ,cmdNoExitCode :: Bool
@@ -174,6 +175,7 @@ mode = cmdArgsMode $ modes
         ,cmdCppSimple = nam_ "cpp-simple" &= help "Use a simple CPP (strip # lines)"
         ,cmdCppAnsi = nam_ "cpp-ansi" &= help "Use CPP in ANSI compatibility mode"
         ,cmdJson = nam_ "json" &= help "Display hint data as JSON"
+        ,cmdJsonCC = nam_ "json-cc" &= help "Display hint data as Code Climate Issues JSON"
         ,cmdNoSummary = nam_ "no-summary" &= help "Do not show summary information"
         ,cmdOnly = nam "only" &= typ "HINT" &= help "Specify which hints explicitly"
         ,cmdNoExitCode = nam_ "no-exit-code" &= help "Do not give a negative exit if hints"

--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -114,7 +114,7 @@ data Cmd
         ,cmdCppSimple :: Bool
         ,cmdCppAnsi :: Bool
         ,cmdJson :: Bool                -- ^ display hint data as JSON
-        ,cmdJsonCC :: Bool              -- ^ display hint data as Code Climate Issues
+        ,cmdCC :: Bool                  -- ^ display hint data as Code Climate Issues
         ,cmdNoSummary :: Bool           -- ^ do not show the summary info
         ,cmdOnly :: [String]            -- ^ specify which hints explicitly
         ,cmdNoExitCode :: Bool
@@ -175,7 +175,7 @@ mode = cmdArgsMode $ modes
         ,cmdCppSimple = nam_ "cpp-simple" &= help "Use a simple CPP (strip # lines)"
         ,cmdCppAnsi = nam_ "cpp-ansi" &= help "Use CPP in ANSI compatibility mode"
         ,cmdJson = nam_ "json" &= help "Display hint data as JSON"
-        ,cmdJsonCC = nam_ "json-cc" &= help "Display hint data as Code Climate Issues JSON"
+        ,cmdCC = nam_ "cc" &= help "Display hint data as Code Climate Issues"
         ,cmdNoSummary = nam_ "no-summary" &= help "Do not show summary information"
         ,cmdOnly = nam "only" &= typ "HINT" &= help "Specify which hints explicitly"
         ,cmdNoExitCode = nam_ "no-exit-code" &= help "Do not give a negative exit if hints"

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -160,7 +160,7 @@ runHints args settings cmd@CmdMain{..} = do
         ideas <- return $ if cmdShowAll then ideas else  filter (\i -> ideaSeverity i /= Ignore) ideas
         if cmdJson then
             putStrLn $ showIdeasJson ideas
-         else if cmdJsonCC then
+         else if cmdCC then
             mapM_ (printIssue . fromIdea) ideas
          else if cmdSerialise then do
             hSetBuffering stdout NoBuffering

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -34,6 +34,7 @@ import Grep
 import Test.Proof
 import Parallel
 import HSE.All
+import CC
 
 
 -- | This function takes a list of command line arguments, and returns the given hints.
@@ -159,6 +160,8 @@ runHints args settings cmd@CmdMain{..} = do
         ideas <- return $ if cmdShowAll then ideas else  filter (\i -> ideaSeverity i /= Ignore) ideas
         if cmdJson then
             putStrLn $ showIdeasJson ideas
+         else if cmdJsonCC then
+            mapM_ (printIssue . fromIdea) ideas
          else if cmdSerialise then do
             hSetBuffering stdout NoBuffering
             print $ map (show &&& ideaRefactoring) ideas

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-9.2
+packages:
+- .
+extra-deps:
+- haskell-src-exts-util-0.2.1.2


### PR DESCRIPTION
- Add `--json-cc` flag to output in in accordance with the CC SPEC[1].
- Add `cc/` directory with the machinery required to run as a codeclimate
  engine. The only bit that couldn't be isolated in this directory is
   the .dockerignore which must live in the directory you're building
   from. 
- Add a .codeclimate.yml so we can test the engine on ourselves.

[1]: https://github.com/codeclimate/spec/blob/master/SPEC.md

This should replace pbrisbin/codeclimate-hlint and address the requested features around configurability. This version of the engine runs the hlint binary normally, so passing additional flags, accessing project-local configuration files, etc, should all Just Work.

Try it out:

    cc/build
    codeclimate analyze

See https://github.com/codeclimate/codeclimate#installation

This is meant as a jumping-off point: please let me know if there's a better home for `CC.hs`, a better name for the `--json-cc` flag, or a better place to put the `cc/` Docker machinery.

One other question: I notice `stack.yml` is git-ignored. That file will have to exist for the docker image to build, and code climate maintainers will be doing the image build out of a fresh checkout, so I'm not sure if we should commit one, or put one in `cc/` that we can use as part of the `cc/build` process?