### PR TITLE
Convert 'Restrict.hs' to ghc-lib

### DIFF
--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE PackageImports #-}
 
 module Hint.Restrict(restrictHint) where
 
@@ -23,15 +24,25 @@ import Control.Applicative
 import Control.Monad
 import Prelude
 
+import "ghc-lib-parser" HsSyn
+import "ghc-lib-parser" RdrName
+import "ghc-lib-parser" ApiAnnotation
+import qualified "ghc-lib-parser" Module as GHC
+import qualified "ghc-lib-parser" HsImpExp as GHC
+import qualified "ghc-lib-parser" SrcLoc as GHC
+import GHC.Util
 
 -- FIXME: The settings should be partially applied, but that's hard to orchestrate right now
 restrictHint :: [Setting] -> ModuHint
 restrictHint settings scope m =
-        checkPragmas modu (modulePragmas (hseModule m)) restrict ++
-        maybe [] (checkImports modu $ moduleImports (hseModule m)) (Map.lookup RestrictModule restrict) ++
-        maybe [] (checkFunctions modu $ moduleDecls (hseModule m)) (Map.lookup RestrictFunction restrict)
+    let anns = ghcAnnotations m
+        opts = flags anns
+        exts = langExts anns in
+    checkPragmas modu opts exts restrict ++
+    maybe [] (checkImports modu $ hsmodImports (unloc (ghcModule m))) (Map.lookup RestrictModule restrict) ++
+    maybe [] (checkFunctions modu $ hsmodDecls (unloc (ghcModule m))) (Map.lookup RestrictFunction restrict)
     where
-        modu = moduleName (hseModule m)
+        modu = modName (unloc (ghcModule m))
         restrict = restrictions settings
 
 ---------------------------------------------------------------------
@@ -71,46 +82,42 @@ within modu func RestrictItem{..} = any (\(a,b) -> (a == modu || a == "") && (b 
 ---------------------------------------------------------------------
 -- CHECKS
 
-checkPragmas :: String -> [ModulePragma S] -> Map.Map RestrictType (Bool, Map.Map String RestrictItem) -> [Idea]
-checkPragmas modu xs mps = f RestrictFlag "flags" onFlags ++ f RestrictExtension "extensions" onExtensions
-    where
-        f tag name sel =
-            [ (if null good then ideaNoTo else id) $ notes $ warn ("Avoid restricted " ++ name) o (regen good) []
-            | Just (def, mp) <- [Map.lookup tag mps]
-            , o <- xs, Just (xs, regen) <- [sel o]
-            , let (good, bad) = partition (isGood def mp) xs
-            , let note = maybe noteMayBreak Note . (=<<) riMessage . flip Map.lookup mp
-            , let notes w = w{ideaNote=note <$> bad}
-            , not $ null bad]
+checkPragmas :: String
+              -> [(Located AnnotationComment, [String])]
+              -> [(Located AnnotationComment, [String])]
+              ->  Map.Map RestrictType (Bool, Map.Map String RestrictItem)
+              -> [Idea]
+checkPragmas modu flags exts mps =
+  f RestrictFlag "flags" flags ++ f RestrictExtension "extensions" exts
+  where
+   f tag name xs =
+     [(if null good then ideaNoTo else id) $ notes $ rawIdea Hint.Type.Warning ("Avoid restricted " ++ name) (ghcSpanToHSE l) c Nothing [] []
+     | Just (def, mp) <- [Map.lookup tag mps]
+     , (GHC.L l (AnnBlockComment c), les) <- xs
+     , let (good, bad) = partition (isGood def mp) les
+     , let note = maybe noteMayBreak Note . (=<<) riMessage . flip Map.lookup mp
+     , let notes w = w {ideaNote=note <$> bad}
+     , not $ null bad]
+   isGood def mp x = maybe def (within modu "") $ Map.lookup x mp
 
-        onFlags (OptionsPragma s t x) = Just (words x, OptionsPragma s t . unwords)
-        onFlags _ = Nothing
-
-        onExtensions (LanguagePragma s xs) = Just (map fromNamed xs, LanguagePragma (s :: S) . map toNamed)
-        onExtensions _ = Nothing
-
-        isGood def mp x = maybe def (within modu "") $ Map.lookup x mp
-
-
-checkImports :: String -> [ImportDecl S] -> (Bool, Map.Map String RestrictItem) -> [Idea]
+checkImports :: String -> [LImportDecl GhcPs] -> (Bool, Map.Map String RestrictItem) -> [Idea]
 checkImports modu imp (def, mp) =
     [ ideaMessage riMessage $ if not allowImport
-      then ideaNoTo $ warn "Avoid restricted module" i i []
-      else warn "Avoid restricted qualification" i i{importAs=ModuleName an <$> listToMaybe riAs} []
-    | i@ImportDecl{..} <- imp
-    , let ri@RestrictItem{..} = Map.findWithDefault (RestrictItem [] [("","") | def] Nothing) (fromModuleName importModule) mp
+      then ideaNoTo $ warn' "Avoid restricted module" i i []
+      else warn' "Avoid restricted qualification" i (noloc $ (unloc i){ideclAs=noloc . GHC.mkModuleName <$> listToMaybe riAs}) []
+    | i@(GHC.L _ GHC.ImportDecl {..}) <- imp
+    , let ri@RestrictItem{..} = Map.findWithDefault (RestrictItem [] [("","") | def] Nothing) (GHC.moduleNameString (unloc ideclName)) mp
     , let allowImport = within modu "" ri
-    , let allowQual = maybe True (\x -> null riAs || fromModuleName x `elem` riAs) importAs
+    , let allowQual = maybe True (\x -> null riAs || GHC.moduleNameString (unloc x) `elem` riAs) ideclAs
     , not allowImport || not allowQual
     ]
 
-
-checkFunctions :: String -> [Decl_] -> (Bool, Map.Map String RestrictItem) -> [Idea]
+checkFunctions :: String -> [LHsDecl GhcPs] -> (Bool, Map.Map String RestrictItem) -> [Idea]
 checkFunctions modu decls (def, mp) =
-    [ (ideaMessage riMessage $ ideaNoTo $ warn "Avoid restricted function" x x []){ideaDecl = [dname]}
+    [ (ideaMessage riMessage $ ideaNoTo $ warn' "Avoid restricted function" x x []){ideaDecl = [dname]}
     | d <- decls
-    , let dname = fromNamed d
-    , x <- universeBi d :: [QName S]
-    , let ri@RestrictItem{..} = Map.findWithDefault (RestrictItem [] [("","") | def] Nothing) (fromNamed x) mp
+    , let dname = fromMaybe "" (declName (unloc d))
+    , x <- universeBi d :: [Located RdrName]
+    , let ri@RestrictItem{..} = Map.findWithDefault (RestrictItem [] [("","") | def] Nothing) (rdrNameName (unloc x)) mp
     , not $ within modu dname ri
     ]


### PR DESCRIPTION
This PR converts `Restrict.hs` to operate on `ghc-lib-parser` parse trees. 