### PR TITLE
Add smells to hlint

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -65,7 +65,3 @@
 - ignore: {name: Use explicit module export list, within: HSE.Util}
 # this const has meaingful argument names
 - ignore: {name: Use const, within: Config.Yaml}
-
-- smell: {type: long type lists, limit: 10}
-- smell: {type: many arg functions, limit: 6}
-- smell: {type: many imports, limit: 15 }

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -65,3 +65,5 @@
 - ignore: {name: Use explicit module export list, within: HSE.Util}
 # this const has meaingful argument names
 - ignore: {name: Use const, within: Config.Yaml}
+
+- smell: {type: long type lists, limit: 10}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -67,3 +67,5 @@
 - ignore: {name: Use const, within: Config.Yaml}
 
 - smell: {type: long type lists, limit: 10}
+- smell: {type: many arg functions, limit: 6}
+- smell: {type: many imports, limit: 15 }

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -115,6 +115,7 @@ library
         Hint.Pattern
         Hint.Pragma
         Hint.Restrict
+        Hint.Smell
         Hint.Type
         Hint.Unsafe
         Hint.Util

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -106,11 +106,12 @@ data Restrict = Restrict
     ,restrictWithin :: [(String, String)]
     } deriving Show
 
-data SmellType = SmellLongFunctions | SmellLongTypeLists deriving (Show,Eq,Ord)
+data SmellType = SmellLongFunctions | SmellLongTypeLists | SmellManyArgFunctions deriving (Show,Eq,Ord)
 
 getSmellType :: String -> Maybe SmellType
 getSmellType "long functions" = Just SmellLongFunctions
 getSmellType "long type lists" = Just SmellLongTypeLists
+getSmellType "many arg functions" = Just SmellManyArgFunctions
 getSmellType _ = Nothing
 
 data Smell = Smell

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -106,10 +106,11 @@ data Restrict = Restrict
     ,restrictWithin :: [(String, String)]
     } deriving Show
 
-data SmellType = SmellLongFunctions deriving (Show,Eq,Ord)
+data SmellType = SmellLongFunctions | SmellLongTypeLists deriving (Show,Eq,Ord)
 
 getSmellType :: String -> Maybe SmellType
 getSmellType "long functions" = Just SmellLongFunctions
+getSmellType "long type lists" = Just SmellLongTypeLists
 getSmellType _ = Nothing
 
 data Smell = Smell

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -1,8 +1,8 @@
 
 module Config.Type(
     Severity(..), Classify(..), HintRule(..), Note(..), Setting(..),
-    Restrict(..), RestrictType(..),
-    defaultHintName, isUnifyVar, showNotes, getSeverity, getRestrictType
+    Restrict(..), RestrictType(..), Smell(..), SmellType(..),
+    defaultHintName, isUnifyVar, showNotes, getSeverity, getRestrictType, getSmellType
     ) where
 
 import HSE.All
@@ -106,11 +106,23 @@ data Restrict = Restrict
     ,restrictWithin :: [(String, String)]
     } deriving Show
 
+data SmellType = SmellLongFunctions deriving (Show,Eq,Ord)
+
+getSmellType :: String -> Maybe SmellType
+getSmellType "long functions" = Just SmellLongFunctions
+getSmellType _ = Nothing
+
+data Smell = Smell
+    {smellType :: SmellType
+    ,smellLimit :: Int
+    } deriving Show
+
 data Setting
     = SettingClassify Classify
     | SettingMatchExp HintRule
     | SettingRestrict Restrict
     | SettingArgument String -- ^ Extra command-line argument
+    | SettingSmell Smell
     | Builtin String -- use a builtin hint set
     | Infix Fixity
       deriving Show

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -106,12 +106,14 @@ data Restrict = Restrict
     ,restrictWithin :: [(String, String)]
     } deriving Show
 
-data SmellType = SmellLongFunctions | SmellLongTypeLists | SmellManyArgFunctions deriving (Show,Eq,Ord)
+data SmellType = SmellLongFunctions | SmellLongTypeLists | SmellManyArgFunctions | SmellManyImports
+  deriving (Show,Eq,Ord)
 
 getSmellType :: String -> Maybe SmellType
 getSmellType "long functions" = Just SmellLongFunctions
 getSmellType "long type lists" = Just SmellLongTypeLists
 getSmellType "many arg functions" = Just SmellManyArgFunctions
+getSmellType "many imports" = Just SmellManyImports
 getSmellType _ = Nothing
 
 data Smell = Smell

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -1,7 +1,7 @@
 
 module Config.Type(
     Severity(..), Classify(..), HintRule(..), Note(..), Setting(..),
-    Restrict(..), RestrictType(..), Smell(..), SmellType(..),
+    Restrict(..), RestrictType(..), SmellType(..),
     defaultHintName, isUnifyVar, showNotes, getSeverity, getRestrictType, getSmellType
     ) where
 
@@ -116,17 +116,12 @@ getSmellType "many arg functions" = Just SmellManyArgFunctions
 getSmellType "many imports" = Just SmellManyImports
 getSmellType _ = Nothing
 
-data Smell = Smell
-    {smellType :: SmellType
-    ,smellLimit :: Int
-    } deriving Show
-
 data Setting
     = SettingClassify Classify
     | SettingMatchExp HintRule
     | SettingRestrict Restrict
     | SettingArgument String -- ^ Extra command-line argument
-    | SettingSmell Smell
+    | SettingSmell SmellType Int
     | Builtin String -- use a builtin hint set
     | Infix Fixity
       deriving Show

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -190,11 +190,11 @@ parseSmell v = do
   smellName <- parseField "type" v >>= parseString
   smellType <- require v "Expected SmellType"  $ getSmellType smellName
   smellLimit <- parseField "limit" v >>= parseInt
-  return [SettingSmell Smell{..}]
+  return [SettingSmell smellType smellLimit]
     where
       require :: Val -> String -> Maybe a -> Parser a
       require _ _ (Just a) = return a
-      require val err Nothing = parseFail val err
+      require val err Nothing = parseFail val err 
 
 parseGroup :: Val -> Parser Group
 parseGroup v = do

--- a/src/Hint/All.hs
+++ b/src/Hint/All.hs
@@ -60,7 +60,9 @@ builtin x = case x of
     HintComment    -> comm commentHint
     HintNewType    -> decl newtypeHint
     HintRestrict   -> mempty{hintModule=restrictHint}
-    HintSmell      -> mempty{hintDecl=smellHint}
+    HintSmell      -> mempty{hintDecl=smellHint
+                            ,hintModule=smellModuleHint
+                            }
     where
         wrap = timed "Hint" (drop 4 $ show x) . forceList
         decl f = mempty{hintDecl=const $ \a b c -> wrap $ f a b c}

--- a/src/Hint/All.hs
+++ b/src/Hint/All.hs
@@ -30,6 +30,7 @@ import Hint.Duplicate
 import Hint.Comment
 import Hint.Unsafe
 import Hint.NewType
+import Hint.Smell
 
 -- | A list of the builtin hints wired into HLint.
 --   This list is likely to grow over time.
@@ -37,7 +38,7 @@ data HintBuiltin =
     HintList | HintListRec | HintMonad | HintLambda |
     HintBracket | HintNaming | HintPattern | HintImport | HintExport |
     HintPragma | HintExtensions | HintUnsafe | HintDuplicate | HintRestrict |
-    HintComment | HintNewType
+    HintComment | HintNewType | HintSmell
     deriving (Show,Eq,Ord,Bounded,Enum)
 
 
@@ -59,6 +60,7 @@ builtin x = case x of
     HintComment    -> comm commentHint
     HintNewType    -> decl newtypeHint
     HintRestrict   -> mempty{hintModule=restrictHint}
+    HintSmell      -> mempty{hintDecl=smellHint}
     where
         wrap = timed "Hint" (drop 4 $ show x) . forceList
         decl f = mempty{hintDecl=const $ \a b c -> wrap $ f a b c}

--- a/src/Hint/All.hs
+++ b/src/Hint/All.hs
@@ -60,9 +60,7 @@ builtin x = case x of
     HintComment    -> comm commentHint
     HintNewType    -> decl newtypeHint
     HintRestrict   -> mempty{hintModule=restrictHint}
-    HintSmell      -> mempty{hintDecl=smellHint
-                            ,hintModule=smellModuleHint
-                            }
+    HintSmell      -> mempty{hintDecl=smellHint,hintModule=smellModuleHint}
     where
         wrap = timed "Hint" (drop 4 $ show x) . forceList
         decl f = mempty{hintDecl=const $ \a b c -> wrap $ f a b c}

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE RecordWildCards #-}
+module Hint.Smell where
+
+import Hint.Type
+import Config.Type
+import Data.Maybe
+import qualified Data.Map as Map
+
+smellHint :: [Setting] -> DeclHint
+smellHint settings scope m d = sniff smellLongFunctions SmellLongFunctions
+  where
+    sniff f t = maybe [] (f d) $ Map.lookup t (smells settings)
+
+smellLongFunctions :: Decl_ -> Int -> [Idea]
+smellLongFunctions d n
+  | Just length <- spanLength <$> declBind d
+  , length >= n
+  = [(warn "Long function" d d []) { ideaTo = Nothing}]
+smellLongFunctions _ _ = []
+
+
+declBind :: Decl l -> Maybe l
+declBind (FunBind  l match)         = Just l
+declBind (PatBind l (PVar _ n) _ _) = Just l
+declBind _                          = Nothing
+
+spanLength :: SrcSpanInfo -> Int
+spanLength (SrcSpanInfo span _) = srcSpanEndLine span - srcSpanStartLine span + 1
+
+smells :: [Setting] -> Map.Map SmellType Int
+smells settings = Map.fromList [ (smellType, smellLimit) | SettingSmell Smell{..} <- settings]

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -1,13 +1,17 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RecordWildCards #-}
 module Hint.Smell where
 
 import Hint.Type
 import Config.Type
+import Control.Monad
 import Data.Maybe
 import qualified Data.Map as Map
 
 smellHint :: [Setting] -> DeclHint
-smellHint settings scope m d = sniff smellLongFunctions SmellLongFunctions
+smellHint settings scope m d =
+  sniff smellLongFunctions SmellLongFunctions ++
+  sniff smellLongTypeLists SmellLongTypeLists
   where
     sniff f t = maybe [] (f d) $ Map.lookup t (smells settings)
 
@@ -18,7 +22,6 @@ smellLongFunctions d n
   = [(warn "Long function" d d []) { ideaTo = Nothing}]
 smellLongFunctions _ _ = []
 
-
 declBind :: Decl l -> Maybe l
 declBind (FunBind  l match)         = Just l
 declBind (PatBind l (PVar _ n) _ _) = Just l
@@ -26,6 +29,33 @@ declBind _                          = Nothing
 
 spanLength :: SrcSpanInfo -> Int
 spanLength (SrcSpanInfo span _) = srcSpanEndLine span - srcSpanStartLine span + 1
+
+smellLongTypeLists :: Decl_ -> Int -> [Idea]
+smellLongTypeLists d@(TypeSig _ _ t) n = warn "Long type list" d d [] <$ filter longTypeList (unrollType t)
+  where
+    longTypeList (TyPromoted _ (PromotedList _ _ x)) = length x >= n
+    longTypeList _ = False
+smellLongTypeLists _ _ = []    
+
+subTypes :: Type l -> [Type l]
+subTypes (TyForall _ _ _ t) = [t]
+subTypes (TyFun _ a b) = [a, b]
+subTypes (TyTuple _ _ x) = x
+subTypes (TyUnboxedSum _ x) = x
+subTypes (TyList _ a) = [a]
+subTypes (TyParArray _ a) = [a]
+subTypes (TyApp _ a b) = [a, b]
+subTypes (TyParen _ a) = [a]
+subTypes (TyInfix _ a _ b) = [a, b]
+subTypes (TyKind _ a _) = [a]
+subTypes (TyPromoted _ (PromotedList _ _ x)) = x
+subTypes (TyPromoted _ (PromotedTuple _ x)) = x
+subTypes (TyEquals _ a b) = [a, b]
+subTypes (TyBang _ _ _ a) = [a]
+subTypes _ = []
+
+unrollType :: Type l -> [Type l]
+unrollType t = t : (subTypes t >>= unrollType)
 
 smells :: [Setting] -> Map.Map SmellType Int
 smells settings = Map.fromList [ (smellType, smellLimit) | SettingSmell Smell{..} <- settings]

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -5,8 +5,19 @@ module Hint.Smell where
 import Hint.Type
 import Config.Type
 import Control.Monad
+import Data.List.Extra
 import Data.Maybe
 import qualified Data.Map as Map
+
+smellModuleHint :: [Setting] -> ModuHint
+smellModuleHint settings scope m@(Module _ _ _ imports _) = case Map.lookup SmellManyImports (smells settings) of
+  Just n | length imports >= n ->
+           let span = srcInfoSpan $ ann $ head imports
+               displayImports = unlines $ f <$> imports
+           in [rawIdea Warning "Many imports" span displayImports  Nothing [] [] ]
+    where
+      f = trimStart . prettyPrint
+  _ -> []
 
 smellHint :: [Setting] -> DeclHint
 smellHint settings scope m d =

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RecordWildCards #-}
 module Hint.Smell where
 

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE RecordWildCards #-}
-module Hint.Smell where
+module Hint.Smell (
+  smellModuleHint,
+  smellHint
+  ) where
 
 import Hint.Type
 import Config.Type
-import Control.Monad
 import Data.List.Extra
-import Data.Maybe
 import qualified Data.Map as Map
 
 smellModuleHint :: [Setting] -> ModuHint
@@ -80,4 +81,4 @@ unrollType :: Type l -> [Type l]
 unrollType t = t : concatMap unrollType (subTypes t)
 
 smells :: [Setting] -> Map.Map SmellType Int
-smells settings = Map.fromList [ (smellType, smellLimit) | SettingSmell Smell{..} <- settings]
+smells settings = Map.fromList [ (smellType, smellLimit) | SettingSmell smellType smellLimit  <- settings]

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -53,7 +53,7 @@ smellManyArgFunctions :: Decl_ -> Int -> [Idea]
 smellManyArgFunctions d@(TypeSig _ _ t) n = warn "Many arg function" d d [] <$  filter manyArgFunction (unrollType t)
   where
     manyArgFunction x = countFunctionArgs x >= n
-smellManyArgFunctions _ _ = []    
+smellManyArgFunctions _ _ = []
 
 countFunctionArgs :: Type l -> Int
 countFunctionArgs (TyFun _ _ b) = 1 + countFunctionArgs b

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -65,7 +65,7 @@ import qualified Data.Map as Map
 smellModuleHint :: [Setting] -> ModuHint
 smellModuleHint settings scope m@(Module _ _ _ imports _) = case Map.lookup SmellManyImports (smells settings) of
   Just n | length imports >= n ->
-           let span = srcInfoSpan $ ann $ head imports
+           let span = foldl1 mergeSrcSpan $ srcInfoSpan . ann <$> imports
                displayImports = unlines $ f <$> imports
            in [rawIdea Warning "Many imports" span displayImports  Nothing [] [] ]
     where

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -1,8 +1,61 @@
-{-# LANGUAGE RecordWildCards #-}
 module Hint.Smell (
   smellModuleHint,
   smellHint
   ) where
+
+{-
+<TEST> [{smell: { type: many arg functions, limit: 2 }}]
+f :: Int -> Int \
+f = undefined
+
+f :: Int -> Int -> Int \
+f = undefined --
+</TEST>
+
+<TEST> 
+f :: Int -> Int \
+f = undefined
+
+f :: Int -> Int -> Int \
+f = undefined
+</TEST>
+
+<TEST> [{smell: { type: long functions, limit: 3}}]
+f = do \
+ x <- y \
+ return x --
+
+f = return x
+</TEST>
+
+<TEST> 
+f = do \
+ x <- y \
+ return x
+
+f = return x
+</TEST>
+
+<TEST> [{smell: { type: long type lists, limit: 2}}]
+f :: Proxy '[a, b] --
+f :: Proxy '[a]
+</TEST>
+
+<TEST>
+f :: Proxy '[a, b]
+f :: Proxy '[a]
+</TEST>
+
+<TEST> [{smell: { type: many imports, limit: 2}}]
+import A; import B --
+import A
+</TEST>
+
+<TEST>
+import A; import B
+import A
+</TEST>
+-}
 
 import Hint.Type
 import Config.Type

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -77,7 +77,7 @@ subTypes (TyBang _ _ _ a) = [a]
 subTypes _ = []
 
 unrollType :: Type l -> [Type l]
-unrollType t = t : (subTypes t >>= unrollType)
+unrollType t = t : concatMap unrollType (subTypes t)
 
 smells :: [Setting] -> Map.Map SmellType Int
 smells settings = Map.fromList [ (smellType, smellLimit) | SettingSmell Smell{..} <- settings]


### PR DESCRIPTION
This PR adds detection of "code smells" to hlint, inspired by some of the functionality in `swiftlint`.

I've started by adding 4 smells (none of them are on by default):

* Long function bodies
* Functions with many arguments
* Type level lists with many elements (especially useful for programming in some of the free monad effect styles)
* Many imports 

All of these are things that can indicate that it's time to do a little cleanup + reorganization. 

Each smell is parameterized by an integer limit (e.g. function bodies should be < 20 lines long) 