### PR TITLE
#393, Suggest f <$> m for m >>= pure . f and similar expressions

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -311,8 +311,8 @@
     - warn: {lhs: return =<< m, rhs: m, name: "Monad law, right identity"}
     - warn: {lhs: liftM, rhs: fmap}
     - warn: {lhs: liftA, rhs: fmap}
-    - hint: {lhs: m >>= return . f, rhs: fmap f m}
-    - hint: {lhs: return . f =<< m, rhs: fmap f m}
+    - hint: {lhs: m >>= return . f, rhs: f <$> m}
+    - hint: {lhs: return . f =<< m, rhs: f <$> m}
     - warn: {lhs: if x then y else return (), rhs: Control.Monad.when x $ _noParen_ y, side: not (isAtom y)}
     - warn: {lhs: if x then y else return (), rhs: Control.Monad.when x y, side: isAtom y}
     - warn: {lhs: if x then return () else y, rhs: Control.Monad.unless x $ _noParen_ y, side: isAtom y}
@@ -374,6 +374,8 @@
     - warn: {lhs: foldr (<|>) empty, rhs: asum}
     - warn: {lhs: liftA2 (flip ($)), rhs: (<**>)}
     - warn: {lhs: Just <$> a <|> pure Nothing, rhs: optional a}
+    - hint: {lhs: m >>= pure . f, rhs: f <$> m}
+    - hint: {lhs: pure . f =<< m, rhs: f <$> m}
 
 
     # LIST COMP
@@ -734,7 +736,7 @@
 # {-# LANGUAGE TypeApplications #-} \
 # foo = id @Int
 # foo = id 12 -- 12
-# 
+#
 # import Prelude \
 # yes = flip mapM -- Control.Monad.forM
 # import Control.Monad \

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -624,7 +624,10 @@
 # yes = not . (/= a) -- (== a)
 # yes = if a then 1 else if b then 1 else 2 -- if a || b then 1 else 2
 # no  = if a then 1 else if b then 3 else 2
-# yes = a >>= return . bob -- fmap bob a
+# yes = a >>= return . bob -- bob <$> a
+# yes = return . bob =<< a -- bob <$> a
+# yes = m alice >>= pure . b -- b <$> m alice
+# yes = pure .b =<< m alice -- b <$> m alice
 # yes = (x !! 0) + (x !! 2) -- head x
 # yes = if b < 42 then [a] else [] -- [a | b < 42]
 # no  = take n (foo xs) == "hello"

--- a/tests/json.test
+++ b/tests/json.test
@@ -21,7 +21,7 @@ bar x = foo x
 baz = getLine >>= return . map toUpper
 OUTPUT
 [{"module":"Main","decl":"bar","severity":"Warning","hint":"Eta reduce","file":"tests/json-two.hs","startLine":2,"startColumn":1,"endLine":2,"endColumn":14,"from":"bar x = foo x","to":"bar = foo","note":[],"refactorings":"[]"}
-,{"module":"Main","decl":"baz","severity":"Suggestion","hint":"Use fmap","file":"tests/json-two.hs","startLine":3,"startColumn":7,"endLine":3,"endColumn":39,"from":"getLine >>= return . map toUpper","to":"fmap (map toUpper) getLine","note":[],"refactorings":"[Replace {rtype = Expr, pos = SrcSpan {startLine = 3, startCol = 7, endLine = 3, endCol = 39}, subts = [(\"f\",SrcSpan {startLine = 3, startCol = 28, endLine = 3, endCol = 39}),(\"m\",SrcSpan {startLine = 3, startCol = 7, endLine = 3, endCol = 14})], orig = \"fmap (f) m\"}]"}]
+,{"module":"Main","decl":"baz","severity":"Suggestion","hint":"Use <$>","file":"tests/json-two.hs","startLine":3,"startColumn":7,"endLine":3,"endColumn":39,"from":"getLine >>= return . map toUpper","to":"map toUpper <$> getLine","note":[],"refactorings":"[Replace {rtype = Expr, pos = SrcSpan {startLine = 3, startCol = 7, endLine = 3, endCol = 39}, subts = [(\"f\",SrcSpan {startLine = 3, startCol = 28, endLine = 3, endCol = 39}),(\"m\",SrcSpan {startLine = 3, startCol = 7, endLine = 3, endCol = 14})], orig = \"f <$> m\"}]"}]
 
 ---------------------------------------------------------------------
 RUN tests/json-parse-error.hs --json

--- a/tests/serialise.test
+++ b/tests/serialise.test
@@ -21,7 +21,7 @@ foo = (+1)
 bar x = foo x
 baz = getLine >>= return . map toUpper
 OUTPUT
-[("tests/serialise-two.hs:2:1: Warning: Eta reduce\nFound:\n  bar x = foo x\nWhy not:\n  bar = foo\n",[]),("tests/serialise-two.hs:3:7: Suggestion: Use fmap\nFound:\n  getLine >>= return . map toUpper\nWhy not:\n  fmap (map toUpper) getLine\n",[Replace {rtype = Expr, pos = SrcSpan {startLine = 3, startCol = 7, endLine = 3, endCol = 39}, subts = [("f",SrcSpan {startLine = 3, startCol = 28, endLine = 3, endCol = 39}),("m",SrcSpan {startLine = 3, startCol = 7, endLine = 3, endCol = 14})], orig = "fmap (f) m"}])]
+[("tests/serialise-two.hs:2:1: Warning: Eta reduce\nFound:\n  bar x = foo x\nWhy not:\n  bar = foo\n",[]),("tests/serialise-two.hs:3:7: Suggestion: Use <$>\nFound:\n  getLine >>= return . map toUpper\nWhy not:\n  map toUpper <$> getLine\n",[Replace {rtype = Expr, pos = SrcSpan {startLine = 3, startCol = 7, endLine = 3, endCol = 39}, subts = [("f",SrcSpan {startLine = 3, startCol = 28, endLine = 3, endCol = 39}),("m",SrcSpan {startLine = 3, startCol = 7, endLine = 3, endCol = 14})], orig = "f <$> m"}])]
 
 
 ---------------------------------------------------------------------


### PR DESCRIPTION
Adds the pure equivalents of the m >>= return . f ==> fmap f m
hints, and changes the 4 of them to use <$> instead of fmap.