### PR TITLE
Remove usage of CPP

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -14,7 +14,7 @@
   - name: [ExistentialQuantification, MultiParamTypeClasses, NamedFieldPuns]
   - name: [FlexibleContexts, FlexibleInstances]
   - name: [PackageImports]
-  - {name: CPP, within: [HsColour, GHC.Util.FreeVars]} # so it can be disabled to avoid GPL code
+  - {name: CPP, within: [HsColour]} # so it can be disabled to avoid GPL code
   - {name: TypeFamilies, within: [GHC.Util.HsExpr, GHC.Util.FreeVars, Hint.Export, Hint.Restrict]} # type family constraints here
 
 - flags:

--- a/src/GHC/Util/FreeVars.hs
+++ b/src/GHC/Util/FreeVars.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -39,9 +38,6 @@ instance Semigroup Vars' where
 
 instance Monoid Vars' where
     mempty = Vars' Set.empty Set.empty
-#if !(MIN_VERSION_base(4,11,0))
-    mappend = (<>)
-#endif
     mconcat vs = Vars' (Set.unions $ map bound' vs) (Set.unions $ map free' vs)
 
 -- A type `a` is a model of `AllVars' a` if exists a function


### PR DESCRIPTION
Following up on the review of https://github.com/ndmitchell/hlint/pull/749, removes the use of `CPP`.