### PR TITLE
Upgrade to ghc-lib-parser-0.20190523

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -60,7 +60,7 @@ library
         extra >= 1.6.6,
         refact >= 0.3,
         aeson >= 1.1.2.0,
-        ghc-lib-parser >= 0.20190516
+        ghc-lib-parser >= 0.20190523
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -225,13 +225,10 @@ parseModuleExInternal flags file str = timedIO "Parse" file $ do
             (ParseFailed sl msg, pfailed) ->
                 failOpParseModuleEx ppstr flags file str sl msg $ fromPFailed pfailed
     where
-        -- TEMPORARY HACK TO AVOID EVALUATING parseFileGhcLib
-        -- see https://github.com/ndmitchell/hlint/issues/637
-        -- fromPFailed (PFailed x) = Just x
+        fromPFailed (PFailed x) = Just x
         fromPFailed _ = Nothing
 
-        -- TEMPORARY HACK
-        -- fromPOk (POk _ x) = Just x
+        fromPOk (POk _ x) = Just x
         fromPOk _ = Nothing
 
         fixity = fromMaybe [] $ fixities $ hseFlags flags


### PR DESCRIPTION
This PR upgrades ghc-lib to include the fix for https://github.com/digital-asset/ghc-lib/pull/66 and re-enables production of ghc parse trees.
