### PR TITLE
Only unlit .lhs files

### DIFF
--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -59,5 +59,5 @@ parseFileGhcLib filename str =
   Lexer.unP Parser.parseModule parseState
   where
     location = mkRealSrcLoc (mkFastString filename) 1 1
-    buffer = stringToStringBuffer (unlit filename str)
+    buffer = stringToStringBuffer (if ".lhs" `isSuffixOf` filename then unlit filename str else str)
     parseState = mkPState dynFlags buffer location


### PR DESCRIPTION
This isn't the whole story with respect to the using of `unlit` but a quick patch to restrict its use to only files with suffix '.lhs'.