### PR TITLE
Fix #75: Windows 10: Enable ANSI-capable terminals

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ test_script:
 - set HASKELL_DEPENDENCIES=apply-refact
 - ps: Invoke-Expression (Invoke-WebRequest 'https://raw.githubusercontent.com/ndmitchell/neil/master/appveyor.ps1')
 # - set UNIPLATE_VERBOSE=-1 # Temporary
-- stack exec -- hlint test
+- stack exec -- hlint --test
 - stack exec -- hlint src
 # Test the documented way of running it in appveyor
 - ps: Invoke-Command ([Scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/ndmitchell/hlint/master/misc/appveyor.ps1').Content)) -ArgumentList @('--version')

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -65,7 +65,7 @@ library
         cpphs >= 1.20.1,
         cmdargs >= 0.10,
         uniplate >= 1.5,
-        ansi-terminal >= 0.6.2,
+        ansi-terminal >= 0.8.1,
         extra >= 1.7.3,
         refact >= 0.3,
         aeson >= 1.1.2.0,


### PR DESCRIPTION
This proposed pull request suggests that, on Windows, `main` should try to enable virtual terminal (VT) processing on `stdout`. On Windows 10, the native (ConHost) terminals (Command Prompt and PowerShell) are ANSI-capable but not ANSI-enabled by default; applications have to enable the ANSI-capability.

Some C pre-processor directives are used, to add the Windows-specific code to `Main.hs`; I did not know how to avoid any CPP. `if os(windows)` is used in `hlint.cabal`.

(The addition of `stack.yaml` and most of the changes to `hlint.cabal` seemed necessary in order to build `hlint` (using `stack build`), in order to test the other changes. (`stack init` would not work for me.)

The example below shows: (top) `hlint --color` 'as is' (`hlint --version` is `HLint v2.1.10, (C) Neil Mitchell 2006-2018`) and the problem of 'raw' 'ANSI' codes being sent to the terminal; and (bottom) `hlint --color` after these changes (executed via the `stack exec` function).

![image](https://user-images.githubusercontent.com/14206448/44686145-2f6df200-aa45-11e8-89e2-0bfd009d4f4e.png)
