### PR TITLE
Harvest annotations from parse state

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -4,4 +4,4 @@
 
 - message:
   - name: Weeds exported
-  - module: [HSE.Util, GHC.Util]
+  - module: [HSE.All, HSE.Util, GHC.Util]

--- a/src/Config/Compute.hs
+++ b/src/Config/Compute.hs
@@ -18,7 +18,7 @@ computeSettings flags file = do
     case x of
         Left (ParseError sl msg _) ->
             return ("# Parse error " ++ showSrcLoc sl ++ ": " ++ msg, [])
-        Right (ModuleEx m _ _) -> do
+        Right (ModuleEx m _ _ _) -> do
             let xs = concatMap (findSetting $ UnQual an) (moduleDecls m)
                 r = concatMap (readSetting mempty) xs
                 s = unlines $ ["# hints found in " ++ file] ++ concatMap renderSetting r ++ ["# no hints found" | null xs]

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -31,7 +31,7 @@ readFileConfigHaskell file contents = do
     case res of
         Left (ParseError sl msg err) ->
             error $ "Config parse failure at " ++ showSrcLoc sl ++ ": " ++ msg ++ "\n" ++ err
-        Right (ModuleEx m cs _) -> return $ readSettings m ++ map SettingClassify (concatMap readComment cs)
+        Right (ModuleEx m cs _ _) -> return $ readSettings m ++ map SettingClassify (concatMap readComment cs)
 
 
 -- | Given a module containing HLint settings information return the 'Classify' rules and the 'HintRule' expressions.

--- a/src/Hint/Export.hs
+++ b/src/Hint/Export.hs
@@ -16,7 +16,7 @@ import Hint.Type
 
 
 exportHint :: ModuHint
-exportHint _ (ModuleEx (Module _ (Just o@(ModuleHead a name warning exports)) _ _ _) _ _)
+exportHint _ (ModuleEx (Module _ (Just o@(ModuleHead a name warning exports)) _ _ _) _ _ _)
     | Nothing <- exports =
         let o2 = ModuleHead a name warning $ Just $ ExportSpecList a [EModuleContents a name]
         in [(ignore "Use module export list" o o2 []){ideaNote = [Note "an explicit list is usually better"]}]


### PR DESCRIPTION
This PR adds two things : (1) a utility for converting GHC source spans into HSE ones (expect that to be useful when populating `Idea` values) and (2) we harvest annotations from the GHC parse state (it's not clear yet if such annotations are going to be required or not but at least now they'll be available in the event they are).