### PR TITLE
add head/drop rule with max, for case that number not known to be non-negative

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -128,6 +128,7 @@
     - warn: {lhs: "cycle [x]", rhs: repeat x}
     - warn: {lhs: head (reverse x), rhs: last x}
     - warn: {lhs: head (drop n x), rhs: x !! n, side: isNat n}
+    - warn: {lhs: head (drop n x), rhs: x !! max 0 n, side: not (isNat n)}
     - warn: {lhs: reverse (tail (reverse x)), rhs: init x, note: IncreasesLaziness}
     - warn: {lhs: reverse (reverse x), rhs: x, note: IncreasesLaziness, name: Avoid reverse}
     - warn: {lhs: isPrefixOf (reverse x) (reverse y), rhs: isSuffixOf x y}


### PR DESCRIPTION
See https://github.com/ndmitchell/hlint/issues/674#issuecomment-505175812.

Closes https://github.com/ndmitchell/hlint/issues/674.

I also thought a bit about the `last`/`take` case, but there doesn't seem to be a nice formulation. It could be something like:
```yaml
    - warn: {lhs: last (take n x), rhs: x !! (min n (length x) - 1)}
```
But not only is this not really a nice expression on the right-hand side. There also is the issue that `x` gets duplicated (which I guess is problematic for hints in general).

One could also think of it in terms of the following two pseudo-hints:
```yaml
    - warn: {lhs: last (take n x), rhs: x !! (n - 1), side: n <= length x}
    - warn: {lhs: last (take n x), rhs: last x, side: n > length x}
```
Pseudo in that the `side` conditions here are not actually something that could be tested statically/syntactically, at least not in that generality. Maybe special cases would be possible for some `n` or for certain list literals `x`. But I'm doubting that would be worth it.