### PR TITLE
Use the same config file logic in argsSettings as in hlint

### DIFF
--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards, TupleSections #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 
-module HLint(hlint) where
+module HLint(hlint, readAllSettings) where
 
 import Control.Applicative
 import Control.Monad.Extra


### PR DESCRIPTION
This correctly picks up the local config file, when used in `haskell-ide-engine`.

See https://github.com/haskell/haskell-ide-engine/issues/363