### PR TITLE
add fixities for operators from the constraints and lattices packages

### DIFF
--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -86,6 +86,9 @@ otherFixities = concat
     ,infix_ 4 ["==="]
     -- esqueleto
     ,infix_ 4 ["==."]
+    -- lattices
+    ,infixr_ 5 ["\\/"] -- \/
+    ,infixr_ 6 ["/\\"] -- /\
     ]
 
 -- Fixites from the `base` package which are currently


### PR DESCRIPTION
I've had a hint misfire due to not knowing `\/`'s fixity. Haven't had trouble with `\\` yet but I'm guessing that's bound to happen to someone :)