### PR TITLE
sortBy . comparing → sortOn

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -91,6 +91,7 @@
     - warn: {lhs: last (sortBy f x), rhs: maximumBy f x, side: isCompare f}
     - warn: {lhs: reverse (sortBy f x), rhs: sortBy (flip f) x, name: Avoid reverse, side: isCompare f}
     - warn: {lhs: sortBy (comparing (flip f)), rhs: sortOn (Down . f)}
+    - warn: {lhs: sortBy (comparing f), rhs: sortOn f}
     - warn: {lhs: reverse (sortOn f x), rhs: sortOn (Data.Ord.Down . f) x, name: Avoid reverse}
     - warn: {lhs: reverse (sort x), rhs: sortOn Data.Ord.Down x, name: Avoid reverse}
     - hint: {lhs: flip (g `on` h), rhs: flip g `on` h, name: Move flip}
@@ -838,4 +839,5 @@
 # main = hello .~ Just 12 -- hello ?~ 12
 # foo = liftIO $ window `on` deleteEvent $ do a; b
 # no = sort <$> f input `shouldBe` sort <$> x
+# sortBy (comparing snd) -- sortOn snd
 # </TEST>

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -51,7 +51,7 @@ applyHintsReal settings hints_ ms = concat $
         concat [order [] $ hintComment hints settings c | c <- cs]
     | (nm,(m,cs)) <- mns
     , let decHints = hintDecl hints settings nm m -- partially apply
-    , let order n = map (\i -> i{ideaModule= f $ moduleName m : ideaModule i, ideaDecl= f $ n ++ ideaDecl i}) . sortBy (comparing ideaSpan)
+    , let order n = map (\i -> i{ideaModule= f $ moduleName m : ideaModule i, ideaDecl= f $ n ++ ideaDecl i}) . sortOn ideaSpan
     , let merge = mergeBy (comparing ideaSpan)] ++
     [map (classify cls) (hintModules hints settings $ map (second fst) mns)]
     where

--- a/src/Hint/ListRec.hs
+++ b/src/Hint/ListRec.hs
@@ -33,7 +33,6 @@ import Hint.Type
 import Hint.Util
 import Data.List.Extra
 import Data.Maybe
-import Data.Ord
 import Data.Either.Extra
 import Control.Monad
 import Refact.Types hiding (RType(Match))
@@ -119,7 +118,7 @@ findCase x = do
     Branch name1 ps1 p1 c1 b1 <- findBranch x1
     Branch name2 ps2 p2 c2 b2 <- findBranch x2
     guard (name1 == name2 && ps1 == ps2 && p1 == p2)
-    [(BNil, b1), (BCons x xs, b2)] <- return $ sortBy (comparing fst) [(c1,b1), (c2,b2)]
+    [(BNil, b1), (BCons x xs, b2)] <- return $ sortOn fst [(c1,b1), (c2,b2)]
     b2 <- transformAppsM (delCons name1 p1 xs) b2
     (ps,b2) <- return $ eliminateArgs ps1 b2
 


### PR DESCRIPTION
Evening

I discovered `sortOn` yesterday and rushed to see if it's in hlint yet. 7e775ed was made 16 hours prior but it doesn't appear to suggest «[the Schwartzian transform](http://hackage.haskell.org/package/base-4.11.1.0/docs/Data-List.html#v:sortOn)» itself. I'm not sure if I missed anything but it's added in this PR. Applied to the source of hlint itself as well.