### PR TITLE
Symmetric version of "if-then-else to list comprehension", and De Morgan laws

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -443,6 +443,7 @@
     # LIST COMP
 
     - hint: {lhs: "if b then [x] else []", rhs: "[x | b]", name: Use list comprehension}
+    - hint: {lhs: "if b then [] else [x]", rhs: "[x | not b]", name: Use list comprehension}
     - hint: {lhs: "[x | x <- y]", rhs: "y", side: isVar x, name: Redundant list comprehension}
 
     # SEQ

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -759,6 +759,8 @@
     rules:
     - hint: {lhs: "x /= []", rhs: not (null x), name: Use null}
     - hint: {lhs: "[] /= x", rhs: not (null x), name: Use null}
+    - hint: {lhs: "not (x || y)", rhs: "not x && not y", name: Apply De Morgan law}
+    - hint: {lhs: "not (x && y)", rhs: "not x || not y", name: Apply De Morgan law}
 
 
 # <TEST>


### PR DESCRIPTION
So, here three new hints inspired by what I saw in student code.

Specifically, this was a small function somebody wrote as part of a submission:
```haskell
    simpleCases :: (Int, Int) -> [Int]
    simpleCases (x, y) = if y<x || not (p x) then [] else [x]
```
I'd much rather have seen this as something like:
```haskell
    simpleCases :: (Int, Int) -> [Int]
    simpleCases (x, y) = [x | x <= y, p x]
```
There is already a hint for introducing single element list comprehensions from if-then-else:
https://github.com/ndmitchell/hlint/blob/d1895a2daf05e00f27aadf9223210453ff53b928/data/hlint.yaml#L445

However, it only matches the opposite case. So I introduced:
```yaml
    - hint: {lhs: "if b then [] else [x]", rhs: "[x | not b]", name: Use list comprehension}
```

This would get us to:
```haskell
    simpleCases :: (Int, Int) -> [Int]
    simpleCases (x, y) = [x | not  (y<x || not (p x))]
```
Then, application of one of the De Morgan laws
```yaml
    - hint: {lhs: "not (x || y)", rhs: "not x && not y", name: Apply De Morgan law}
    - hint: {lhs: "not (x && y)", rhs: "not x || not y", name: Apply De Morgan law}
```
gives:
```haskell
    simpleCases :: (Int, Int) -> [Int]
    simpleCases (x, y) = [x | not  (y<x) && not (not (p x))]
```
from which already existing hints would finally get us to:
```haskell
    simpleCases :: (Int, Int) -> [Int]
    simpleCases (x, y) = [x | y >= x && p x]
```

I introduced the three hints in the `teaching` group. Maybe they are more generally useful, but the introductions of the `not` calls might be not so favored in some case. Specifically, in a teaching setting the atomic conditionals will often be arithmetic comparisons, so adding `not` and then pushing it down will often result in nicer looking conditions in the end that do not contain `not` at all anymore. That might not be the case in "real" code, where conditionals may involve other, more custom tests, and where the programmer actually prefers a `not` around a complex condition rather than pushing it down via De Morgan.

Of course, if you think the laws could be in the general section as well, I can move them.

Also, one more hint I considered, to really get the specific example above to
```haskell
    simpleCases :: (Int, Int) -> [Int]
    simpleCases (x, y) = [x | y >= x, p x]
```
was:
```yaml
    - hint: {lhs: "[x | y && z]", rhs: "[x | y, z]", name: Break down conjunction in list comprehension}
```
But maybe that is really *too* specific, even in a teaching setting.