### PR TITLE
Speed up empty refactorings case

### DIFF
--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -205,6 +205,7 @@ getIdeas cmd@CmdMain{..} settings = do
         else ideas
 
 handleRefactoring :: [Idea] -> [String] -> Cmd -> IO ()
+handleRefactoring [] _ _ = pure () -- No refactorings to apply
 handleRefactoring ideas files cmd@CmdMain{..} =
     case cmdFiles of
         [file] -> do


### PR DESCRIPTION
This patch causes hlint to bail earlier if it has no refactorings to apply.