### PR TITLE
Some small preparation towards eliminating the SDoc field from ParseError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /issues/
 /Sample.hs
 /hlint.prof
+/TAGS

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -203,9 +203,9 @@ parseModuleEx flags file str = timedIO "Parse" file $ do
               return $ Right (ParsedModuleResults (applyFixity fixity x, cs) (Just mod))
             (ParseOk (x, cs), PFailed _) ->
               return $ Right (ParsedModuleResults (applyFixity fixity x, cs) Nothing)
-            (hseFail@(ParseFailed sl msg), ghcFail@(PFailed ps)) ->
+            (hseFail @ (ParseFailed sl msg), ghcFail @ (PFailed ps)) ->
               failOpParseModuleEx ppstr flags file str hseFail (Just ghcFail)
-            (hseFail@(ParseFailed sl msg), POk _ _) ->
+            (hseFail @ (ParseFailed sl msg), POk _ _) ->
               failOpParseModuleEx ppstr flags file str hseFail Nothing
     where
         fixity = fromMaybe [] $ fixities $ hseFlags flags


### PR DESCRIPTION
In this PR, we lift a new function `failOpParseModuleEx`, lifted out of `parseModuleEx`. The intent is to then split this function into two cases, preferring to construct `ParseError` values from GHC `ParseFailed _` values when they exist else fall back on the standard HSE implementation. Doing that will no doubt involve updating test results (error strings will change). In any case, at that point we'll then eliminate the `SDoc` field from `ParseError` (which will remain unused up to its elimination). Tests pass and no new behaviors are introduced.