### PR TITLE
#398, suggest optional p from option Nothing (Just <$> p)

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -43,6 +43,12 @@
     - import Control.Lens.Operators
     - import Control.Monad.Reader
 
+- package:
+    name: attoparsec
+    modules:
+    - import Data.Attoparsec.Text
+    - import Data.Attoparsec.ByteString
+
 - group:
     name: default
     enabled: true
@@ -657,6 +663,16 @@
     - error: {lhs: "Control.Lens.has (a . Control.Lens.at b)", rhs: "Control.Lens.has a"}
     - error: {lhs: "Control.Lens.nullOf (Control.Lens.at a)", rhs: "False"}
     - error: {lhs: "Control.Lens.nullOf (a . Control.Lens.at b)", rhs: "Control.Lens.nullOf a"}
+
+- group:
+    name: attoparsec
+    enabled: true
+    imports:
+    - package base
+    - package attoparsec
+    rules:
+    - warn: {lhs: Data.Attoparsec.Text.option Nothing (Just <$> p),       rhs: optional p}
+    - warn: {lhs: Data.Attoparsec.ByteString.option Nothing (Just <$> p), rhs: optional p}
 
 - group:
     name: generalise


### PR DESCRIPTION
As suggested in the  #398 issue's thread, I defined the attoparsec package in the default hlint.yaml,
and added the hint there.