### PR TITLE
add another hint suggesting use of null, in a new group: teaching

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -732,6 +732,14 @@
     rules:
     - warn: {lhs: a $ b $ c, rhs: a . b $ c}
 
+- group:
+    name: teaching
+    enabled: false
+    imports:
+    - package base
+    rules:
+    - hint: {lhs: "x /= []", rhs: not (null x), name: Use null}
+
 
 # <TEST>
 # yes = concat . map f -- concatMap f


### PR DESCRIPTION
There already was a suggestion for the case:
```haskell
if x == [] then ...
```
but not for the complementary case:
```haskell
if x /= [] then ...
```
