### PR TITLE
Use Numerical Value For Nonroot User To Avoid Additional Layer

### DIFF
--- a/cc/Dockerfile
+++ b/cc/Dockerfile
@@ -1,4 +1,12 @@
 #
+#
+#############
+#
+# Please be aware of the specification as of: 
+# https://github.com/codeclimate/spec/blob/master/SPEC.md
+#
+############
+#
 # Build stage
 #
 FROM haskell as builder

--- a/cc/Dockerfile
+++ b/cc/Dockerfile
@@ -50,7 +50,6 @@ RUN mkdir -p /code
 VOLUME /code
 WORKDIR /code
 
-RUN useradd app --uid 9000
-USER app
+USER 1000
 
 CMD ["/usr/bin/engine"]

--- a/cc/Dockerfile
+++ b/cc/Dockerfile
@@ -50,6 +50,7 @@ RUN mkdir -p /code
 VOLUME /code
 WORKDIR /code
 
-USER 1000
+RUN useradd app --uid 9000
+USER app
 
 CMD ["/usr/bin/engine"]


### PR DESCRIPTION
Avoid user  (`app`) creation as it's creating a unnecessary additional layer and the user itself is not being used anyway. Instead prefer to use numerical values, i. e. as this PR is introducing with a `uid` of `1000` for a `nonroot` user.  
