### PR TITLE
Add failing test for brackets / slice ($x)

### DIFF
--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -22,6 +22,15 @@ no = \(x -> y) -> z
 yes = (`foo` (bar baz)) -- @Suggestion (`foo` bar baz)
 yes = f ((x)) -- @Warning x
 main = do f; (print x) -- @Suggestion do f print x
+yes = f (x) y -- @Warning x
+no = f (+x) y
+no = f ($x) y
+no = ($x)
+yes = (($x)) -- @Warning ($x)
+no = ($1)
+yes = (($1)) -- @Warning ($1)
+no = (+5)
+yes = ((+5)) -- @Warning (+5)
 
 -- type bracket reduction
 foo :: (Int -> Int) -> Int

--- a/tests/bracket.test
+++ b/tests/bracket.test
@@ -1,0 +1,29 @@
+---------------------------------------------------------------------
+RUN tests/bracket-slice.hs
+FILE tests/bracket-slice.hs
+
+fAnd :: [a -> Bool] -> a -> Bool
+fAnd fs x = all ($x) fs
+
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
+RUN tests/bracket-slice-spaced.hs
+FILE tests/bracket-slice-spaced.hs
+
+fAnd :: [a -> Bool] -> a -> Bool
+fAnd fs x = all ($ x) fs
+
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
+RUN tests/bracket-slice-plus.hs
+FILE tests/bracket-slice-plus.hs
+
+incAll :: [Int] -> Int -> [Int]
+incAll ys x = map (+x) fs
+
+OUTPUT
+No hints


### PR DESCRIPTION
More of a bug report than a real PR.

hlint complains about redundant brackets in the slice `($x)`. It seems there's something about `$x` that causes it to be treated as an atom, presumably due to Template Haskell?
