### PR TITLE
Allow `unit_` prefix to bypass camelCase suggestion

### DIFF
--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -87,7 +87,7 @@ getNames x = case x of
 suggestName :: String -> Maybe String
 suggestName x
     | isSym x || good || not (any isLower x) || any isDigit x ||
-        any (`isPrefixOf` x) ["prop_","case_","test_"] = Nothing
+        any (`isPrefixOf` x) ["prop_","case_","unit_","test_"] = Nothing
     | otherwise = Just $ f x
     where
         good = all isAlphaNum $ drp '_' $ drp '#' $ drp '\'' $ reverse $ drp '_' x


### PR DESCRIPTION
You were allowing `case_` and `prop_` to bypass camelCase suggestion.

But tasty-discover deprecates `case_` in favor of `unit_` for HUnit tests: https://github.com/lwm/tasty-discover#write-tests

