### PR TITLE
Copy the not.null hints from teaching to generalise

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -758,6 +758,8 @@
     - warn: {lhs: map, rhs: fmap}
     - warn: {lhs: a ++ b, rhs: a <> b}
     - warn: {lhs: "sequence [a]", rhs: "pure <$> a"}
+    - warn: {lhs: "x /= []", rhs: not (null x), name: Use null}
+    - warn: {lhs: "[] /= x", rhs: not (null x), name: Use null}
 
 - group:
     name: generalise-for-conciseness


### PR DESCRIPTION
Using `null` instead of testing equality against `[]` has a real advantage: it lets you drop the `Eq` constraint on the contents, and operate on any `Foldable` rather than just on lists. As such, this is a generalisation useful in real programs, and not just for teaching.