### PR TITLE
Should close #395, or at least the part agreed on.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
 Changelog for HLint
 
-    #393, suggest fmap f m from m >>= pure . f and pure . f =<
+    #395, Suggest x $> y from x *> pure y and x *> return y
+          Suggest x <$ y from pure x <* y and return x <* y
+    #393, Suggest f <$> m from m >>= pure . f and pure . f =<<
     #366, avoid the github API for prebuilt hlint, is rate limited
     #352, suggest maybe for fromMaybe d (f <$> x)
     #338, warn about things imported hidden but not used

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -302,6 +302,10 @@
     - warn: {lhs: id <$> x, rhs: x, name: Functor law}
     - hint: {lhs: fmap f $ x, rhs: f Control.Applicative.<$> x, side: isApp x || isAtom x}
     - hint: {lhs: \x -> a <$> b x, rhs: fmap a . b}
+    - hint: {lhs: x *> pure y, rhs: x Data.Functor.$> y}
+    - hint: {lhs: x *> return y, rhs: x Data.Functor.$> y}
+    - hint: {lhs: pure x <* y, rhs: x Data.Functor.<$ y}
+    - hint: {lhs: return x <* y, rhs: x Data.Functor.<$ y}
 
     # MONAD
 
@@ -628,6 +632,10 @@
 # yes = return . bob =<< a -- bob <$> a
 # yes = m alice >>= pure . b -- b <$> m alice
 # yes = pure .b =<< m alice -- b <$> m alice
+# yes = asciiCI "hi" *> pure Hi -- asciiCI "hi" Data.Functor.$> Hi
+# yes = asciiCI "bye" *> return Bye -- asciiCI "bye" Data.Functor.$> Bye
+# yes = pure x <* y -- x Data.Functor.<$ y
+# yes = return x <* y -- x Data.Functor.<$ y
 # yes = (x !! 0) + (x !! 2) -- head x
 # yes = if b < 42 then [a] else [] -- [a | b < 42]
 # no  = take n (foo xs) == "hello"


### PR DESCRIPTION
I only added the suggestions listed in #395 for `*>` (not those for `>>`).

I took the liberty of modifying the previous line in CHANGES.txt, as the suggestion given is `f <$> m` instead of `fmap f m`. I also added the new changes to the file.