### PR TITLE
Upgrade to ghc-lib-0.20190516

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -60,7 +60,7 @@ library
         extra >= 1.6.6,
         refact >= 0.3,
         aeson >= 1.1.2.0,
-        ghc-lib-parser >= 0.20190423
+        ghc-lib-parser >= 0.20190516
 
     if flag(gpl)
         build-depends: hscolour >= 1.21


### PR DESCRIPTION
In this upgrade, `ghc-lib-parser` employs syntactic obfuscation of its cbits which will help avoid conflicts (e.g. duplicate symbol definitions) when `hlint` is linked into executables aggregating other libraries containing GHC sources. Additionally, the parser was produced by happy 1.19.10 with the `--coerece` option so parse execution times should be expected to pick up by about 10%.