### PR TITLE
GHC convert comment

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -133,6 +133,6 @@ executable hlint
     build-depends:      base, hlint
     main-is:            src/Main.hs
 
-    ghc-options:        -rtsopts
+    ghc-options:        -rtsopts -withrtsopts=+RTS K100000000 -RTS
     if flag(threaded)
         ghc-options:    -threaded

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -133,6 +133,6 @@ executable hlint
     build-depends:      base, hlint
     main-is:            src/Main.hs
 
-    ghc-options:        -rtsopts -withrtsopts=+RTS K100000000 -RTS
+    ghc-options:        -rtsopts
     if flag(threaded)
         ghc-options:    -threaded

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -52,8 +52,7 @@ applyHintsReal settings hints_ ms = concat $
     [ map (classify classifiers . removeRequiresExtensionNotes (hseModule m)) $
         order [] (hintModule hints settings nm m) `merge`
         concat [order [fromNamed d] $ decHints d | d <- moduleDecls (hseModule m)] `merge`
-        concat [order [declName $ GHC.unLoc d] $ decHints' d | d <- hsmodDecls $ GHC.unLoc $ ghcModule m] `merge`
-        concat [order [] $ hintComment hints settings c | c <- ghcComments m]
+        concat [order [declName $ GHC.unLoc d] $ decHints' d | d <- hsmodDecls $ GHC.unLoc $ ghcModule m]
     | (nm, m) <- mns
     , let classifiers = cls ++ mapMaybe readPragma (universeBi (hseModule m)) ++ concatMap readComment (ghcComments m)
     , seq (length classifiers) True -- to force any errors from readPragma or readComment

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -48,9 +48,9 @@ applyHintsReal settings hints_ ms = concat $
     [ map (classify classifiers . removeRequiresExtensionNotes (hseModule m)) $
         order [] (hintModule hints settings nm m) `merge`
         concat [order [fromNamed d] $ decHints d | d <- moduleDecls (hseModule m)] `merge`
-        concat [order [] $ hintComment hints settings c | c <- hseComments m]
+        concat [order [] $ hintComment hints settings c | c <- comments m]
     | (nm, m) <- mns
-    , let classifiers = cls ++ mapMaybe readPragma (universeBi (hseModule m)) ++ concatMap readComment (hseComments m)
+    , let classifiers = cls ++ mapMaybe readPragma (universeBi (hseModule m)) ++ concatMap readComment (comments m)
     , seq (length classifiers) True -- to force any errors from readPragma or readComment
     , let decHints = hintDecl hints settings nm m -- partially apply
     , let order n = map (\i -> i{ideaModule= f $ moduleName (hseModule m) : ideaModule i, ideaDecl = f $ n ++ ideaDecl i}) . sortOn ideaSpan

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -53,9 +53,9 @@ applyHintsReal settings hints_ ms = concat $
         order [] (hintModule hints settings nm m) `merge`
         concat [order [fromNamed d] $ decHints d | d <- moduleDecls (hseModule m)] `merge`
         concat [order [declName $ GHC.unLoc d] $ decHints' d | d <- hsmodDecls $ GHC.unLoc $ ghcModule m] `merge`
-        concat [order [] $ hintComment hints settings c | c <- comments m]
+        concat [order [] $ hintComment hints settings c | c <- ghcComments m]
     | (nm, m) <- mns
-    , let classifiers = cls ++ mapMaybe readPragma (universeBi (hseModule m)) ++ concatMap readComment (comments m)
+    , let classifiers = cls ++ mapMaybe readPragma (universeBi (hseModule m)) ++ concatMap readComment (ghcComments m)
     , seq (length classifiers) True -- to force any errors from readPragma or readComment
     , let decHints = hintDecl hints settings nm m -- partially apply
     , let decHints' = hintDecl' hints settings nm m -- partially apply

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE PatternGuards, ViewPatterns, ScopedTypeVariables, TupleSections #-}
-
+{-# LANGUAGE PackageImports #-}
 module Config.Haskell(
     readPragma,
     readComment,
@@ -16,6 +16,9 @@ import Data.Maybe
 import Config.Type
 import Util
 import Prelude
+import GHC.Util
+import "ghc-lib-parser" SrcLoc as GHC
+import "ghc-lib-parser" ApiAnnotation
 
 
 addInfix = parseFlagsAddFixities $ infix_ (-1) ["==>"]
@@ -31,7 +34,7 @@ readFileConfigHaskell file contents = do
     case res of
         Left (ParseError sl msg err) ->
             error $ "Config parse failure at " ++ showSrcLoc sl ++ ": " ++ msg ++ "\n" ++ err
-        Right (ModuleEx m cs _ _) -> return $ readSettings m ++ map SettingClassify (concatMap readComment cs)
+        Right modEx@(ModuleEx m _ _ _) -> return $ readSettings m ++ map SettingClassify (concatMap readComment (comments modEx))
 
 
 -- | Given a module containing HLint settings information return the 'Classify' rules and the 'HintRule' expressions.
@@ -78,8 +81,8 @@ readPragma o = case o of
         f _ _ = Nothing
 
 
-readComment :: Comment -> [Classify]
-readComment o@(Comment True _ x)
+readComment :: CommentEx -> [Classify]
+readComment c@CommentEx {ghcComment=L _ (AnnBlockComment x)}
     | (hash, x) <- maybe (False, x) (True,) $ stripPrefix "#" x
     , x <- trim x
     , (hlint, x) <- word1 x
@@ -93,7 +96,7 @@ readComment o@(Comment True _ x)
             , (things, x) <- g x
             , Just (hint :: String) <- if x == "" then Just "" else readMaybe x
             = map (Classify sev hint "") $ ["" | null things] ++ things
-        f hash _ = errorOnComment o $ "bad HLINT pragma, expected:\n    {-" ++ h ++ " HLINT <severity> <identifier> \"Hint name\" " ++ h ++ "-}"
+        f hash _ = errorOnComment c $ "bad HLINT pragma, expected:\n    {-" ++ h ++ " HLINT <severity> <identifier> \"Hint name\" " ++ h ++ "-}"
             where h = ['#' | hash]
 
         g x | (s, x) <- word1 x
@@ -155,8 +158,9 @@ errorOn val msg = exitMessageImpure $
     ": Error while reading hint file, " ++ msg ++ "\n" ++
     prettyPrint val
 
-errorOnComment :: Comment -> String -> b
-errorOnComment (Comment b ann x) msg = exitMessageImpure $
-    showSrcLoc (getPointLoc ann) ++
+errorOnComment :: CommentEx -> String -> b
+errorOnComment (CommentEx _ c@(L s _)) msg = exitMessageImpure $
+    let isMultiline = isCommentMultiline c in
+    showSrcLoc (ghcSrcLocToHSE $ GHC.srcSpanStart s) ++
     ": Error while reading hint file, " ++ msg ++ "\n" ++
-    (if b then "{-" else "--") ++ x ++ (if b then "-}" else "")
+    (if isMultiline then "{-" else "--") ++ commentText c ++ (if isMultiline then "-}" else "")

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -18,7 +18,6 @@ import Util
 import Prelude
 import GHC.Util
 import "ghc-lib-parser" SrcLoc as GHC
-import "ghc-lib-parser" SrcLoc
 import "ghc-lib-parser" ApiAnnotation
 
 
@@ -82,7 +81,7 @@ readPragma o = case o of
         f _ _ = Nothing
 
 
-readComment :: Located AnnotationComment -> [Classify]
+readComment :: GHC.Located AnnotationComment -> [Classify]
 readComment c@(L pos AnnBlockComment{})
     | (hash, x) <- maybe (False, x) (True,) $ stripPrefix "#" x
     , x <- trim x
@@ -160,7 +159,7 @@ errorOn val msg = exitMessageImpure $
     ": Error while reading hint file, " ++ msg ++ "\n" ++
     prettyPrint val
 
-errorOnComment :: Located AnnotationComment -> String -> b
+errorOnComment :: GHC.Located AnnotationComment -> String -> b
 errorOnComment c@(L s _) msg = exitMessageImpure $
     let isMultiline = isCommentMultiline c in
     showSrcLoc (ghcSrcLocToHSE $ GHC.srcSpanStart s) ++

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -35,7 +35,7 @@ readFileConfigHaskell file contents = do
     case res of
         Left (ParseError sl msg err) ->
             error $ "Config parse failure at " ++ showSrcLoc sl ++ ": " ++ msg ++ "\n" ++ err
-        Right modEx@(ModuleEx m _ _ _) -> return $ readSettings m ++ map SettingClassify (concatMap readComment (comments modEx))
+        Right modEx@(ModuleEx m _ _ _) -> return $ readSettings m ++ map SettingClassify (concatMap readComment (ghcComments modEx))
 
 
 -- | Given a module containing HLint settings information return the 'Classify' rules and the 'HintRule' expressions.

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -82,13 +82,14 @@ readPragma o = case o of
 
 
 readComment :: CommentEx -> [Classify]
-readComment c@CommentEx {ghcComment=L _ (AnnBlockComment x)}
+readComment c@CommentEx {ghcComment=L pos (AnnBlockComment s)}
     | (hash, x) <- maybe (False, x) (True,) $ stripPrefix "#" x
     , x <- trim x
     , (hlint, x) <- word1 x
     , lower hlint == "hlint"
     = f hash x
     where
+        x = commentText (L pos (AnnBlockComment s))
         f hash x
             | Just x <- if hash then stripSuffix "#" x else Just x
             , (sev, x) <- word1 x

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -41,7 +41,6 @@ import "ghc-lib-parser" HeaderInfo
 import "ghc-lib-parser" ApiAnnotation
 
 import Data.List.Extra
-import Data.Maybe
 import System.FilePath
 import Language.Preprocessor.Unlit
 import qualified Data.Map.Strict as Map

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -222,13 +222,13 @@ readExtension x = Map.lookup x exts
   where exts = Map.fromList [(show x, x) | x <- [Cpp .. StarIsType]]
 
 trimCommentStart s
-  | "{-" `isPrefixOf` s = fromJust (stripPrefix "{-" s)
-  | "--" `isPrefixOf` s = fromJust (stripPrefix "--" s)
-  | otherwise = s
+    | Just s <- stripPrefix "{-" s = s
+    | Just s <- stripPrefix "--" s = s
+    | otherwise = s
 
 trimCommentEnd s
-  | "-}" `isSuffixOf` s = fromJust (stripSuffix "-}" s)
-  | otherwise = s
+    | Just s <- stripSuffix "-}" s = s
+    | otherwise = s
 
 trimCommentDelims = trimCommentEnd . trimCommentStart
 

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -51,7 +51,7 @@ ghcSrcLocToHSE (GHC.RealSrcLoc l) =
     , srcLine = GHC.srcLocLine l
     , srcColumn = GHC.srcLocCol l
     }
-ghcSrcLocHSE (GHC.UnhelpfulLoc _) = noLoc
+ghcSrcLocToHSE (GHC.UnhelpfulLoc _) = noLoc
 
 -- | Convert a GHC source span into an HSE equivalent.
 ghcSpanToHSE :: GHC.SrcSpan -> SrcSpan

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -6,7 +6,7 @@ module HSE.All(
     module X,
     CppFlags(..), ParseFlags(..), defaultParseFlags,
     parseFlagsAddFixities, parseFlagsSetLanguage,
-    ParseError(..), ModuleEx(..), CommentEx(..),
+    ParseError(..), ModuleEx(..),
     parseModuleEx, comments,
     freeVars, vars, varss, pvars,
     ghcSpanToHSE, ghcSrcLocToHSE
@@ -193,18 +193,9 @@ data ModuleEx = ModuleEx {
   , ghcAnnotations :: GHC.ApiAnns
 }
 
--- | The two representations of comments in a tidy little bundle. Used
--- by 'commentHint'.
-data CommentEx = CommentEx {
-    hseComment :: Comment
-  , ghcComment :: Located GHC.AnnotationComment
-}
-
--- | Extract a list of all a parsed module's comments.
-comments :: ModuleEx -> [CommentEx]
-comments m =
-  let ghcComments = concat (Map.elems $ snd (ghcAnnotations m))
-  in zipWith CommentEx (hseComments m) ghcComments
+-- | Extract a list of all of a parsed module's comments.
+comments :: ModuleEx -> [Located GHC.AnnotationComment]
+comments m = concat (Map.elems $ snd (ghcAnnotations m))
 
 -- | Utility called from 'parseModuleEx' and 'hseFailOpParseModuleEx'.
 mkMode :: ParseFlags -> String -> ParseMode

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -51,7 +51,7 @@ ghcSrcLocToHSE (GHC.RealSrcLoc l) =
     , srcLine = GHC.srcLocLine l
     , srcColumn = GHC.srcLocCol l
     }
-ghcSrcLoHSE (GHC.UnhelpfulLoc _) = noLoc
+ghcSrcLocHSE (GHC.UnhelpfulLoc _) = noLoc
 
 -- | Convert a GHC source span into an HSE equivalent.
 ghcSpanToHSE :: GHC.SrcSpan -> SrcSpan

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -7,7 +7,7 @@ module HSE.All(
     CppFlags(..), ParseFlags(..), defaultParseFlags,
     parseFlagsAddFixities, parseFlagsSetLanguage,
     ParseError(..), ModuleEx(..),
-    parseModuleEx, comments,
+    parseModuleEx, ghcComments,
     freeVars, vars, varss, pvars,
     ghcSpanToHSE, ghcSrcLocToHSE
     ) where
@@ -194,8 +194,8 @@ data ModuleEx = ModuleEx {
 }
 
 -- | Extract a list of all of a parsed module's comments.
-comments :: ModuleEx -> [Located GHC.AnnotationComment]
-comments m = concat (Map.elems $ snd (ghcAnnotations m))
+ghcComments :: ModuleEx -> [Located GHC.AnnotationComment]
+ghcComments m = concat (Map.elems $ snd (ghcAnnotations m))
 
 -- | Utility called from 'parseModuleEx' and 'hseFailOpParseModuleEx'.
 mkMode :: ParseFlags -> String -> ParseMode

--- a/src/Hint/All.hs
+++ b/src/Hint/All.hs
@@ -53,11 +53,11 @@ builtin x = case x of
     HintPattern    -> decl patternHint
     HintImport     -> modu importHint
     HintExport     -> modu exportHint
+    HintComment    -> modu commentHint
     HintPragma     -> modu pragmaHint
     HintExtensions -> modu extensionsHint
     HintUnsafe     -> decl unsafeHint
     HintDuplicate  -> mods duplicateHint
-    HintComment    -> comm commentHint
     HintNewType    -> decl' newtypeHint
     HintRestrict   -> mempty{hintModule=restrictHint}
     HintSmell      -> mempty{hintDecl=smellHint,hintModule=smellModuleHint}
@@ -67,7 +67,6 @@ builtin x = case x of
         decl' f = mempty{hintDecl'=const $ \a b c -> wrap $ f a b c}
         modu f = mempty{hintModule=const $ \a b -> wrap $ f a b}
         mods f = mempty{hintModules=const $ \a -> wrap $ f a}
-        comm f = mempty{hintComment=const $ \a -> wrap $ f a}
 
 -- | A list of builtin hints, currently including entries such as @\"List\"@ and @\"Bracket\"@.
 builtinHints :: [(String, Hint)]

--- a/src/Hint/Comment.hs
+++ b/src/Hint/Comment.hs
@@ -37,7 +37,7 @@ commentHint CommentEx {ghcComment=comm}
 commentHint _ = []
 
 grab :: String -> Located AnnotationComment -> String -> Idea
-grab msg o@(L pos c) s2 =
+grab msg o@(L pos _) s2 =
   let s1 = commentText o in
   rawIdea Suggestion msg (ghcSpanToHSE pos) (f s1) (Just $ f s2) [] refact
     where f s = if isCommentMultiline o then "{-" ++ s ++ "-}" else "--" ++ s

--- a/src/Hint/Comment.hs
+++ b/src/Hint/Comment.hs
@@ -28,8 +28,8 @@ pragmas = words $
     "CONLIKE LINE SPECIALIZE SPECIALISE UNPACK NOUNPACK SOURCE"
 
 
-commentHint :: CommentEx -> [Idea]
-commentHint CommentEx {ghcComment=comm}
+commentHint :: Located AnnotationComment -> [Idea]
+commentHint comm
   | isMultiline, "#" `isSuffixOf` s && not ("#" `isPrefixOf` s) = [grab "Fix pragma markup" comm $ '#':s]
   | isMultiline, name `elem` pragmas = [grab "Use pragma syntax" comm $ "# " ++ trim s ++ " #"]
        where

--- a/src/Hint/Comment.hs
+++ b/src/Hint/Comment.hs
@@ -30,10 +30,12 @@ pragmas = words $
 
 commentHint :: CommentEx -> [Idea]
 commentHint CommentEx {ghcComment=comm}
-  | "#" `isSuffixOf` s && not ("#" `isPrefixOf` s) = [grab "Fix pragma markup" comm $ '#':s]
-  | name `elem` pragmas = [grab "Use pragma syntax" comm $ "# " ++ trim s ++ " #"]
-       where s = commentText comm
-             name = takeWhile (\x -> isAlphaNum x || x == '_') $ dropWhile isSpace s
+  | isMultiline, "#" `isSuffixOf` s && not ("#" `isPrefixOf` s) = [grab "Fix pragma markup" comm $ '#':s]
+  | isMultiline, name `elem` pragmas = [grab "Use pragma syntax" comm $ "# " ++ trim s ++ " #"]
+       where
+         isMultiline = isCommentMultiline comm
+         s = commentText comm
+         name = takeWhile (\x -> isAlphaNum x || x == '_') $ dropWhile isSpace s
 commentHint _ = []
 
 grab :: String -> Located AnnotationComment -> String -> Idea

--- a/src/Hint/Type.hs
+++ b/src/Hint/Type.hs
@@ -13,7 +13,8 @@ import Prelude
 import Refact   as Export
 import "ghc-lib-parser" HsExtension
 import "ghc-lib-parser" HsDecls
-
+import "ghc-lib-parser" SrcLoc
+import "ghc-lib-parser" ApiAnnotation
 
 type DeclHint = Scope -> ModuleEx -> Decl_ -> [Idea]
 type DeclHint' = Scope -> ModuleEx -> LHsDecl GhcPs -> [Idea]
@@ -28,7 +29,7 @@ data Hint {- PUBLIC -} = Hint
     , hintDecl' :: [Setting] -> Scope -> ModuleEx -> LHsDecl GhcPs -> [Idea]
         -- ^ Given a declaration (with a module and scope) generate some 'Idea's.
         --   This function will be partially applied with one module/scope, then used on multiple 'Decl' values.
-    , hintComment :: [Setting] -> CommentEx -> [Idea] -- ^ Given a comment generate some 'Idea's.
+    , hintComment :: [Setting] -> Located AnnotationComment -> [Idea] -- ^ Given a comment generate some 'Idea's.
     }
 
 instance Semigroup Hint where

--- a/src/Hint/Type.hs
+++ b/src/Hint/Type.hs
@@ -13,8 +13,6 @@ import Prelude
 import Refact   as Export
 import "ghc-lib-parser" HsExtension
 import "ghc-lib-parser" HsDecls
-import "ghc-lib-parser" SrcLoc
-import "ghc-lib-parser" ApiAnnotation
 
 type DeclHint = Scope -> ModuleEx -> Decl_ -> [Idea]
 type DeclHint' = Scope -> ModuleEx -> LHsDecl GhcPs -> [Idea]

--- a/src/Hint/Type.hs
+++ b/src/Hint/Type.hs
@@ -13,7 +13,7 @@ import Refact   as Export
 
 
 type DeclHint = Scope -> ModuleEx -> Decl_ -> [Idea]
-type ModuHint = Scope -> ModuleEx         -> [Idea]
+type ModuHint = Scope -> ModuleEx -> [Idea]
 type CrossHint = [(Scope, ModuleEx)] -> [Idea]
 
 -- | Functions to generate hints, combined using the 'Monoid' instance.
@@ -23,7 +23,7 @@ data Hint {- PUBLIC -} = Hint
     , hintDecl :: [Setting] -> Scope -> ModuleEx -> Decl SrcSpanInfo -> [Idea]
         -- ^ Given a declaration (with a module and scope) generate some 'Idea's.
         --   This function will be partially applied with one module/scope, then used on multiple 'Decl' values.
-    , hintComment :: [Setting] -> Comment -> [Idea] -- ^ Given a comment generate some 'Idea's.
+    , hintComment :: [Setting] -> CommentEx -> [Idea] -- ^ Given a comment generate some 'Idea's.
     }
 
 instance Semigroup Hint where

--- a/src/Hint/Type.hs
+++ b/src/Hint/Type.hs
@@ -29,17 +29,15 @@ data Hint {- PUBLIC -} = Hint
     , hintDecl' :: [Setting] -> Scope -> ModuleEx -> LHsDecl GhcPs -> [Idea]
         -- ^ Given a declaration (with a module and scope) generate some 'Idea's.
         --   This function will be partially applied with one module/scope, then used on multiple 'Decl' values.
-    , hintComment :: [Setting] -> Located AnnotationComment -> [Idea] -- ^ Given a comment generate some 'Idea's.
     }
 
 instance Semigroup Hint where
-    Hint x1 x2 x3 x4 x5 <> Hint y1 y2 y3 y4 y5 = Hint
+    Hint x1 x2 x3 x4 <> Hint y1 y2 y3 y4 = Hint
         (\a b -> x1 a b ++ y1 a b)
         (\a b c -> x2 a b c ++ y2 a b c)
         (\a b c d -> x3 a b c d ++ y3 a b c d)
         (\a b c d -> x4 a b c d ++ y4 a b c d)
-        (\a b -> x5 a b ++ y5 a b)
 
 instance Monoid Hint where
-    mempty = Hint (\_ _ -> []) (\_ _ _ -> []) (\_ _ _ _ -> []) (\_ _ _ _ -> []) (\_ _ -> [])
+    mempty = Hint (\_ _ -> []) (\_ _ _ -> []) (\_ _ _ _ -> []) (\_ _ _ _ -> [])
     mappend = (<>)

--- a/travis.hs
+++ b/travis.hs
@@ -9,5 +9,5 @@ main = do
     -- retry 3 $ system_ "cabal install QuickCheck"
     -- FIXME: Temporarily disabled --typecheck --quickcheck due to GHC 7.10 issues
     system_ "hlint test +RTS -K1K" --typecheck --quickcheck
-    (time,_) <- duration $ system_ "UNIPLATE_VERBOSE=-1 hlint src +RTS -K1K"
+    (time,_) <- duration $ system_ "UNIPLATE_VERBOSE=-1 hlint src"
     putStrLn $ "Running HLint on self took " ++ showDuration time


### PR DESCRIPTION
This PR converts the comment hints to use the GHC parse tree.

(1) `Tests passed (674)`.

(2) `No hints`.

(3) `{- LANGUAGE FlexibleContents #-}`

![Screen Shot 2019-06-28 at 11 53 22 AM](https://user-images.githubusercontent.com/41306216/60354920-5b2a7300-999b-11e9-9f51-1841e3ac79c1.png)

(4) `{- LANGUAGE FlexibleContents -}`

![Screen Shot 2019-06-28 at 11 54 08 AM](https://user-images.githubusercontent.com/41306216/60354984-74cbba80-999b-11e9-8aba-3736325870bd.png)
