### PR TITLE
Suggest using explicit deriving strategies for newtypes

### DIFF
--- a/src/Idea.hs
+++ b/src/Idea.hs
@@ -3,7 +3,7 @@
 module Idea(
     Idea(..),
     rawIdea, idea, suggest, warn, ignore,
-    rawIdeaN, suggestN,
+    rawIdeaN, suggestN, ignoreN,
     showIdeasJson, showANSI,
     Note(..), showNotes,
     Severity(..)
@@ -92,3 +92,4 @@ ignore = idea Ignore
 ideaN severity hint from to = idea severity hint from to []
 
 suggestN = ideaN Suggestion
+ignoreN = ideaN Ignore


### PR DESCRIPTION
Following #682, this is a first shot at suggesting explicit deriving strategies.

There are still a few questions before considering this patch satisfying

- ~how do I make it opt-in? (it makes a newtype-related test fail)~
- for the lack of a better solution, it always suggests `deriving newtype`, that could change behaviour (I don't think i can compute the actual, implicit behaviour)
- it covers gadt-like newtype definitions, I'm not 100% sure of the implications
- ~`NewTypeDerivingStrategies` is quite a long name and it's tedious for vertical alignment. Maybe you'd prefer a shorter name?~
