### PR TITLE
Upgrade to ghc-lib-parser-8.8.0.20190723 (8.8.1-rc1)

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -60,7 +60,7 @@ library
         extra >= 1.6.6,
         refact >= 0.3,
         aeson >= 1.1.2.0,
-        ghc-lib-parser == 8.8.0.20190424
+        ghc-lib-parser == 8.8.0.20190723
 
     if flag(gpl)
         build-depends: hscolour >= 1.21


### PR DESCRIPTION
Upgrade to the `ghc-lib-parser` 8.8.1-rc1 release.
