### PR TITLE
Fix Codeclimate ("hlint lint" is broken)

### DIFF
--- a/cc/Engine.hs
+++ b/cc/Engine.hs
@@ -63,8 +63,7 @@ main = do
     c <- readConfig "/config.json"
 
     callProcess "hlint" $
-        [ "lint"
-        , "--cc"
+        [ "--cc"
         , "--datadir", "/opt/hlint"
         , "--no-exit-code"
         ]


### PR DESCRIPTION
I don't know how this slipped, but apparently `hlint lint` doesn't work anymore and thus Codeclimate HLint integration is broken.

This PR removes "hlint lint" from the Codeclimate Dockerfile, but we might also want to remove mentions of "`[lint]`" from the CLI docs:

```
hlint lint --help
HLint v2.2.2, (C) Neil Mitchell 2006-2019

hlint [lint] [OPTIONS] [FILE/DIR]
...
```

```
hlint lint .
Couldn't find file: lint
```