### PR TITLE
Remove srcloc qualifications

### DIFF
--- a/src/GHC/Util/Module.hs
+++ b/src/GHC/Util/Module.hs
@@ -6,6 +6,6 @@ import "ghc-lib-parser" HsSyn
 import "ghc-lib-parser" Module
 import "ghc-lib-parser" SrcLoc
 
-modName :: HsModule GhcPs -> String
-modName HsModule {hsmodName=Nothing} = "Main"
-modName HsModule {hsmodName=Just (L _ n)} = moduleNameString n
+modName :: Located (HsModule GhcPs) -> String
+modName (LL _ HsModule {hsmodName=Nothing}) = "Main"
+modName (LL _ HsModule {hsmodName=Just (L _ n)}) = moduleNameString n

--- a/src/Hint/Duplicate.hs
+++ b/src/Hint/Duplicate.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE PatternGuards, ScopedTypeVariables #-}
 {-# LANGUAGE PackageImports #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 {-
@@ -24,15 +23,16 @@ foo = a where {a = 1; b = 2; c = 3}; bar = a where {a = 1; b = 2; c = 3} -- ???
 
 module Hint.Duplicate(duplicateHint) where
 
-import Hint.Type
+import Hint.Type (CrossHint, ModuleEx(..), Idea(..),rawIdeaN',Severity(Suggestion,Warning),showSrcLoc,ghcSrcLocToHSE)
 import Data.Data
+import Data.Generics.Uniplate.Operations
 import Data.Default
 import Data.Maybe
 import Data.Tuple.Extra
 import Data.List hiding (find)
 import qualified Data.Map as Map
 
-import "ghc-lib-parser" SrcLoc as GHC
+import "ghc-lib-parser" SrcLoc
 import "ghc-lib-parser" HsSyn
 import "ghc-lib-parser" Outputable
 import "ghc-lib-parser" Bag
@@ -43,7 +43,7 @@ duplicateHint ms =
    -- Do expressions.
    dupes [ (m, d, y)
          | (m, d, x) <- ds
-         , HsDo _ _ (dL -> L _ y) :: HsExpr GhcPs <- universeBi x
+         , HsDo _ _ (LL _ y) :: HsExpr GhcPs <- universeBi x
          ] ++
   -- Bindings in a 'let' expression or a 'where' clause.
    dupes [ (m, d, y)
@@ -53,22 +53,22 @@ duplicateHint ms =
          ]
     where
       ds = [(modName m, fromMaybe "" (declName d), d)
-           | ModuleEx _ _ (dL -> L _ m) _ <- map snd ms
-           , d <- map GHC.unLoc (hsmodDecls m)]
+           | ModuleEx _ _ m _ <- map snd ms
+           , d <- map unLoc (hsmodDecls (unLoc m))]
 
-dupes :: (Outputable e, Data e) => [(String, String, [GHC.Located e])] -> [Idea]
+dupes :: (Outputable e, Data e) => [(String, String, [Located e])] -> [Idea]
 dupes ys =
     [(rawIdeaN'
         (if length xs >= 5 then Hint.Type.Warning else Suggestion)
         "Reduce duplication" p1
         (unlines $ map unsafePrettyPrint xs)
         (Just $ "Combine with " ++
-         showSrcLoc (ghcSrcLocToHSE (GHC.srcSpanStart p2))) []
+         showSrcLoc (ghcSrcLocToHSE (srcSpanStart p2))) []
      ){ideaModule = [m1, m2], ideaDecl = [d1, d2]}
     | ((m1, d1, SrcSpanD p1), (m2, d2, SrcSpanD p2), xs) <- duplicateOrdered 3 $ map f ys]
     where
       f (m, d, xs) =
-        [((m, d, SrcSpanD (GHC.getLoc x)), W (transformBi (const GHC.noSrcSpan) (GHC.unLoc x))) | x <- xs]
+        [((m, d, SrcSpanD (getLoc x)), wrap (stripLocs' x)) | x <- xs]
 
 ---------------------------------------------------------------------
 -- DUPLICATE FINDING

--- a/src/Hint/Export.hs
+++ b/src/Hint/Export.hs
@@ -10,39 +10,39 @@ module Foo(module Foo, foo) where foo = 1 -- module Foo(..., foo) where
 </TEST>
 -}
 {-# LANGUAGE PackageImports #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Hint.Export(exportHint) where
 
-import Hint.Type
+import Hint.Type(ModuHint, ModuleEx(..),ideaNote,ignore',Note(..))
+
 import "ghc-lib-parser" HsSyn
-import qualified "ghc-lib-parser" Module as GHC
-import "ghc-lib-parser" SrcLoc as GHC
+import "ghc-lib-parser" Module
+import "ghc-lib-parser" SrcLoc
 import "ghc-lib-parser" OccName
 import "ghc-lib-parser" RdrName
 
 exportHint :: ModuHint
-exportHint _ (ModuleEx _ _ (dL -> L s m@HsModule {hsmodName = Just name, hsmodExports = exports}) _)
+exportHint _ (ModuleEx _ _ (LL s m@HsModule {hsmodName = Just name, hsmodExports = exports}) _)
   | Nothing <- exports =
-      let r = o{ hsmodExports = Just (GHC.noLoc [GHC.noLoc (IEModuleContents noExt name)] )} in
-      [(ignore' "Use module export list" (L s o) (GHC.noLoc r) []){ideaNote = [Note "an explicit list is usally better"]}]
-  | Just (dL -> L _ xs) <- exports
+      let r = o{ hsmodExports = Just (noLoc [noLoc (IEModuleContents noExt name)] )} in
+      [(ignore' "Use module export list" (L s o) (noLoc r) []){ideaNote = [Note "an explicit list is usally better"]}]
+  | Just (L _ xs) <- exports
   , mods <- [x | x <- xs, isMod x]
-  , modName <- GHC.moduleNameString (GHC.unLoc name)
-  , names <- [GHC.moduleNameString (GHC.unLoc n) | (dL -> L _ (IEModuleContents _ n)) <- mods]
+  , modName <- moduleNameString (unLoc name)
+  , names <- [ moduleNameString (unLoc n) | (LL _ (IEModuleContents _ n)) <- mods]
   , exports' <- [x | x <- xs, not (matchesModName modName x)]
   , modName `elem` names =
       let dots = mkRdrUnqual (mkVarOcc " ... ")
-          r = o{ hsmodExports = Just (GHC.noLoc (GHC.noLoc (IEVar noExt (GHC.noLoc (IEName (GHC.noLoc dots)))) : exports') )}
+          r = o{ hsmodExports = Just (noLoc (noLoc (IEVar noExt (noLoc (IEName (noLoc dots)))) : exports') )}
       in
-        [ignore' "Use explicit module export list" (L s o) (GHC.noLoc r) []]
+        [ignore' "Use explicit module export list" (L s o) (noLoc r) []]
       where
           o = m{hsmodImports=[], hsmodDecls=[], hsmodDeprecMessage=Nothing, hsmodHaddockModHeader=Nothing }
-          isMod (dL -> L _ (IEModuleContents _ _)) = True
+          isMod (LL _ (IEModuleContents _ _)) = True
           isMod _ = False
 
-          matchesModName m (dL -> L _ (IEModuleContents _ (dL -> L _ n))) = GHC.moduleNameString n == m
+          matchesModName m (LL _ (IEModuleContents _ (L _ n))) = moduleNameString n == m
           matchesModName _ _ = False
 
 exportHint _ _ = []

--- a/src/Hint/Pragma.hs
+++ b/src/Hint/Pragma.hs
@@ -31,14 +31,15 @@
 
 module Hint.Pragma(pragmaHint) where
 
-import Hint.Type
+import Hint.Type(ModuHint,ModuleEx(..),Idea(..),Severity(..),toSS',rawIdea',prettyExtension,glasgowExts)
 import Data.List.Extra
 import Data.Maybe
 import Refact.Types
 import qualified Refact.Types as R
 
 import "ghc-lib-parser" ApiAnnotation
-import qualified "ghc-lib-parser" SrcLoc as GHC
+import "ghc-lib-parser" SrcLoc
+
 import GHC.Util
 
 pragmaHint :: ModuHint
@@ -48,8 +49,8 @@ pragmaHint _ modu =
       lang = langExts ps in
     languageDupes lang ++ optToPragma opts lang
 
-optToPragma :: [(GHC.Located AnnotationComment, [String])]
-             -> [(GHC.Located AnnotationComment, [String])]
+optToPragma :: [(Located AnnotationComment, [String])]
+             -> [(Located AnnotationComment, [String])]
              -> [Idea]
 optToPragma flags langExts =
   [pragmaIdea (OptionsToComment (map fst old) ys rs) | old /= []]
@@ -62,32 +63,32 @@ optToPragma flags langExts =
       ls = concatMap snd langExts
       ns2 = nubOrd (concat ns) \\ ls
 
-      ys = [mkLangExts GHC.noSrcSpan ns2 | ns2 /= []] ++ catMaybes new
-      mkRefact :: (GHC.Located AnnotationComment, [String])
-               -> Maybe (GHC.Located AnnotationComment)
+      ys = [mkLangExts noSrcSpan ns2 | ns2 /= []] ++ catMaybes new
+      mkRefact :: (Located AnnotationComment, [String])
+               -> Maybe (Located AnnotationComment)
                -> [String]
                -> Refactoring R.SrcSpan
       mkRefact old (maybe "" comment -> new) ns =
-        let ns' = map (\n -> comment (mkLangExts GHC.noSrcSpan [n])) ns
+        let ns' = map (\n -> comment (mkLangExts noSrcSpan [n])) ns
         in ModifyComment (toSS' (fst old)) (intercalate "\n" (filter (not . null) (new : ns')))
 
-data PragmaIdea = SingleComment (GHC.Located AnnotationComment) (GHC.Located AnnotationComment)
-                 | MultiComment (GHC.Located AnnotationComment) (GHC.Located AnnotationComment) (GHC.Located AnnotationComment)
-                 | OptionsToComment [GHC.Located AnnotationComment] [GHC.Located AnnotationComment] [Refactoring R.SrcSpan]
+data PragmaIdea = SingleComment (Located AnnotationComment) (Located AnnotationComment)
+                 | MultiComment (Located AnnotationComment) (Located AnnotationComment) (Located AnnotationComment)
+                 | OptionsToComment [Located AnnotationComment] [Located AnnotationComment] [Refactoring R.SrcSpan]
 
 pragmaIdea :: PragmaIdea -> Idea
 pragmaIdea pidea =
   case pidea of
     SingleComment old new ->
-      mkFewer (GHC.getLoc old) (comment old) (Just $ comment new) []
+      mkFewer (getLoc old) (comment old) (Just $ comment new) []
       [ModifyComment (toSS' old) (comment new)]
     MultiComment repl delete new ->
-      mkFewer (GHC.getLoc repl)
+      mkFewer (getLoc repl)
         (f [repl, delete]) (Just $ comment new) []
         [ ModifyComment (toSS' repl) (comment new)
         , ModifyComment (toSS' delete) ""]
     OptionsToComment old new r ->
-      mkLanguage (GHC.getLoc . head $ old)
+      mkLanguage (getLoc . head $ old)
         (f old) (Just $ f new) []
         r
     where
@@ -95,11 +96,11 @@ pragmaIdea pidea =
           mkFewer = rawIdea' Hint.Type.Warning "Use fewer LANGUAGE pragmas"
           mkLanguage = rawIdea' Hint.Type.Warning "Use LANGUAGE pragmas"
 
-languageDupes :: [(GHC.Located AnnotationComment, [String])] -> [Idea]
-languageDupes ( (a@(GHC.dL -> GHC.L l _), les) : cs ) =
+languageDupes :: [(Located AnnotationComment, [String])] -> [Idea]
+languageDupes ( (a@(LL l _), les) : cs ) =
   (if nubOrd les /= les
        then [pragmaIdea (SingleComment a (mkLangExts l $ nubOrd les))]
-       else [pragmaIdea (MultiComment a b (mkLangExts l (nubOrd $ les ++ les'))) | ( b@(GHC.dL -> GHC.L _ _), les' ) <- cs, not $ null $ intersect les les']
+       else [pragmaIdea (MultiComment a b (mkLangExts l (nubOrd $ les ++ les'))) | ( b@(LL _ _), les' ) <- cs, not $ null $ intersect les les']
   ) ++ languageDupes cs
 languageDupes _ = []
 
@@ -122,10 +123,10 @@ strToLanguage _ = Nothing
 -- extension enabling flags. Return that together with a list of any
 -- language extensions enabled by this pragma that are not otherwise
 -- enabled by LANGUAGE pragmas in the module.
-optToLanguage :: (GHC.Located AnnotationComment, [String])
+optToLanguage :: (Located AnnotationComment, [String])
                -> [String]
-               -> Maybe (Maybe (GHC.Located AnnotationComment), [String])
-optToLanguage (GHC.dL -> GHC.L loc _, flags) langExts
+               -> Maybe (Maybe (Located AnnotationComment), [String])
+optToLanguage (LL loc _, flags) langExts
   | any isJust vs =
       -- 'ls' is a list of language features enabled by this
       -- OPTIONS_GHC pragma that are not enabled by LANGUAGE pragmas


### PR DESCRIPTION
This PR is conditional on https://github.com/ndmitchell/hlint/pull/749 and will need rebasing on master after that one has landed before merge.

This gist of this PR is to (1) remove `qualified` from import declarations like `import qualified "ghc-lib-parser" X`  (2) replace `GHC.x` with simply `x` and (3) usages of view pattern `dL ->` with the synonym `LL`. Overall, the resulting code should read much more naturally.