### PR TITLE
Eliminate the recently added SDoc list field from ParseError

### DIFF
--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -80,7 +80,7 @@ parseModuleApply flags s file src = do
     res <- parseModuleEx (parseFlagsAddFixities [x | Infix x <- s] flags) file src
     case res of
         Right (ParsedModuleResults (m, c) _)  -> return $ Right (m,c)
-        Left (ParseError sl msg ctxt _) ->
+        Left (ParseError sl msg ctxt) ->
             return $ Left $ classify [x | SettingClassify x <- s] $ rawIdeaN Error "Parse error" (mkSrcSpan sl sl) ctxt Nothing []
 
 

--- a/src/Config/Compute.hs
+++ b/src/Config/Compute.hs
@@ -16,7 +16,7 @@ computeSettings :: ParseFlags -> FilePath -> IO (String, [Setting])
 computeSettings flags file = do
     x <- parseModuleEx flags file Nothing
     case x of
-        Left (ParseError sl msg _ _) ->
+        Left (ParseError sl msg _) ->
             return ("# Parse error " ++ showSrcLoc sl ++ ": " ++ msg, [])
         Right (ParsedModuleResults (m, _) _) -> do
             let xs = concatMap (findSetting $ UnQual an) (moduleDecls m)

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -29,7 +29,7 @@ readFileConfigHaskell file contents = do
     let flags = addInfix defaultParseFlags
     res <- parseModuleEx flags file contents
     case res of
-        Left (ParseError sl msg err _) ->
+        Left (ParseError sl msg err) ->
             error $ "Config parse failure at " ++ showSrcLoc sl ++ ": " ++ msg ++ "\n" ++ err
         Right (ParsedModuleResults (m, cs) _) -> return $ readSettings m ++ map SettingClassify (concatMap readComment cs)
 

--- a/src/Grep.hs
+++ b/src/Grep.hs
@@ -24,7 +24,7 @@ runGrep patt flags files = do
     forM_ files $ \file -> do
         res <- parseModuleEx flags file Nothing
         case res of
-            Left (ParseError sl msg ctxt _) ->
+            Left (ParseError sl msg ctxt) ->
                 print $ rawIdeaN Error (if "Parse error" `isPrefixOf` msg then msg else "Parse error: " ++ msg) (mkSrcSpan sl sl) ctxt Nothing []
             Right (ParsedModuleResults (m, c) _) ->
                 forM_ (applyHints [] rule [(m, c)]) $ \i ->


### PR DESCRIPTION
In this iteration, the recently added `[SDoc]` field in `ParseError` is removed. Now, if a GHC parse state value is available from a `PFailed s` then the error handling code uses it to produce the `ParseError`. Despite this somewhat fundamental change, the test suite continues to pass in entirety. 

Manual testing seems to indicate that either the old way or the new way, the error message harvested dealing with the failure doesn't actually get reported to the user.