### PR TITLE
Fix code climate build, broken by removal of stack.yaml

### DIFF
--- a/cc/Dockerfile
+++ b/cc/Dockerfile
@@ -10,12 +10,12 @@ ENV PATH /root/.local/bin:$PATH
 RUN mkdir -p /src
 WORKDIR /src
 
-# Install appropriate GHC
-COPY stack.yaml /src/
+# Initialize package/stack
+COPY hlint.cabal /src/
+RUN stack init
 RUN stack setup
 
 # Install HLint
-COPY hlint.cabal /src/
 RUN stack install --dependencies-only
 COPY ./src /src/src
 COPY ./data /src/data


### PR DESCRIPTION
The Code Climate build relied on the existence of the `stack.yaml` file.
When that was removed this build broke. I've reconfigured the Dockerfile
to initialize `stack.yaml` itself.

There is probably a way to get this tested in CI. I'm not sure if you have
opinions there.

cc: @dblandin @larkinscott