### PR TITLE
Expose 'readFilesConfig' and 'splitSettings' from HLint4

### DIFF
--- a/src/Language/Haskell/HLint4.hs
+++ b/src/Language/Haskell/HLint4.hs
@@ -19,7 +19,7 @@ module Language.Haskell.HLint4(
     -- * Settings
     Classify(..),
     getHLintDataDir, autoSettings, argsSettings,
-    findSettings, readSettingsFile,
+    findSettings, readSettingsFile, readFilesConfig, splitSettings,
     -- * Hints
     Hint, resolveHints,
     -- * Parse files


### PR DESCRIPTION
Exposing `readFilesConfig` and `splitSettings` helps us out in DAML land.
