### PR TITLE
More test prefixes that bypass camelCase hint

### DIFF
--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -87,7 +87,7 @@ getNames x = case x of
 suggestName :: String -> Maybe String
 suggestName x
     | isSym x || good || not (any isLower x) || any isDigit x ||
-        any (`isPrefixOf` x) ["prop_","case_","unit_","test_"] = Nothing
+        any (`isPrefixOf` x) ["prop_","case_","unit_","test_","spec_","scprop_","hprop_"] = Nothing
     | otherwise = Just $ f x
     where
         good = all isAlphaNum $ drp '_' $ drp '#' $ drp '\'' $ reverse $ drp '_' x


### PR DESCRIPTION
Déjà vu — I should have known I'd run into some of the other test prefixes supported by tasty-discover. This covers the full list in their readme.