### PR TITLE
Add hint for obscured `concatMap`

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -122,6 +122,8 @@
     - warn: {lhs: isPrefixOf (reverse x) (reverse y), rhs: isSuffixOf x y}
     - warn: {lhs: "foldr (++) []", rhs: concat}
     - warn: {lhs: foldr (++) "", rhs: concat}
+    - warn: {lhs: "foldr ((++) . f) []", rhs: concatMap f}
+    - warn: {lhs: foldr ((++) . f) "", rhs: concatMap f}
     - warn: {lhs: "foldl (++) []", rhs: concat, note: IncreasesLaziness}
     - warn: {lhs: foldl (++) "", rhs: concat, note: IncreasesLaziness}
     - warn: {lhs: foldl f (head x) (tail x), rhs: foldl1 f x}


### PR DESCRIPTION
Similar to the `foldr (++) []` cases, `foldr ((++) . f) []` is just `concatMap f`.

I wasn't sure where to put this hint, though, last time I've contributed to hlint there was still a Default.hs. I've placed the new two warnings (for lists and strings) after their `foldr (++) []` variant.