### PR TITLE
Convert duplicates to ghc-lib

### DIFF
--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -52,7 +52,7 @@ applyHintsReal settings hints_ ms = concat $
     [ map (classify classifiers . removeRequiresExtensionNotes (hseModule m)) $
         order [] (hintModule hints settings nm m) `merge`
         concat [order [fromNamed d] $ decHints d | d <- moduleDecls (hseModule m)] `merge`
-        concat [order (maybeToList $ nameOfDecl $ GHC.unLoc d) $ decHints' d | d <- hsmodDecls $ GHC.unLoc $ ghcModule m]
+        concat [order (maybeToList $ declName $ GHC.unLoc d) $ decHints' d | d <- hsmodDecls $ GHC.unLoc $ ghcModule m]
     | (nm, m) <- mns
     , let classifiers = cls ++ mapMaybe readPragma (universeBi (hseModule m)) ++ concatMap readComment (ghcComments m)
     , seq (length classifiers) True -- to force any errors from readPragma or readComment

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -52,7 +52,7 @@ applyHintsReal settings hints_ ms = concat $
     [ map (classify classifiers . removeRequiresExtensionNotes (hseModule m)) $
         order [] (hintModule hints settings nm m) `merge`
         concat [order [fromNamed d] $ decHints d | d <- moduleDecls (hseModule m)] `merge`
-        concat [order [declName $ GHC.unLoc d] $ decHints' d | d <- hsmodDecls $ GHC.unLoc $ ghcModule m]
+        concat [order [nameOfDecl $ GHC.unLoc d] $ decHints' d | d <- hsmodDecls $ GHC.unLoc $ ghcModule m]
     | (nm, m) <- mns
     , let classifiers = cls ++ mapMaybe readPragma (universeBi (hseModule m)) ++ concatMap readComment (ghcComments m)
     , seq (length classifiers) True -- to force any errors from readPragma or readComment

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -21,6 +21,7 @@ import "ghc-lib-parser" SrcLoc as GHC
 import "ghc-lib-parser" ApiAnnotation
 
 
+addInfix :: ParseFlags -> ParseFlags
 addInfix = parseFlagsAddFixities $ infix_ (-1) ["==>"]
 
 

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -313,5 +313,5 @@ newtype W a = W a deriving Outputable -- Wrapper of terms.
 -- the term types themselves, leads to identical results.
 wToStr :: Outputable a => W a -> String
 wToStr (W e) = showPpr baseDynFlags e
-instance (Outputable a) => Eq (W a) where (==) a b = wToStr a == wToStr b
-instance (Outputable a) => Ord (W a) where compare = compare `on` wToStr
+instance Outputable a => Eq (W a) where (==) a b = wToStr a == wToStr b
+instance Outputable a => Ord (W a) where compare = compare `on` wToStr

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -247,6 +247,12 @@ isCommentMultiline :: Located AnnotationComment -> Bool
 isCommentMultiline (L _ (AnnBlockComment _)) = True
 isCommentMultiline _ = False
 
+-- | @declName x@ returns the \"new name\" that is created (for
+-- example a function declaration) by @x@.  If @x@ isn't a declaration
+-- that creates a new name (for example an instance declaration),
+-- 'Nothing' is returned instead.  This is useful because we don't
+-- want to tell users to rename binders that they aren't creating
+-- right now and therefore usually cannot change.
 declName :: HsDecl GhcPs -> Maybe String
 declName x = occNameString . occName <$> case x of
     TyClD _ FamDecl{tcdFam=FamilyDecl{fdLName}} -> Just $ unLoc fdLName

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TypeFamilies, NamedFieldPuns #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
 
 module GHC.Util (
@@ -299,13 +300,10 @@ getloc = getLoc
 noext :: NoExt
 noext = noExt
 
-newtype SrcSpanD = SrcSpanD SrcSpan -- SrcSpan, deriving `Default`.
+newtype SrcSpanD = SrcSpanD SrcSpan deriving (Outputable, Eq, Ord)
 instance Default SrcSpanD where def = SrcSpanD noSrcSpan
-instance Outputable SrcSpanD where ppr (SrcSpanD s) = ppr s
-instance Eq SrcSpanD where (==) (SrcSpanD a) (SrcSpanD b) = a == b
-instance Ord SrcSpanD where compare (SrcSpanD a) (SrcSpanD b) = compare a b
 
-newtype W a = W a -- Wrapper of terms.
+newtype W a = W a deriving Outputable -- Wrapper of terms.
 -- The issue is that at times, terms we work with in this program are
 -- not in `Eq` and `Ord` and we need them to be. This work-around
 -- resorts to implementing `Eq` and `Ord` for the these types via
@@ -315,6 +313,5 @@ newtype W a = W a -- Wrapper of terms.
 -- the term types themselves, leads to identical results.
 wToStr :: Outputable a => W a -> String
 wToStr (W e) = showPpr baseDynFlags e
-instance (Outputable a) => Outputable (W a) where ppr (W e) = ppr e
 instance (Outputable a) => Eq (W a) where (==) a b = wToStr a == wToStr b
 instance (Outputable a) => Ord (W a) where compare = compare `on` wToStr

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -13,7 +13,7 @@ module GHC.Util (
   , Located
   , readExtension
   , commentText, isCommentMultiline
-  , nameOfDecl, nameOfModule
+  , declName, modName
   , unsafePrettyPrint
   , eqMaybe
   , noloc, unloc, getloc, noext
@@ -246,8 +246,8 @@ isCommentMultiline :: Located AnnotationComment -> Bool
 isCommentMultiline (L _ (AnnBlockComment _)) = True
 isCommentMultiline _ = False
 
-nameOfDecl :: HsDecl GhcPs -> Maybe String
-nameOfDecl x = occNameString . occName <$> case x of
+declName :: HsDecl GhcPs -> Maybe String
+declName x = occNameString . occName <$> case x of
     TyClD _ FamDecl{tcdFam=FamilyDecl{fdLName}} -> Just $ unLoc fdLName
     TyClD _ SynDecl{tcdLName} -> Just $ unLoc tcdLName
     TyClD _ DataDecl{tcdLName} -> Just $ unLoc tcdLName
@@ -262,9 +262,9 @@ nameOfDecl x = occNameString . occName <$> case x of
     ForD _ ForeignExport{fd_name} -> Just $ unLoc fd_name
     _ -> Nothing
 
-nameOfModule :: HsModule GhcPs -> String
-nameOfModule HsModule {hsmodName=Nothing} = "Main"
-nameOfModule HsModule {hsmodName=Just (L _ n)} = moduleNameString n
+modName :: HsModule GhcPs -> String
+modName HsModule {hsmodName=Nothing} = "Main"
+modName HsModule {hsmodName=Just (L _ n)} = moduleNameString n
 
 -- \"Unsafely\" in this case means that it uses the following
 -- 'DynFlags' for printing -

--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -143,8 +143,15 @@ bracket isPartialAtom root = f Nothing
         g :: (Data (a S), ExactP a, Pretty (a S), Brackets (a S)) => a S -> [Idea]
         g o = concat [f (Just (i,o,gen)) x | (i,(x,gen)) <- zip [0..] $ holes o]
 
+bracketWarning :: (Pretty (a1 S), Pretty (a2 SrcSpanInfo),
+                    Data (a1 S), Annotated a2, Annotated a1) =>
+                  String -> a2 SrcSpanInfo -> a1 S -> Idea
 bracketWarning msg o x =
   suggest msg o x [Replace (findType x) (toSS o) [("x", toSS x)] "x"]
+
+bracketError :: (Pretty (a1 S), Pretty (a2 SrcSpanInfo),
+                  Data (a1 S), Annotated a2, Annotated a1) =>
+                String -> a2 SrcSpanInfo -> a1 S -> Idea
 bracketError msg o x =
   warn msg o x [Replace (findType x) (toSS o) [("x", toSS x)] "x"]
 

--- a/src/Hint/Comment.hs
+++ b/src/Hint/Comment.hs
@@ -23,6 +23,7 @@ import "ghc-lib-parser" SrcLoc
 import "ghc-lib-parser" ApiAnnotation
 import GHC.Util
 
+pragmas :: [String]
 pragmas = words $
     "LANGUAGE OPTIONS_GHC INCLUDE WARNING DEPRECATED MINIMAL INLINE NOINLINE INLINABLE " ++
     "CONLIKE LINE SPECIALIZE SPECIALISE UNPACK NOUNPACK SOURCE"

--- a/src/Hint/Duplicate.hs
+++ b/src/Hint/Duplicate.hs
@@ -86,17 +86,15 @@ add pos [] d = d
 add pos (v:vs) (Dupe p mp) = Dupe p $ Map.insertWith f v (add pos vs $ Dupe pos Map.empty) mp
     where f new = add pos vs
 
-
-duplicateOrdered :: (Ord pos, Default pos, Ord val) => Int -> [[(pos,val)]] -> [(pos,pos,[val])]
+duplicateOrdered :: forall pos val.
+  (Ord pos, Default pos, Ord val) => Int -> [[(pos,val)]] -> [(pos,pos,[val])]
 duplicateOrdered threshold xs = concat $ concat $ snd $ mapAccumL f (Dupe def Map.empty) xs
     where
-        f :: (Ord pos, Default pos, Ord val) =>
-               Dupe pos val -> [(pos, val)] -> (Dupe pos val, [[(pos, pos, [val])]])
+        f :: Dupe pos val -> [(pos, val)] -> (Dupe pos val, [[(pos, pos, [val])]])
         f d xs = second overlaps $ mapAccumL (g pos) d $ takeWhile ((>= threshold) . length) $ tails xs
             where pos = Map.fromList $ zip (map fst xs) [0..]
 
-        g :: (Ord pos, Default pos, Ord val) =>
-             Map.Map pos Int -> Dupe pos val -> [(pos, val)] -> (Dupe pos val, [(pos, pos, [val])])
+        g :: Map.Map pos Int -> Dupe pos val -> [(pos, val)] -> (Dupe pos val, [(pos, pos, [val])])
         g pos d xs = (d2, res)
             where
                 res = [(p,pme,take mx vs) | i >= threshold

--- a/src/Hint/Duplicate.hs
+++ b/src/Hint/Duplicate.hs
@@ -50,7 +50,7 @@ duplicateHint ms =
          , let y = bagToList b
          ]
     where
-      ds = [(nameOfModule m, fromMaybe "" (nameOfDecl d), d)
+      ds = [(modName m, fromMaybe "" (declName d), d)
            | ModuleEx _ _ (L _ m) _ <- map snd ms
            , d <- map unloc (hsmodDecls m)]
 

--- a/src/Hint/Duplicate.hs
+++ b/src/Hint/Duplicate.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE PatternGuards, ScopedTypeVariables #-}
+{-# LANGUAGE PackageImports #-}
 
 {-
 Find bindings within a let, and lists of statements
@@ -22,31 +23,49 @@ foo = a where {a = 1; b = 2; c = 3}; bar = a where {a = 1; b = 2; c = 3} -- ???
 module Hint.Duplicate(duplicateHint) where
 
 import Hint.Type
+import Data.Data
 import Data.Default
 import Data.Tuple.Extra
 import Data.List hiding (find)
 import qualified Data.Map as Map
 
+import "ghc-lib-parser" SrcLoc as GHC
+import "ghc-lib-parser" HsSyn
+import "ghc-lib-parser" Outputable
+import "ghc-lib-parser" Bag
+import GHC.Util
 
 duplicateHint :: CrossHint
 duplicateHint ms =
-    dupes [(m,d,y) | (m,d,x) <- ds, Do _ y :: Exp S <- universeBi x] ++
-    dupes [(m,d,y) | (m,d,x) <- ds, BDecls _ y :: Binds S <- universeBi x]
-    where ds = [(moduleName (hseModule m), fromNamed d, d) | m <- map snd ms, d <- moduleDecls (hseModule m)]
-
-
-dupes :: (Pretty (f SrcSpan), Annotated f, Ord (f ())) => [(String, String, [f S])] -> [Idea]
-dupes ys =
-    [(rawIdeaN
-        (if length xs >= 5 then Warning else Suggestion)
-        "Reduce duplication" p1
-        (unlines $ map (prettyPrint . fmap (const p1)) xs)
-        (Just $ "Combine with " ++ showSrcLoc (getPointLoc p2)) [])
-      {ideaModule = [m1,m2], ideaDecl = [d1,d2]}
-    | ((m1,d1,p1),(m2,d2,p2),xs) <- duplicateOrdered 3 $ map f ys]
+   -- Do expressions.
+   dupes [ (m, d, y)
+         | (m, d, x) <- ds
+         , HsDo _ _ (L _ y) :: HsExpr GhcPs <- universeBi x
+         ] ++
+  -- Bindings in a 'let' expression or a 'where' clause.
+   dupes [ (m, d, y)
+         | (m, d, x) <- ds
+         , HsValBinds _ (ValBinds _ b _ ) :: HsLocalBinds GhcPs <- universeBi x
+         , let y = bagToList b
+         ]
     where
-        f (m,d,xs) = [((m,d,srcInfoSpan $ ann x), dropAnn x) | x <- xs]
+      ds = [(nameOfModule m, nameOfDecl d, d)
+           | ModuleEx _ _ (L _ m) _ <- map snd ms
+           , d <- map unloc (hsmodDecls m)]
 
+dupes :: (Outputable e, Data e) => [(String, String, [Located e])] -> [Idea]
+dupes ys =
+    [(rawIdeaN'
+        (if length xs >= 5 then Hint.Type.Warning else Suggestion)
+        "Reduce duplication" p1
+        (unlines $ map unsafePrettyPrint xs)
+        (Just $ "Combine with " ++
+         showSrcLoc (ghcSrcLocToHSE (GHC.srcSpanStart p2))) []
+     ){ideaModule = [m1, m2], ideaDecl = [d1, d2]}
+    | ((m1, d1, SrcSpanD p1), (m2, d2, SrcSpanD p2), xs) <- duplicateOrdered 3 $ map f ys]
+    where
+      f (m, d, xs) =
+        [((m, d, SrcSpanD (getloc x)), W (transformBi (const GHC.noSrcSpan) (unloc x))) | x <- xs]
 
 ---------------------------------------------------------------------
 -- DUPLICATE FINDING
@@ -70,9 +89,13 @@ add pos (v:vs) (Dupe p mp) = Dupe p $ Map.insertWith f v (add pos vs $ Dupe pos 
 duplicateOrdered :: (Ord pos, Default pos, Ord val) => Int -> [[(pos,val)]] -> [(pos,pos,[val])]
 duplicateOrdered threshold xs = concat $ concat $ snd $ mapAccumL f (Dupe def Map.empty) xs
     where
+        f :: (Ord pos, Default pos, Ord val) =>
+               Dupe pos val -> [(pos, val)] -> (Dupe pos val, [[(pos, pos, [val])]])
         f d xs = second overlaps $ mapAccumL (g pos) d $ takeWhile ((>= threshold) . length) $ tails xs
             where pos = Map.fromList $ zip (map fst xs) [0..]
 
+        g :: (Ord pos, Default pos, Ord val) =>
+             Map.Map pos Int -> Dupe pos val -> [(pos, val)] -> (Dupe pos val, [(pos, pos, [val])])
         g pos d xs = (d2, res)
             where
                 res = [(p,pme,take mx vs) | i >= threshold

--- a/src/Hint/ListRec.hs
+++ b/src/Hint/ListRec.hs
@@ -51,6 +51,7 @@ listRecHint _ _ = concatMap f . universe
             return $ idea severity ("Use " ++ use) o y [Replace Decl (toSS o) [] (prettyPrint y)]
 
 
+recursiveStr :: String
 recursiveStr = "_recursive_"
 recursive = toNamed recursiveStr
 

--- a/src/Hint/Match.hs
+++ b/src/Hint/Match.hs
@@ -54,6 +54,7 @@ import Prelude
 import qualified Refact.Types as R
 
 
+fmapAn :: Exp b -> Exp SrcSpanInfo
 fmapAn = fmap (const an)
 
 

--- a/src/Hint/Monad.hs
+++ b/src/Hint/Monad.hs
@@ -64,7 +64,9 @@ import qualified Refact.Types as R
 import Prelude
 
 
+badFuncs :: [String]
 badFuncs = ["mapM","foldM","forM","replicateM","sequence","zipWithM","traverse","for","sequenceA"]
+unitFuncs :: [String]
 unitFuncs = ["when","unless","void"]
 
 
@@ -91,6 +93,7 @@ monadExp (fromNamed -> decl) (parent, x) = case x of
 
 
 -- Sometimes people write a * do a + b, to avoid brackets
+doOperator :: (Eq a, Num a) => Maybe (a, Exp S) -> Exp l -> Bool
 doOperator (Just (1, InfixApp _ _ op _)) InfixApp{} | not $ isDol op = True
 doOperator _ _ = False
 

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -102,7 +102,7 @@ shortenLGRHS x = x
 
 getNames :: LHsDecl GhcPs -> [String]
 
-getNames (L _ decl) = maybeToList (nameOfDecl decl) ++ getConstructorNames decl
+getNames (L _ decl) = maybeToList (declName decl) ++ getConstructorNames decl
 
 getConstructorNames :: HsDecl GhcPs -> [String]
 getConstructorNames (TyClD _ (DataDecl _ _ _ _ (HsDataDefn _ _ _ _ _ cons _))) =

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -101,7 +101,7 @@ shortenLGRHS (L locGRHS (GRHS ttg0 guards (L locExpr _))) =
 shortenLGRHS x = x
 
 getNames :: LHsDecl GhcPs -> [String]
-getNames (L _ decl) = declName decl : getConstructorNames decl
+getNames (L _ decl) = nameOfDecl decl : getConstructorNames decl
 
 getConstructorNames :: HsDecl GhcPs -> [String]
 getConstructorNames (TyClD _ (DataDecl _ _ _ _ (HsDataDefn _ _ _ _ _ cons _))) =

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -52,7 +52,10 @@ restrictions settings = Map.map f $ Map.fromListWith (++) [(restrictType x, [x])
         f rs = (all restrictDefault rs
                ,Map.fromListWith (<>) [(s, RestrictItem restrictAs restrictWithin) | Restrict{..} <- rs, s <- restrictName])
 
+ideaMayBreak :: Idea -> Idea
 ideaMayBreak w = w{ideaNote=[Note "may break the code"]}
+
+ideaNoTo :: Idea -> Idea
 ideaNoTo w = w{ideaTo=Nothing}
 
 within :: String -> String -> RestrictItem -> Bool

--- a/src/Idea.hs
+++ b/src/Idea.hs
@@ -4,7 +4,7 @@
 module Idea(
     Idea(..),
     rawIdea, idea, idea', suggest, suggest', warn, warn',ignore, ignore',
-    rawIdeaN, suggestN, suggestN', ignoreN, ignoreN', ignoreNoSuggestion',
+    rawIdeaN, rawIdeaN', suggestN, suggestN', ignoreN, ignoreN', ignoreNoSuggestion',
     showIdeasJson, showANSI,
     Note(..), showNotes,
     Severity(..),
@@ -84,8 +84,12 @@ showEx tt Idea{..} = unlines $
 
 rawIdea :: Severity -> String -> SrcSpan -> String -> Maybe String -> [Note]-> [Refactoring R.SrcSpan] -> Idea
 rawIdea = Idea [] []
+
 rawIdeaN :: Severity -> String -> SrcSpan -> String -> Maybe String -> [Note] -> Idea
 rawIdeaN a b c d e f = Idea [] [] a b c d e f []
+
+rawIdeaN' :: Severity -> String -> GHC.SrcSpan -> String -> Maybe String -> [Note] -> Idea
+rawIdeaN' a b c d e f = Idea [] [] a b (ghcSpanToHSE c) d e f []
 
 idea :: (Annotated ast, Pretty a, Pretty (ast SrcSpanInfo)) =>
         Severity -> String -> ast SrcSpanInfo -> a -> [Refactoring R.SrcSpan] -> Idea

--- a/src/Test/All.hs
+++ b/src/Test/All.hs
@@ -52,14 +52,16 @@ test CmdTest{..} main dataDir files = do
         wrap "Hint names" $ mapM_ (\x -> do progress; testNames $ snd x) testFiles
         wrap "Hint annotations" $ forM_ testFiles $ \(file,h) -> do progress; testAnnotations h file
         when cmdTypeCheck $ wrap "Hint typechecking" $
-            progress >> testTypeCheck cmdDataDir cmdTempDir [h | (file, h) <- testFiles, takeFileName file /= "Test.hs"]
+            progress >> testTypeCheck cmdDataDir cmdTempDir (hs testFiles)
         when cmdQuickCheck $ wrap "Hint QuickChecking" $
-            progress >> testQuickCheck cmdDataDir cmdTempDir [h | (file, h) <- testFiles, takeFileName file /= "Test.hs"]
+            progress >> testQuickCheck cmdDataDir cmdTempDir (hs testFiles)
 
         when (null files && not hasSrc) $ liftIO $ putStrLn "Warning, couldn't find source code, so non-hint tests skipped"
         getIdeas
     whenLoud $ mapM_ print ideas
     return failures
+    where
+      hs testFiles = [h | (file, h) <- testFiles, takeFileName file /= "Test.hs"]
 
 
 ---------------------------------------------------------------------

--- a/src/Test/All.hs
+++ b/src/Test/All.hs
@@ -51,17 +51,16 @@ test CmdTest{..} main dataDir files = do
 
         wrap "Hint names" $ mapM_ (\x -> do progress; testNames $ snd x) testFiles
         wrap "Hint annotations" $ forM_ testFiles $ \(file,h) -> do progress; testAnnotations h file
+        let hs = [h | (file, h) <- testFiles, takeFileName file /= "Test.hs"]
         when cmdTypeCheck $ wrap "Hint typechecking" $
-            progress >> testTypeCheck cmdDataDir cmdTempDir (hs testFiles)
+            progress >> testTypeCheck cmdDataDir cmdTempDir hs
         when cmdQuickCheck $ wrap "Hint QuickChecking" $
-            progress >> testQuickCheck cmdDataDir cmdTempDir (hs testFiles)
+            progress >> testQuickCheck cmdDataDir cmdTempDir hs
 
         when (null files && not hasSrc) $ liftIO $ putStrLn "Warning, couldn't find source code, so non-hint tests skipped"
         getIdeas
     whenLoud $ mapM_ print ideas
     return failures
-    where
-      hs testFiles = [h | (file, h) <- testFiles, takeFileName file /= "Test.hs"]
 
 
 ---------------------------------------------------------------------

--- a/src/Test/Annotations.hs
+++ b/src/Test/Annotations.hs
@@ -106,6 +106,7 @@ parseTestFile file =
         f _ [] = []
 
 
+parseTest :: String -> Int -> String -> [Setting] -> TestCase
 parseTest file i x = uncurry (TestCase (SrcLoc file i 0)) $ f x
     where
         f x | Just x <- stripPrefix "<COMMENT>" x = first ("--"++) $ f x

--- a/src/Test/Proof.hs
+++ b/src/Test/Proof.hs
@@ -59,6 +59,7 @@ proof reports hints thy = do
             where n = maximum $ map (length . fst) xs
 
 
+missingFuncs :: [(String, String)]
 missingFuncs = let a*b = [(b,a) | b <- words b] in concat
     ["IO" * "putChar putStr print putStrLn getLine getChar getContents hReady hPrint stdin"
     ,"Exit" * "exitSuccess"

--- a/src/Test/Translate.hs
+++ b/src/Test/Translate.hs
@@ -101,5 +101,6 @@ toQuickCheck hints =
         restrict _ v = toNamed v
 
 
+isRemovesError :: Note -> Bool
 isRemovesError RemovesError{} = True
 isRemovesError _ = False


### PR DESCRIPTION
Convert "Reduce duplication" hints to GHC. Also adds some more hitherto missing top-level sigs ~and performs one renaming `declName` => `nameOfDecl`~.