### PR TITLE
Remove faulty rules that I've previously added

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -634,8 +634,6 @@
     - package lens
     rules:
     - warn: {lhs: "(a ^. b) ^. c", rhs: "a ^. (b . c)"}
-    - warn: {lhs: "(a ^. b) ^? c", rhs: "a ^? (b . c)"}
-    - warn: {lhs: "a ^? (b . _Just)", rhs: "a ^. b"}
     - warn: {lhs: "fromJust (a ^? b)", rhs: "a ^?! b"}
     - warn: {lhs: "a .~ Just b", rhs: "a ?~ b"}
     - warn: {lhs: "a & (mapped %~ b)", rhs: "a <&> b"}


### PR DESCRIPTION
These are rules that I've found helpful for my own work, and then contributed, but I later found that those are not true for all cases - I've missed that lens's `(^.)` mappends all items in folds..

Sorry for previously contributing bugs 😬

For `(a ^. b) ^? c` → `a ^? (b . c)`:

    > :set -XFlexibleContexts
    > let a = [Just "Hello", Just "World"]
    > let b = folded
    > let c = _Just
    > (a ^. b) ^? c == a ^? (b . c)
    False
    > (a ^. b) ^? c
    Just "HelloWorld"
    > a ^? b . c
    Just "Hello"

For `a ^? (b . _Just)` → `a ^. b`:

    > a ^? (b . _Just) == a ^. b
    False
    > a ^? (b . _Just)
    Just "Hello"
    > a ^. b
    Just "HelloWorld"