### PR TITLE
Somehow '*' ended up in here. Sorry!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *~
 *_flymake*
-*
 TAGS
 /dist/
 /.hpc/


### PR DESCRIPTION
I cleverly managed write an exclusion rule for all files in the `.gitignore`. Obviously I was stress testing the code-review process. This fixes it.