### PR TITLE
Update source location handling

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -15,7 +15,7 @@
   - name: [FlexibleContexts, FlexibleInstances]
   - name: [PackageImports]
   - {name: CPP, within: HsColour} # so it can be disabled to avoid GPL code
-  - {name: TypeFamilies, within: GHC.Util} # type family constraints here
+  - {name: TypeFamilies, within: [GHC.Util, Hint.Export, Hint.Restrict]} # type family constraints here
 
 - flags:
   - default: false

--- a/src/Hint/Comment.hs
+++ b/src/Hint/Comment.hs
@@ -11,6 +11,7 @@
 </TEST>
 -}
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ViewPatterns #-}
 
 
 module Hint.Comment(commentHint) where
@@ -43,8 +44,8 @@ commentHint _ m = concatMap chk (ghcComments m)
         chk _ = []
 
         grab :: String -> Located AnnotationComment -> String -> Idea
-        grab msg o@(L pos _) s2 =
+        grab msg o@(dL -> L pos _) s2 =
           let s1 = commentText o in
-          rawIdea Suggestion msg (ghcSpanToHSE pos) (f s1) (Just $ f s2) [] refact
+          rawIdea' Suggestion msg pos (f s1) (Just $ f s2) [] refact
             where f s = if isCommentMultiline o then "{-" ++ s ++ "-}" else "--" ++ s
                   refact = [ModifyComment (toRefactSrcSpan (ghcSpanToHSE pos)) (f s2)]

--- a/src/Hint/Duplicate.hs
+++ b/src/Hint/Duplicate.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE PatternGuards, ScopedTypeVariables #-}
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ViewPatterns#-}
 
 {-
 Find bindings within a let, and lists of statements
@@ -41,7 +42,7 @@ duplicateHint ms =
    -- Do expressions.
    dupes [ (m, d, y)
          | (m, d, x) <- ds
-         , HsDo _ _ (L _ y) :: HsExpr GhcPs <- universeBi x
+         , HsDo _ _ (dL -> L _ y) :: HsExpr GhcPs <- universeBi x
          ] ++
   -- Bindings in a 'let' expression or a 'where' clause.
    dupes [ (m, d, y)
@@ -51,7 +52,7 @@ duplicateHint ms =
          ]
     where
       ds = [(modName m, fromMaybe "" (declName d), d)
-           | ModuleEx _ _ (L _ m) _ <- map snd ms
+           | ModuleEx _ _ (dL -> L _ m) _ <- map snd ms
            , d <- map unloc (hsmodDecls m)]
 
 dupes :: (Outputable e, Data e) => [(String, String, [Located e])] -> [Idea]

--- a/src/Hint/Export.hs
+++ b/src/Hint/Export.hs
@@ -10,6 +10,8 @@ module Foo(module Foo, foo) where foo = 1 -- module Foo(..., foo) where
 </TEST>
 -}
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Hint.Export(exportHint) where
 
@@ -19,28 +21,29 @@ import qualified "ghc-lib-parser" Module as GHC
 import "ghc-lib-parser" SrcLoc as GHC
 import "ghc-lib-parser" OccName
 import "ghc-lib-parser" RdrName
+import GHC.Util
 
 exportHint :: ModuHint
-exportHint _ (ModuleEx _ _ (L s m@HsModule {hsmodName = Just name, hsmodExports = exports}) _)
+exportHint _ (ModuleEx _ _ (dL -> L s m@HsModule {hsmodName = Just name, hsmodExports = exports}) _)
   | Nothing <- exports =
-      let r = o{ hsmodExports = Just (GHC.noLoc [GHC.noLoc (IEModuleContents noExt name)] )} in
-      [(ignore' "Use module export list" (L s o) (GHC.noLoc r) []){ideaNote = [Note "an explicit list is usally better"]}]
-  | Just (L _ xs) <- exports
+      let r = o{ hsmodExports = Just (noloc [noloc (IEModuleContents noext name)] )} in
+      [(ignore' "Use module export list" (cL s o) (noloc r) []){ideaNote = [Note "an explicit list is usally better"]}]
+  | Just (dL -> L _ xs) <- exports
   , mods <- [x | x <- xs, isMod x]
-  , modName <- GHC.moduleNameString (GHC.unLoc name)
-  , names <- [GHC.moduleNameString (GHC.unLoc n) | (L _ (IEModuleContents _ n)) <- mods]
+  , modName <- GHC.moduleNameString (unloc name)
+  , names <- [GHC.moduleNameString (unloc n) | (dL -> L _ (IEModuleContents _ n)) <- mods]
   , exports' <- [x | x <- xs, not (matchesModName modName x)]
   , modName `elem` names =
       let dots = mkRdrUnqual (mkVarOcc " ... ")
-          r = o{ hsmodExports = Just (GHC.noLoc (GHC.noLoc (IEVar noExt (GHC.noLoc (IEName (GHC.noLoc dots)))) : exports') )}
+          r = o{ hsmodExports = Just (noloc (noloc (IEVar noext (noloc (IEName (noloc dots)))) : exports') )}
       in
-        [ignore' "Use explicit module export list" (L s o) (GHC.noLoc r) []]
+        [ignore' "Use explicit module export list" (cL s o) (noloc r) []]
       where
           o = m{hsmodImports=[], hsmodDecls=[], hsmodDeprecMessage=Nothing, hsmodHaddockModHeader=Nothing }
-          isMod (L _ (IEModuleContents _ _)) = True
+          isMod (dL -> L _ (IEModuleContents _ _)) = True
           isMod _ = False
 
-          matchesModName m (L _ (IEModuleContents _ (L _ n))) = GHC.moduleNameString n == m
+          matchesModName m (dL -> L _ (IEModuleContents _ (dL -> L _ n))) = GHC.moduleNameString n == m
           matchesModName _ _ = False
 
 exportHint _ _ = []

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -81,20 +81,20 @@ naming seen originalDecl =
         replacedDecl = replaceNames suggestedNames originalDecl
 
 shorten :: LHsDecl GhcPs -> LHsDecl GhcPs
-shorten (L locDecl (ValD ttg0 bind@(FunBind _ _ matchGroup@(MG _ (L locMatches matches) _) _ _))) =
-    L locDecl (ValD ttg0 bind {fun_matches = matchGroup {mg_alts = L locMatches $ map shortenMatch matches}})
-shorten (L locDecl (ValD ttg0 bind@(PatBind _ _ grhss@(GRHSs _ rhss _) _))) =
-    L locDecl (ValD ttg0 bind {pat_rhs = grhss {grhssGRHSs = map shortenLGRHS rhss}})
+shorten (dL -> L locDecl (ValD ttg0 bind@(FunBind _ _ matchGroup@(MG _ (dL -> L locMatches matches) _) _ _))) =
+    cL locDecl (ValD ttg0 bind {fun_matches = matchGroup {mg_alts = cL locMatches $ map shortenMatch matches}})
+shorten (dL -> L locDecl (ValD ttg0 bind@(PatBind _ _ grhss@(GRHSs _ rhss _) _))) =
+    cL locDecl (ValD ttg0 bind {pat_rhs = grhss {grhssGRHSs = map shortenLGRHS rhss}})
 shorten x = x
 
 shortenMatch :: LMatch GhcPs (LHsExpr GhcPs) -> LMatch GhcPs (LHsExpr GhcPs)
-shortenMatch (L locMatch match@(Match _ _ _ grhss@(GRHSs _ rhss _))) =
-    L locMatch match {m_grhss = grhss {grhssGRHSs = map shortenLGRHS rhss}}
+shortenMatch (dL -> L locMatch match@(Match _ _ _ grhss@(GRHSs _ rhss _))) =
+    cL locMatch match {m_grhss = grhss {grhssGRHSs = map shortenLGRHS rhss}}
 shortenMatch x = x
 
 shortenLGRHS :: LGRHS GhcPs (LHsExpr GhcPs) -> LGRHS GhcPs (LHsExpr GhcPs)
-shortenLGRHS (L locGRHS (GRHS ttg0 guards (L locExpr _))) =
-    L locGRHS (GRHS ttg0 guards (L locExpr dots))
+shortenLGRHS (dL -> L locGRHS (GRHS ttg0 guards (dL -> L locExpr _))) =
+    cL locGRHS (GRHS ttg0 guards (cL locExpr dots))
     where
         dots :: HsExpr GhcPs
         dots = HsLit NoExt (HsString (SourceText "...") (mkFastString "..."))
@@ -102,7 +102,7 @@ shortenLGRHS x = x
 
 getNames :: LHsDecl GhcPs -> [String]
 
-getNames (L _ decl) = maybeToList (declName decl) ++ getConstructorNames decl
+getNames (dL -> L _ decl) = maybeToList (declName decl) ++ getConstructorNames decl
 
 getConstructorNames :: HsDecl GhcPs -> [String]
 getConstructorNames (TyClD _ (DataDecl _ _ _ _ (HsDataDefn _ _ _ _ _ cons _))) =

--- a/src/Hint/NewType.hs
+++ b/src/Hint/NewType.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ViewPatterns #-}
 {-
     Suggest newtype instead of data for type declarations that have
     only one field. Don't suggest newtype for existentially
@@ -50,12 +51,12 @@ newtypeHintDecl old
 newtypeHintDecl _ = []
 
 newTypeDerivingStrategiesHintDecl :: LHsDecl GhcPs -> [Idea]
-newTypeDerivingStrategiesHintDecl decl@(L _ (TyClD _ (DataDecl _ _ _ _ dataDef))) =
+newTypeDerivingStrategiesHintDecl decl@(dL -> L _ (TyClD _ (DataDecl _ _ _ _ dataDef))) =
     [ignoreNoSuggestion' "Use DerivingStrategies" decl | not $ isData dataDef, not $ hasAllStrategies dataDef]
 newTypeDerivingStrategiesHintDecl _ = []
 
 hasAllStrategies :: HsDataDefn GhcPs -> Bool
-hasAllStrategies (HsDataDefn _ NewType _ _ _ _ (L _ xs)) = all hasStrategyClause xs
+hasAllStrategies (HsDataDefn _ NewType _ _ _ _ (dL -> L _ xs)) = all hasStrategyClause xs
 hasAllStrategies _ = False
 
 isData :: HsDataDefn GhcPs -> Bool
@@ -64,7 +65,7 @@ isData (HsDataDefn _ DataType _ _ _ _ _) = True
 isData _ = False
 
 hasStrategyClause :: LHsDerivingClause GhcPs -> Bool
-hasStrategyClause (L _ (HsDerivingClause _ (Just _) _)) = True
+hasStrategyClause (dL -> L _ (HsDerivingClause _ (Just _) _)) = True
 hasStrategyClause _ = False
 
 data WarnNewtype = WarnNewtype
@@ -80,12 +81,12 @@ data WarnNewtype = WarnNewtype
 -- * Single record field constructors get newtyped - @data X = X {getX :: Int}@ -> @newtype X = X {getX :: Int}@
 -- * All other declarations are ignored.
 singleSimpleField :: LHsDecl GhcPs -> Maybe WarnNewtype
-singleSimpleField (L loc (TyClD ext decl@(DataDecl _ _ _ _ dataDef@(HsDataDefn _ DataType _ _ _ [L _ constructor] _))))
+singleSimpleField (dL -> L loc (TyClD ext decl@(DataDecl _ _ _ _ dataDef@(HsDataDefn _ DataType _ _ _ [dL -> L _ constructor] _))))
     | Just inType <- simpleCons constructor =
         Just WarnNewtype
-              { newDecl = L loc $ TyClD ext decl {tcdDataDefn = dataDef
+              { newDecl = cL loc $ TyClD ext decl {tcdDataDefn = dataDef
                   { dd_ND = NewType
-                  , dd_cons = map (\(L consloc x) -> L consloc $ dropConsBang x) $ dd_cons dataDef
+                  , dd_cons = map (\(dL -> L consloc x) -> cL consloc $ dropConsBang x) $ dd_cons dataDef
                   }}
               , insideType = inType
               }
@@ -94,12 +95,12 @@ singleSimpleField _ = Nothing
 -- | Checks whether its argument is a \"simple constructor\" (see criteria in 'singleSimpleFieldNew')
 -- returning the type inside the constructor if it is. This is needed for strictness analysis.
 simpleCons :: ConDecl GhcPs -> Maybe (HsType GhcPs)
-simpleCons (ConDeclH98 _ _ _ [] context (PrefixCon [L _ inType]) _)
+simpleCons (ConDeclH98 _ _ _ [] context (PrefixCon [dL -> L _ inType]) _)
     | emptyOrNoContext context
     , not $ isUnboxedTuple inType
     , not $ isHashy inType
     = Just inType
-simpleCons (ConDeclH98 _ _ _ [] context (RecCon (L _ [L _ (ConDeclField _ [_] (L _ inType) _)])) _)
+simpleCons (ConDeclH98 _ _ _ [] context (RecCon (dL -> L _ [dL -> L _ (ConDeclField _ [_] (dL -> L _ inType) _)])) _)
     | emptyOrNoContext context
     , not $ isUnboxedTuple inType
     , not $ isHashy inType
@@ -116,18 +117,18 @@ warnBang _ = True
 
 emptyOrNoContext :: Maybe (LHsContext GhcPs) -> Bool
 emptyOrNoContext Nothing = True
-emptyOrNoContext (Just (L _ [])) = True
+emptyOrNoContext (Just (dL -> L _ [])) = True
 emptyOrNoContext _ = False
 
 -- | The \"Bang\" here refers to 'HsSrcBang', which notably also includes @UNPACK@ pragmas!
 dropConsBang :: ConDecl GhcPs -> ConDecl GhcPs
 dropConsBang decl@(ConDeclH98 _ _ _ _ _ (PrefixCon fields) _) =
     decl {con_args = PrefixCon $ map getBangType fields}
-dropConsBang decl@(ConDeclH98 _ _ _ _ _ (RecCon (L recloc conDeclFields)) _) =
-    decl {con_args = RecCon $ L recloc $ removeUnpacksRecords conDeclFields}
+dropConsBang decl@(ConDeclH98 _ _ _ _ _ (RecCon (dL -> L recloc conDeclFields)) _) =
+    decl {con_args = RecCon $ cL recloc $ removeUnpacksRecords conDeclFields}
     where
         removeUnpacksRecords :: [LConDeclField GhcPs] -> [LConDeclField GhcPs]
-        removeUnpacksRecords = map (\(L conDeclFieldLoc x) -> L conDeclFieldLoc $ removeConDeclFieldUnpacks x)
+        removeUnpacksRecords = map (\(dL -> L conDeclFieldLoc x) -> cL conDeclFieldLoc $ removeConDeclFieldUnpacks x)
 
         removeConDeclFieldUnpacks :: ConDeclField GhcPs -> ConDeclField GhcPs
         removeConDeclFieldUnpacks conDeclField@(ConDeclField _ _ fieldType _) =

--- a/src/Hint/Pragma.hs
+++ b/src/Hint/Pragma.hs
@@ -96,10 +96,10 @@ pragmaIdea pidea =
           mkLanguage = rawIdea' Hint.Type.Warning "Use LANGUAGE pragmas"
 
 languageDupes :: [(Located AnnotationComment, [String])] -> [Idea]
-languageDupes ( (a@(GHC.L l _), les) : cs ) =
+languageDupes ( (a@(dL -> GHC.L l _), les) : cs ) =
   (if nubOrd les /= les
        then [pragmaIdea (SingleComment a (mkLangExts l $ nubOrd les))]
-       else [pragmaIdea (MultiComment a b (mkLangExts l (nubOrd $ les ++ les'))) | ( b@(GHC.L _ _), les' ) <- cs, not $ null $ intersect les les']
+       else [pragmaIdea (MultiComment a b (mkLangExts l (nubOrd $ les ++ les'))) | ( b@(dL -> GHC.L _ _), les' ) <- cs, not $ null $ intersect les les']
   ) ++ languageDupes cs
 languageDupes _ = []
 
@@ -125,7 +125,7 @@ strToLanguage _ = Nothing
 optToLanguage :: (Located AnnotationComment, [String])
                -> [String]
                -> Maybe (Maybe (Located AnnotationComment), [String])
-optToLanguage (GHC.L loc _, flags) langExts
+optToLanguage (dL -> GHC.L loc _, flags) langExts
   | any isJust vs =
       -- 'ls' is a list of language features enabled by this
       -- OPTIONS_GHC pragma that are not enabled by LANGUAGE pragmas

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Hint.Smell (
   smellModuleHint,
@@ -98,7 +99,7 @@ import GHC.Util
 
 smellModuleHint :: [Setting] -> ModuHint
 smellModuleHint settings scope m =
-  let (GHC.L _ mod) = ghcModule m
+  let (dL -> GHC.L _ mod) = ghcModule m
       imports = GHC.hsmodImports mod in
   case Map.lookup SmellManyImports (smells settings) of
     Just n | length imports >= n ->
@@ -133,30 +134,30 @@ smellLongFunctions d n = [ idea
 -- right hand sides?)
 declSpans :: LHsDecl GhcPs -> [(GHC.SrcSpan, Idea)]
 declSpans
-   (GHC.L _ (ValD _
+   (dL -> GHC.L _ (ValD _
      GHC.FunBind {GHC.fun_matches=GHC.MG {
-                  GHC.mg_alts=GHC.L _ [GHC.L _ GHC.Match {
+                  GHC.mg_alts=(dL -> GHC.L _ [dL -> GHC.L _ GHC.Match {
                        GHC.m_ctxt=ctx
                      , GHC.m_grhss=GHC.GRHSs{GHC.grhssGRHSs=[locGrhs]
-                                 , GHC.grhssLocalBinds=where_}}]}})) =
+                                 , GHC.grhssLocalBinds=where_}}])}})) =
  -- The span of the right hand side and the spans of each binding in
  -- the where clause.
  rhsSpans ctx locGrhs ++ whereSpans where_
 -- Any other kind of function.
-declSpans f@(GHC.L l (ValD _ GHC.FunBind {})) = [(l, warn' "Long function" f f [])]
+declSpans f@(dL -> GHC.L l (ValD _ GHC.FunBind {})) = [(l, warn' "Long function" f f [])]
 declSpans _ = []
 
 -- The span of a guarded right hand side.
 rhsSpans :: GHC.HsMatchContext RdrName -> GHC.LGRHS GhcPs (GHC.LHsExpr GhcPs) -> [(GHC.SrcSpan, Idea)]
-rhsSpans _ (GHC.L _ (GHC.GRHS _ _ (GHC.L _ GHC.RecordCon {}))) = [] -- record constructors get a pass
-rhsSpans ctx (GHC.L _ r@(GHC.GRHS _ _ (GHC.L l _))) =
-  [(l, rawIdea Config.Type.Warning "Long function" (ghcSpanToHSE l) (showSDocUnsafe (GHC.pprGRHS ctx r)) Nothing [] [])]
+rhsSpans _ (dL -> GHC.L _ (GHC.GRHS _ _ (dL -> GHC.L _ GHC.RecordCon {}))) = [] -- record constructors get a pass
+rhsSpans ctx (dL -> GHC.L _ r@(GHC.GRHS _ _ (GHC.L l _))) =
+  [(l, rawIdea' Config.Type.Warning "Long function" l (showSDocUnsafe (GHC.pprGRHS ctx r)) Nothing [] [])]
 rhsSpans _ _ = []
 
 -- The spans of a 'where' clause are the spans of its bindings.
 whereSpans :: GHC.LHsLocalBinds GhcPs -> [(GHC.SrcSpan, Idea)]
-whereSpans (GHC.L l (GHC.HsValBinds _ (GHC.ValBinds _ bs _))) =
-  concatMap (declSpans . (\(GHC.L loc bind) -> GHC.L loc (ValD noext bind))) (bagToList bs)
+whereSpans (dL -> GHC.L l (GHC.HsValBinds _ (GHC.ValBinds _ bs _))) =
+  concatMap (declSpans . (\(dL -> GHC.L loc bind) -> cL loc (ValD noext bind))) (bagToList bs)
 whereSpans _ = []
 
 spanLength :: GHC.SrcSpan -> Int
@@ -164,7 +165,7 @@ spanLength (GHC.RealSrcSpan span) = GHC.srcSpanEndLine span - GHC.srcSpanStartLi
 spanLength (GHC.UnhelpfulSpan _) = -1
 
 smellLongTypeLists :: LHsDecl GhcPs -> Int -> [Idea]
-smellLongTypeLists d@(GHC.L _ (SigD _ (GHC.TypeSig _ _ (HsWC _ (HsIB _ (GHC.L _ t)))))) n =
+smellLongTypeLists d@(dL -> GHC.L _ (SigD _ (GHC.TypeSig _ _ (HsWC _ (HsIB _ (dL -> GHC.L _ t)))))) n =
   warn' "Long type list" d d [] <$ filter longTypeList (universe t)
   where
     longTypeList (HsExplicitListTy _ IsPromoted x) = length x >= n
@@ -172,7 +173,7 @@ smellLongTypeLists d@(GHC.L _ (SigD _ (GHC.TypeSig _ _ (HsWC _ (HsIB _ (GHC.L _ 
 smellLongTypeLists _ _ = []
 
 smellManyArgFunctions :: LHsDecl GhcPs -> Int -> [Idea]
-smellManyArgFunctions d@(GHC.L _ (SigD _ (GHC.TypeSig _ _ (HsWC _ (HsIB _ (GHC.L _ t)))))) n =
+smellManyArgFunctions d@(dL -> GHC.L _ (SigD _ (GHC.TypeSig _ _ (HsWC _ (HsIB _ (dL -> GHC.L _ t)))))) n =
   warn' "Many arg function" d d [] <$  filter manyArgFunction (universe t)
   where
     manyArgFunction t = countFunctionArgs t >= n


### PR DESCRIPTION
For your consideration. This PR adds nothing new instead, it updates source location handling to use the new `dL` view-pattern and `cL` function. Thus, this set of modifications I view as being about "future proofing" and "observing best practices". The background is that the `HsSyn` types are gradually being transformed in accordance with "trees that grow" principles. In particular for us here, the way that source code locations are handled. See [this Wiki page](https://gitlab.haskell.org/ghc/ghc/wikis/implementing-trees-that-grow/handling-source-locations) and [this issue](https://gitlab.haskell.org/ghc/ghc/issues/15495) for more details.