### PR TITLE
Convert import hints to ghc-lib-parser

### DIFF
--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -266,6 +266,13 @@ declName (ForD _ ForeignImport{fd_name}) = occNameString $ occName $ unLoc fd_na
 declName (ForD _ ForeignExport{fd_name}) = occNameString $ occName $ unLoc fd_name
 declName _ = ""
 
+-- \"Unsafely\" in this case means that it uses the following
+-- 'DynFlags' for printing -
+-- <http://hackage.haskell.org/package/ghc-lib-parser-8.8.0.20190424/docs/src/DynFlags.html#v_unsafeGlobalDynFlags
+-- unsafeGlobalDynFlags> This could lead to the issues documented
+-- there, but it also might not be a problem for our use case.  TODO:
+-- Decide whether this really is unsafe, and if it is, what needs to
+-- be done to make it safe.
 unsafePrettyPrint :: (Outputable.Outputable a) => a -> String
 unsafePrettyPrint = Outputable.showSDocUnsafe . Outputable.ppr
 

--- a/src/Idea.hs
+++ b/src/Idea.hs
@@ -3,11 +3,11 @@
 
 module Idea(
     Idea(..),
-    rawIdea, idea, idea', suggest, suggest', warn, ignore, ignore',
+    rawIdea, idea, idea', suggest, suggest', warn, warn',ignore, ignore',
     rawIdeaN, suggestN, suggestN', ignoreN, ignoreNoSuggestion',
     showIdeasJson, showANSI,
     Note(..), showNotes,
-    Severity(..)
+    Severity(..),
     ) where
 
 import Data.Functor
@@ -82,9 +82,13 @@ showEx tt Idea{..} = unlines $
             where xs = lines $ tt x
 
 
+rawIdea :: Severity -> String -> SrcSpan -> String -> Maybe String -> [Note]-> [Refactoring R.SrcSpan] -> Idea
 rawIdea = Idea [] []
+rawIdeaN :: Severity -> String -> SrcSpan -> String -> Maybe String -> [Note] -> Idea
 rawIdeaN a b c d e f = Idea [] [] a b c d e f []
 
+idea :: (Annotated ast, Pretty a, Pretty (ast SrcSpanInfo)) =>
+        Severity -> String -> ast SrcSpanInfo -> a -> [Refactoring R.SrcSpan] -> Idea
 idea severity hint from to = rawIdea severity hint (srcInfoSpan $ ann from) (f from) (Just $ f to) []
     where f = trimStart . prettyPrint
 
@@ -93,29 +97,50 @@ idea' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
 idea' severity hint from to =
   rawIdea severity hint (ghcSpanToHSE (GHC.getLoc from)) (GHC.unsafePrettyPrint from) (Just $ GHC.unsafePrettyPrint to) []
 
+suggest :: (Annotated ast, Pretty a, Pretty (ast SrcSpanInfo)) =>
+           String -> ast SrcSpanInfo -> a -> [Refactoring R.SrcSpan] -> Idea
 suggest = idea Suggestion
-suggest' :: (GHC.HasSrcSpan a, Outputable.Outputable a)
-         => String -> a -> a -> [Refactoring R.SrcSpan] -> Idea
+
+suggest' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
+            String -> a -> a -> [Refactoring R.SrcSpan] -> Idea
 suggest' = idea' Suggestion
 
+warn :: (Annotated ast, Pretty a, Pretty (ast SrcSpanInfo)) =>
+        String -> ast SrcSpanInfo -> a -> [Refactoring R.SrcSpan] -> Idea
 warn = idea Warning
+
+warn' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
+         String -> a -> a -> [Refactoring R.SrcSpan] -> Idea
+warn' = idea' Warning
 
 ignoreNoSuggestion' :: (GHC.HasSrcSpan a, Outputable.Outputable a)
                     => String -> a -> Idea
 ignoreNoSuggestion' hint x = rawIdeaN Ignore hint (ghcSpanToHSE (GHC.getLoc x)) (GHC.unsafePrettyPrint x) Nothing []
 
+ignore :: (Annotated ast, Pretty a, Pretty (ast SrcSpanInfo)) =>
+          String -> ast SrcSpanInfo -> a -> [Refactoring R.SrcSpan] -> Idea
 ignore = idea Ignore
+
 ignore' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
            String -> a -> a -> [Refactoring R.SrcSpan] -> Idea
 ignore' = idea' Ignore
 
+ideaN :: (Annotated ast, Pretty a, Pretty (ast SrcSpanInfo)) =>
+         Severity -> String -> ast SrcSpanInfo -> a -> Idea
 ideaN severity hint from to = idea severity hint from to []
+
 ideaN' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
           Severity -> String -> a -> a -> Idea
 ideaN' severity hint from to = idea' severity hint from to []
 
+suggestN :: (Annotated ast, Pretty a, Pretty (ast SrcSpanInfo)) =>
+            String -> ast SrcSpanInfo -> a -> Idea
 suggestN = ideaN Suggestion
+
 suggestN' :: (GHC.HasSrcSpan a, Outputable.Outputable a) =>
              String -> a -> a -> Idea
 suggestN' = ideaN' Suggestion
+
+ignoreN :: (Annotated ast, Pretty a, Pretty (ast SrcSpanInfo)) =>
+           String -> ast SrcSpanInfo -> a -> Idea
 ignoreN = ideaN Ignore

--- a/src/Refact.hs
+++ b/src/Refact.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE PackageImports #-}
 module Refact
     ( toRefactSrcSpan
-    , toSS
+    , toSS, toSS'
     , toSrcSpan'
     ) where
 
 import qualified Refact.Types as R
 import HSE.All
 
-import qualified "ghc-lib-parser" SrcLoc as Hs
+import qualified "ghc-lib-parser" SrcLoc as GHC
 
 toRefactSrcSpan :: SrcSpan -> R.SrcSpan
 toRefactSrcSpan ss = R.SrcSpan (srcSpanStartLine ss)
@@ -21,12 +21,15 @@ toSS = toRefactSrcSpan . srcInfoSpan . ann
 
 -- | Don't crash in case ghc gives us a \"fake\" span,
 -- opting instead to show @0 0 0 0@ coordinates.
-toSrcSpan' :: Hs.HasSrcSpan a => a -> R.SrcSpan
-toSrcSpan' x = case Hs.getLoc x of
-    Hs.RealSrcSpan span ->
-        R.SrcSpan (Hs.srcSpanStartLine span)
-                  (Hs.srcSpanStartCol span)
-                  (Hs.srcSpanEndLine span)
-                  (Hs.srcSpanEndCol span)
-    Hs.UnhelpfulSpan _ ->
+toSrcSpan' :: GHC.HasSrcSpan a => a -> R.SrcSpan
+toSrcSpan' x = case GHC.getLoc x of
+    GHC.RealSrcSpan span ->
+        R.SrcSpan (GHC.srcSpanStartLine span)
+                  (GHC.srcSpanStartCol span)
+                  (GHC.srcSpanEndLine span)
+                  (GHC.srcSpanEndCol span)
+    GHC.UnhelpfulSpan _ ->
         R.SrcSpan 0 0 0 0
+
+toSS' :: GHC.Located e -> R.SrcSpan
+toSS' = toRefactSrcSpan . ghcSpanToHSE . GHC.getLoc


### PR DESCRIPTION
This PR rewrites the import module hints in terms of the GHC parse tree.