### PR TITLE
Convert Naming.hs to ghc-lib-parser

### DIFF
--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -234,5 +234,9 @@ declName (ForD _ ForeignImport{fd_name}) = occNameString $ occName $ unLoc fd_na
 declName (ForD _ ForeignExport{fd_name}) = occNameString $ occName $ unLoc fd_name
 declName _ = ""
 
+-- \"Unsafely\" in this case means that it uses the following 'DynFlags' for printing -
+-- <http://hackage.haskell.org/package/ghc-lib-parser-8.8.0.20190424/docs/src/DynFlags.html#v_unsafeGlobalDynFlags unsafeGlobalDynFlags>
+-- This could lead to the issues documented there, but it also might not be a problem for our use case.
+-- TODO: Decide whether this really is unsafe, and if it is, what needs to be done to make it safe.
 unsafePrettyPrint :: (Outputable.Outputable a) => a -> String
 unsafePrettyPrint = Outputable.showSDocUnsafe . Outputable.ppr

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -13,6 +13,7 @@ module GHC.Util (
   , Located
   , readExtension
   , declName
+  , unsafePrettyPrint
   -- Temporary : Export these so GHC doesn't consider them unused and
   -- tell weeder to ignore them.
   , isAtom, addParen, paren, isApp, isOpApp, isAnyApp, isDot, isSection, isDotApp
@@ -232,3 +233,6 @@ declName (SigD _ (ClassOpSig _ _ (x:_) _)) = occNameString $ occName $ unLoc x
 declName (ForD _ ForeignImport{fd_name}) = occNameString $ occName $ unLoc fd_name
 declName (ForD _ ForeignExport{fd_name}) = occNameString $ occName $ unLoc fd_name
 declName _ = ""
+
+unsafePrettyPrint :: (Outputable.Outputable a) => a -> String
+unsafePrettyPrint = Outputable.showSDocUnsafe . Outputable.ppr

--- a/src/Hint/All.hs
+++ b/src/Hint/All.hs
@@ -49,7 +49,7 @@ builtin x = case x of
     HintMonad      -> decl monadHint
     HintLambda     -> decl lambdaHint
     HintBracket    -> decl bracketHint
-    HintNaming     -> decl namingHint
+    HintNaming     -> decl' namingHint
     HintPattern    -> decl patternHint
     HintImport     -> modu importHint
     HintExport     -> modu exportHint

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -143,7 +143,7 @@ suggestName x
 
 replaceNamesNew :: Data a => [(String, String)] -> a -> a
 replaceNamesNew rep = transformBi replace
-    where 
+    where
         replace :: Hs.RdrName -> Hs.RdrName
         replace (Hs.Unqual (Hs.unsafePrettyPrint -> name)) = Hs.Unqual $ Hs.mkOccName Hs.srcDataName $ fromMaybe name $ lookup name rep
         replace x = x

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -84,10 +84,11 @@ naming seen x = [suggest "Use camelCase" x' x2' [Replace Bind (toSS x) [] (prett
           x' = shorten x
           x2' = shorten x2
 
--- TODO: shorten pattern names
 shortenNew :: Hs.LHsDecl Hs.GhcPs -> Hs.LHsDecl Hs.GhcPs
 shortenNew (Hs.L locDecl (Hs.ValD ttg0 bind@(Hs.FunBind _ _ matchGroup@(Hs.MG _ (Hs.L locMatches matches) _) _ _))) =
     Hs.L locDecl (Hs.ValD ttg0 bind {Hs.fun_matches = matchGroup {Hs.mg_alts = Hs.L locMatches $ map shortenMatch matches}})
+shortenNew (Hs.L locDecl (Hs.ValD ttg0 bind@(Hs.PatBind _ _ grhss@(Hs.GRHSs _ rhss _) _))) =
+    Hs.L locDecl (Hs.ValD ttg0 bind {Hs.pat_rhs = grhss {Hs.grhssGRHSs = map shortenLGRHS rhss}})
 shortenNew x = x
 
 shortenMatch :: Hs.LMatch Hs.GhcPs (Hs.LHsExpr Hs.GhcPs) -> Hs.LMatch Hs.GhcPs (Hs.LHsExpr Hs.GhcPs)

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -21,6 +21,7 @@ data No = a :::: b
 data Yes = Foo {bar_cap :: Int}
 data No = FOO | BarBAR | BarBBar
 yes_foo = yes_foo + yes_foo -- yesFoo = ...
+yes_fooPattern Nothing = 0 -- yesFooPattern Nothing = ...
 no = 1 where yes_foo = 2
 a -== b = 1
 myTest = 1; my_test = 1

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -55,7 +55,6 @@ import "ghc-lib-parser" HsDecls
 import "ghc-lib-parser" HsExtension
 import "ghc-lib-parser" HsSyn
 import "ghc-lib-parser" OccName
-import "ghc-lib-parser" RdrName
 import "ghc-lib-parser" SrcLoc
 
 namingHint :: DeclHint'

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -93,6 +93,7 @@ shorten x = case x of
         f cont (UnGuardedRhs _ _) = cont (UnGuardedRhs an dots) Nothing
         f cont (GuardedRhss _ _) = cont (GuardedRhss an [GuardedRhs an [Qualifier an dots] dots]) Nothing
 
+-- TODO: get constructor names
 getNamesNew :: Hs.LHsDecl Hs.GhcPs -> [String]
 getNamesNew = pure . Hs.declName . Hs.unLoc
 

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -127,6 +127,5 @@ suggestName original
 replaceNames :: Data a => [(String, String)] -> a -> a
 replaceNames rep = transformBi replace
     where
-        replace :: RdrName -> RdrName
-        replace (Unqual (unsafePrettyPrint -> name)) = Unqual $ mkOccName srcDataName $ fromMaybe name $ lookup name rep
-        replace x = x
+        replace :: OccName -> OccName
+        replace (unsafePrettyPrint -> name) = mkOccName srcDataName $ fromMaybe name $ lookup name rep

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PackageImports #-}
 {-
     Suggest the use of camelCase
 
@@ -45,9 +46,16 @@ import Data.Maybe
 import Refact.Types hiding (RType(Match))
 import qualified Data.Set as Set
 
+import qualified "ghc-lib-parser" HsDecls as Hs
+import qualified "ghc-lib-parser" HsExtension as Hs
+import qualified "ghc-lib-parser" HsSyn as Hs
+import qualified "ghc-lib-parser" SrcLoc as Hs
 
-namingHint :: DeclHint
-namingHint _ modu = naming $ Set.fromList $ concatMap getNames $ moduleDecls (hseModule modu)
+namingHint :: DeclHint'
+namingHint _ modu = namingNew $ Set.fromList $ concatMap getNamesNew $ Hs.hsmodDecls $ Hs.unLoc (ghcModule modu)
+
+namingNew :: Set.Set String -> Hs.LHsDecl Hs.GhcPs -> [Idea]
+namingNew _ _ = []
 
 naming :: Set.Set String -> Decl_ -> [Idea]
 naming seen x = [suggest "Use camelCase" x' x2' [Replace Bind (toSS x) [] (prettyPrint x2)] | not $ null res]
@@ -67,6 +75,8 @@ shorten x = case x of
         f cont (UnGuardedRhs _ _) = cont (UnGuardedRhs an dots) Nothing
         f cont (GuardedRhss _ _) = cont (GuardedRhss an [GuardedRhs an [Qualifier an dots] dots]) Nothing
 
+getNamesNew :: Hs.LHsDecl Hs.GhcPs -> [String]
+getNamesNew _ = []
 
 getNames :: Decl_ -> [String]
 getNames x = case x of

--- a/src/Idea.hs
+++ b/src/Idea.hs
@@ -3,7 +3,7 @@
 
 module Idea(
     Idea(..),
-    rawIdea, idea, idea', suggest, warn, ignore, ignore',
+    rawIdea, idea, idea', suggest, suggest', warn, ignore, ignore',
     rawIdeaN, suggestN, suggestN', ignoreN, ignoreNoSuggestion',
     showIdeasJson, showANSI,
     Note(..), showNotes,
@@ -93,6 +93,10 @@ idea' severity hint from to =
   rawIdea severity hint (ghcSpanToHSE (GHC.getLoc from)) (unsafePrettyPrint from) (Just $ unsafePrettyPrint to) []
 
 suggest = idea Suggestion
+suggest' :: (GHC.HasSrcSpan a, Outputable.Outputable a)
+         => String -> a -> a -> [Refactoring R.SrcSpan] -> Idea
+suggest' = idea' Suggestion
+
 warn = idea Warning
 
 ignoreNoSuggestion' :: (GHC.HasSrcSpan a, Outputable.Outputable a)

--- a/src/Idea.hs
+++ b/src/Idea.hs
@@ -20,6 +20,7 @@ import qualified Refact.Types as R
 import Prelude
 import qualified "ghc-lib-parser" SrcLoc as GHC
 import qualified "ghc-lib-parser" Outputable
+import qualified GHC.Util as GHC
 
 -- | An idea suggest by a 'Hint'.
 data Idea = Idea
@@ -90,7 +91,7 @@ idea severity hint from to = rawIdea severity hint (srcInfoSpan $ ann from) (f f
 idea' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
          Severity -> String -> a -> a -> [Refactoring R.SrcSpan] -> Idea
 idea' severity hint from to =
-  rawIdea severity hint (ghcSpanToHSE (GHC.getLoc from)) (unsafePrettyPrint from) (Just $ unsafePrettyPrint to) []
+  rawIdea severity hint (ghcSpanToHSE (GHC.getLoc from)) (GHC.unsafePrettyPrint from) (Just $ GHC.unsafePrettyPrint to) []
 
 suggest = idea Suggestion
 suggest' :: (GHC.HasSrcSpan a, Outputable.Outputable a)
@@ -101,7 +102,7 @@ warn = idea Warning
 
 ignoreNoSuggestion' :: (GHC.HasSrcSpan a, Outputable.Outputable a)
                     => String -> a -> Idea
-ignoreNoSuggestion' hint x = rawIdeaN Ignore hint (ghcSpanToHSE (GHC.getLoc x)) (unsafePrettyPrint x) Nothing []
+ignoreNoSuggestion' hint x = rawIdeaN Ignore hint (ghcSpanToHSE (GHC.getLoc x)) (GHC.unsafePrettyPrint x) Nothing []
 
 ignore = idea Ignore
 ignore' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
@@ -118,6 +119,3 @@ suggestN' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
              String -> a -> a -> Idea
 suggestN' = ideaN' Suggestion
 ignoreN = ideaN Ignore
-
-unsafePrettyPrint :: (Outputable.Outputable a) => a -> String
-unsafePrettyPrint = Outputable.showSDocUnsafe . Outputable.ppr

--- a/src/Refact.hs
+++ b/src/Refact.hs
@@ -1,7 +1,14 @@
-module Refact(toRefactSrcSpan, toSS) where
+{-# LANGUAGE PackageImports #-}
+module Refact
+    ( toRefactSrcSpan
+    , toSS
+    , toSrcSpan'
+    ) where
 
 import qualified Refact.Types as R
 import HSE.All
+
+import qualified "ghc-lib-parser" SrcLoc as Hs
 
 toRefactSrcSpan :: SrcSpan -> R.SrcSpan
 toRefactSrcSpan ss = R.SrcSpan (srcSpanStartLine ss)
@@ -11,3 +18,15 @@ toRefactSrcSpan ss = R.SrcSpan (srcSpanStartLine ss)
 
 toSS :: Annotated a => a S -> R.SrcSpan
 toSS = toRefactSrcSpan . srcInfoSpan . ann
+
+toSrcSpan' :: Hs.HasSrcSpan a => a -> R.SrcSpan
+toSrcSpan' x =
+    R.SrcSpan (Hs.srcSpanStartLine span)
+              (Hs.srcSpanStartCol span)
+              (Hs.srcSpanEndLine span)
+              (Hs.srcSpanEndCol span)
+    where
+        span :: Hs.RealSrcSpan
+        span = case Hs.getLoc x of
+                 Hs.RealSrcSpan s -> s
+                 _ -> error "Got a bad ghc SrcSpan! Report a bug to hlint please!"

--- a/src/Refact.hs
+++ b/src/Refact.hs
@@ -19,14 +19,14 @@ toRefactSrcSpan ss = R.SrcSpan (srcSpanStartLine ss)
 toSS :: Annotated a => a S -> R.SrcSpan
 toSS = toRefactSrcSpan . srcInfoSpan . ann
 
+-- | Don't crash in case ghc gives us a \"fake\" span,
+-- opting instead to show @0 0 0 0@ coordinates.
 toSrcSpan' :: Hs.HasSrcSpan a => a -> R.SrcSpan
-toSrcSpan' x =
-    R.SrcSpan (Hs.srcSpanStartLine span)
-              (Hs.srcSpanStartCol span)
-              (Hs.srcSpanEndLine span)
-              (Hs.srcSpanEndCol span)
-    where
-        span :: Hs.RealSrcSpan
-        span = case Hs.getLoc x of
-                 Hs.RealSrcSpan s -> s
-                 _ -> error "Got a bad ghc SrcSpan! Report a bug to hlint please!"
+toSrcSpan' x = case Hs.getLoc x of
+    Hs.RealSrcSpan span ->
+        R.SrcSpan (Hs.srcSpanStartLine span)
+                  (Hs.srcSpanStartCol span)
+                  (Hs.srcSpanEndLine span)
+                  (Hs.srcSpanEndCol span)
+    Hs.UnhelpfulSpan _ ->
+        R.SrcSpan 0 0 0 0


### PR DESCRIPTION

Things still left to do:

* [x] Implement shorten
* [x] Fix `replaceNames` (`uniplate` stuff) - currently stuck on this one, don't know how I can perform transformations on `ghc` identifiers, would love a pointer/guidance on how to do this
* [x] Clean the qualified imports up
* [ ] Fix the `uniplate` errors with more verbosity (kind of lost on this one)