### PR TITLE
README.md: TypeApplications disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ HLint can generate a lot of information, making it difficult to search for parti
 
 ### Language Extensions
 
-HLint enables most Haskell extensions, disabling only those which steal too much syntax (currently Arrows, TransformListComp, XmlSyntax and RegularPatterns). Individual extensions can be enabled or disabled with, for instance, `-XArrows`, or `-XNoMagicHash`. The flag `-XHaskell2010` selects Haskell 2010 compatibility. You can also pass them via `.hlint.yaml` file. For example: `- arguments: [-XQuasiQuotes]`.
+HLint enables most Haskell extensions, disabling only those which steal too much syntax (currently Arrows, RegularPatterns, TransformListComp, TypeApplications, and XmlSyntax). Individual extensions can be enabled or disabled with, for instance, `-XArrows`, or `-XNoMagicHash`. The flag `-XHaskell2010` selects Haskell 2010 compatibility. You can also pass them via `.hlint.yaml` file. For example: `- arguments: [-XQuasiQuotes]`.
 
 ### Emacs Integration
 


### PR DESCRIPTION
Update the list of language extensions to reflect that TypeApplications is disabled by default.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
