### PR TITLE
Check for NamedFieldPuns extension

### DIFF
--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -251,6 +251,7 @@ used StandaloneDeriving = hasS isDerivDecl
 used PatternSignatures = hasS isPatTypeSig
 used RecordWildCards = hasS isPFieldWildcard ||^ hasS isFieldWildcard
 used RecordPuns = hasS isPFieldPun ||^ hasS isFieldPun
+used NamedFieldPuns = hasS isPFieldPun ||^ hasS isFieldPun
 used UnboxedTuples = has (not . isBoxed)
 used PackageImports = hasS (isJust . importPkg)
 used QuasiQuotes = hasS isQuasiQuote ||^ hasS isTyQuasiQuote


### PR DESCRIPTION
According to haskell-src-exts documentation NamedFieldPuns replaced RecordPuns (which is a deprecated extension name):

http://hackage.haskell.org/package/haskell-src-exts-1.21.0/docs/Language-Haskell-Exts-Extension.html#v:RecordPuns

So the check for RecordPun should also be used for NamedFieldPuns