### PR TITLE
langexts explcitily enabled/disabled

### DIFF
--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -42,7 +42,6 @@ import System.FilePath
 import Language.Preprocessor.Unlit
 import qualified Language.Haskell.Exts.Extension as HSE
 import qualified Data.Map.Strict as Map
-import Text.Read
 
 fakeSettings :: Settings
 fakeSettings = Settings

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module GHC.Util (
     baseDynFlags
@@ -40,7 +41,8 @@ import Data.List
 import System.FilePath
 import Language.Preprocessor.Unlit
 import qualified Language.Haskell.Exts.Extension as HSE
-import qualified Data.Map.Strict
+import qualified Data.Map.Strict as Map
+import Text.Read
 
 fakeSettings :: Settings
 fakeSettings = Settings
@@ -211,116 +213,9 @@ isDotApp _ = False
 
 -- | A mapping from 'HSE.KnownExtension' values to their
 -- 'GHC.LanguageExtensions.Type.Extension' equivalents.
-hseToGhcExtension :: Data.Map.Strict.Map HSE.KnownExtension Extension
+hseToGhcExtension :: Map.Map HSE.KnownExtension Extension
 hseToGhcExtension =
-  Data.Map.Strict.fromList
-    [ (HSE.OverlappingInstances, OverlappingInstances)
-    , (HSE.UndecidableInstances, UndecidableInstances)
-    , (HSE.IncoherentInstances, IncoherentInstances)
-    , (HSE.InstanceSigs, InstanceSigs)
-    , (HSE.RecursiveDo, RecursiveDo)
-    , (HSE.ParallelListComp, ParallelListComp)
-    , (HSE.MultiParamTypeClasses, MultiParamTypeClasses)
-    , (HSE.MonomorphismRestriction, MonomorphismRestriction)
-    , (HSE.FunctionalDependencies, FunctionalDependencies)
-    , (HSE.RankNTypes, RankNTypes)
-    , (HSE.ExistentialQuantification, ExistentialQuantification)
-    , (HSE.ScopedTypeVariables, ScopedTypeVariables)
-    , (HSE.ImplicitParams, ImplicitParams)
-    , (HSE.FlexibleContexts, FlexibleContexts)
-    , (HSE.FlexibleInstances, FlexibleInstances)
-    , (HSE.EmptyDataDecls, EmptyDataDecls)
-    , (HSE.KindSignatures, KindSignatures)
-    , (HSE.BangPatterns, BangPatterns)
-    , (HSE.TypeSynonymInstances, TypeSynonymInstances)
-    , (HSE.TemplateHaskell, TemplateHaskell)
-    , (HSE.ForeignFunctionInterface, ForeignFunctionInterface)
-    , (HSE.Arrows, Arrows)
-    , (HSE.ImplicitPrelude, ImplicitPrelude)
-    , (HSE.PatternGuards, PatternGuards)
-    , (HSE.GeneralizedNewtypeDeriving, GeneralizedNewtypeDeriving)
-    , (HSE.DeriveAnyClass, DeriveAnyClass)
-    , (HSE.MagicHash, MagicHash)
-    , (HSE.BinaryLiterals, BinaryLiterals)
-    , (HSE.TypeFamilies, TypeFamilies)
-    , (HSE.StandaloneDeriving, StandaloneDeriving)
-    , (HSE.UnicodeSyntax, UnicodeSyntax)
-    , (HSE.UnliftedFFITypes, UnliftedFFITypes)
-    , (HSE.LiberalTypeSynonyms, LiberalTypeSynonyms)
-    , (HSE.TypeOperators, TypeOperators)
-    , (HSE.ParallelArrays, ParallelArrays)
-    , (HSE.RecordWildCards, RecordWildCards)
-    , (HSE.RecordPuns, RecordPuns)
-    , (HSE.DisambiguateRecordFields, DisambiguateRecordFields)
-    , (HSE.OverloadedStrings, OverloadedStrings)
-    , (HSE.GADTs, GADTs)
-    , (HSE.MonoPatBinds, MonoPatBinds)
-    , (HSE.RelaxedPolyRec, RelaxedPolyRec)
-    , (HSE.ExtendedDefaultRules, ExtendedDefaultRules)
-    , (HSE.UnboxedTuples, UnboxedTuples)
-    , (HSE.DeriveDataTypeable, DeriveDataTypeable)
-    , (HSE.ConstrainedClassMethods, ConstrainedClassMethods)
-    , (HSE.PackageImports, PackageImports)
-    , (HSE.LambdaCase, LambdaCase)
-    , (HSE.EmptyCase, EmptyCase)
-    , (HSE.ImpredicativeTypes, ImpredicativeTypes)
-    , (HSE.PostfixOperators, PostfixOperators)
-    , (HSE.QuasiQuotes, QuasiQuotes)
-    , (HSE.TransformListComp, TransformListComp)
-    , (HSE.ViewPatterns, ViewPatterns)
-    , (HSE.TupleSections, TupleSections)
-    , (HSE.GHCForeignImportPrim, GHCForeignImportPrim)
-    , (HSE.NPlusKPatterns, NPlusKPatterns)
-    , (HSE.DoAndIfThenElse, DoAndIfThenElse)
-    , (HSE.RebindableSyntax, RebindableSyntax)
-    , (HSE.ExplicitForAll, ExplicitForAll)
-    , (HSE.DatatypeContexts, DatatypeContexts)
-    , (HSE.MonoLocalBinds, MonoLocalBinds)
-    , (HSE.DeriveFunctor, DeriveFunctor)
-    , (HSE.DeriveGeneric, DeriveGeneric)
-    , (HSE.DeriveTraversable, DeriveTraversable)
-    , (HSE.DeriveFoldable, DeriveFoldable)
-    , (HSE.NondecreasingIndentation, NondecreasingIndentation)
-    , (HSE.InterruptibleFFI, InterruptibleFFI)
-    , (HSE.CApiFFI, CApiFFI)
-    , (HSE.JavaScriptFFI, JavaScriptFFI)
-    , (HSE.ExplicitNamespaces, ExplicitNamespaces)
-    , (HSE.DataKinds, DataKinds)
-    , (HSE.PolyKinds, PolyKinds)
-    , (HSE.MultiWayIf, MultiWayIf)
-    , (HSE.DefaultSignatures, DefaultSignatures)
-    , (HSE.ConstraintKinds, ConstraintKinds)
-    , (HSE.RoleAnnotations, RoleAnnotations)
-    , (HSE.PatternSynonyms, PatternSynonyms)
-    , (HSE.PartialTypeSignatures, PartialTypeSignatures)
-    , (HSE.TypeApplications, TypeApplications)
-    , (HSE.TypeFamilyDependencies, TypeFamilyDependencies)
-    , (HSE.OverloadedLabels, OverloadedLabels)
-    , (HSE.DerivingStrategies, DerivingStrategies)
-    , (HSE.UnboxedSums, UnboxedSums)
-    , (HSE.TypeInType, TypeInType)
-    , (HSE.Strict, Strict)
-    , (HSE.StrictData, StrictData)
-    , (HSE.DerivingVia, DerivingVia)
-
-    -- These HSE "known extensions" don't appear to have GHC
-    -- analogues.
-
-    -- , (HSE.DoRec, DoRec)
-    -- , (HSE.Rank2Types, Rank2Types)
-    -- , (HSE.PolymorphicComponents, PolymorphicComponents)
-    -- , (HSE.PatternSignatures, PatternSignatures)
-    -- , (HSE.CPP, CPP)
-    -- , (HSE.Generics, Generics)
-    -- , (HSE.NamedFieldPuns, NamedFieldPuns)
-    -- , (HSE.ExtensibleRecords, ExtensibleRecords)
-    -- , (HSE.RestrictedTypeSynonyms, RestrictedTypeSynonyms)
-    -- , (HSE.HereDocuments, HereDocuments)
-    -- , (HSE.NewQualifiedOperators, NewQualifiedOperators)
-    -- , (HSE.XmlSyntax, XmlSyntax)
-    -- , (HSE.RegularPatterns, RegularPatterns)
-    -- , (HSE.SafeImports, SafeImports)
-    -- , (HSE.Safe, Safe)
-    -- , (HSE.Trustworthy, Trustworthy)
-    -- , (HSE.NamedWildCards, NamedWiledCards)
-    ]
+  let ghcExts = Map.fromList [(show x, x) | x <- [Cpp .. StarIsType]]
+  in
+    Map.fromList [ (x, ext) | x <- [minBound .. maxBound]
+                 , Just ext <- [Map.lookup (show x) ghcExts] ]

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module GHC.Util (
     baseDynFlags
@@ -99,9 +98,7 @@ parsePragmasIntoDynFlags flags (enable, disable) filepath str =
   catchErrors $ do
     let opts = getOptions flags (stringToStringBuffer str) filepath
     (flags, _, _) <- parseDynamicFilePragma flags opts
-    -- Explicit enable extensions
     let flags' =  foldl' xopt_set flags enable
-    -- Explicit disable extensions
     let flags'' = foldl' xopt_unset flags' disable
     return $ Right flags''
   where

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -255,9 +255,6 @@ parseModuleEx flags file str = timedIO "Parse" file $ do
                     | otherwise -> readFileUTF8' file
         str <- return $ fromMaybe str $ stripPrefix "\65279" str -- remove the BOM if it exists, see #130
         ppstr <- runCpp (cppFlags flags) file str
-        -- Pull out langexts passed by config or command line to
-        -- explicitly enable/disable
-        -- (see https://github.com/ndmitchell/hlint/issues/681).
         let enableDisableExts = ghcExtensionsFromParseFlags flags
         dynFlags <- parsePragmasIntoDynFlags baseDynFlags enableDisableExts file ppstr
         case dynFlags of


### PR DESCRIPTION
This PR adjusts GHC `DynFlags` to account for language extensions explicitly enabled/disabled (via config. file or command line). This fixes issue https://github.com/ndmitchell/hlint/issues/681.