### PR TITLE
Convert pragma to ghc-lib-parser

### DIFF
--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -151,6 +151,7 @@ rhsSpans :: GHC.HsMatchContext RdrName -> GHC.LGRHS GhcPs (GHC.LHsExpr GhcPs) ->
 rhsSpans _ (GHC.L _ (GHC.GRHS _ _ (GHC.L _ GHC.RecordCon {}))) = [] -- record constructors get a pass
 rhsSpans ctx (GHC.L _ r@(GHC.GRHS _ _ (GHC.L l _))) =
   [(l, rawIdea Config.Type.Warning "Long function" (ghcSpanToHSE l) (showSDocUnsafe (GHC.pprGRHS ctx r)) Nothing [] [])]
+rhsSpans _  (GHC.L _ (GHC.XGRHS _)) = []
 
 -- The spans of a 'where' clause are the spans of its bindings.
 whereSpans :: GHC.LHsLocalBinds GhcPs -> [(GHC.SrcSpan, Idea)]

--- a/src/Idea.hs
+++ b/src/Idea.hs
@@ -3,7 +3,7 @@
 
 module Idea(
     Idea(..),
-    rawIdea, idea, idea', suggest, suggest', warn, warn',ignore, ignore',
+    rawIdea, rawIdea', idea, idea', suggest, suggest', warn, warn',ignore, ignore',
     rawIdeaN, rawIdeaN', suggestN, suggestN', ignoreN, ignoreN', ignoreNoSuggestion',
     showIdeasJson, showANSI,
     Note(..), showNotes,
@@ -84,6 +84,9 @@ showEx tt Idea{..} = unlines $
 
 rawIdea :: Severity -> String -> SrcSpan -> String -> Maybe String -> [Note]-> [Refactoring R.SrcSpan] -> Idea
 rawIdea = Idea [] []
+
+rawIdea' :: Severity -> String -> GHC.SrcSpan -> String -> Maybe String -> [Note]-> [Refactoring R.SrcSpan] -> Idea
+rawIdea' a b c = Idea [] [] a b (ghcSpanToHSE c)
 
 rawIdeaN :: Severity -> String -> SrcSpan -> String -> Maybe String -> [Note] -> Idea
 rawIdeaN a b c d e f = Idea [] [] a b c d e f []


### PR DESCRIPTION
This PR converts `Pragma.hs` to GHC parse trees. It is based off the `convert-restrict` branch which is under review in https://github.com/ndmitchell/hlint/pull/732. It needs to be rebased on `master` if/once `convert-restrict` is merged.