### PR TITLE
Match match groups strictly on 'FromSource'

### DIFF
--- a/src/Hint/ListRec.hs
+++ b/src/Hint/ListRec.hs
@@ -127,7 +127,8 @@ asDo :: LHsExpr GhcPs -> [LStmt GhcPs (LHsExpr GhcPs)]
 asDo (view' ->
        App2' bind lhs
          (LL _ (HsLam _ MG {
-             mg_alts=LL _ [
+              mg_origin=FromSource
+            , mg_alts=LL _ [
                  LL _ Match {  m_ctxt=LambdaExpr
                             , m_pats=[LL _ v@VarPat{}]
                             , m_grhss=GRHSs _
@@ -148,7 +149,7 @@ findCase :: LHsDecl GhcPs -> Maybe (ListCase, LHsExpr GhcPs -> LHsDecl GhcPs)
 findCase x = do
   -- Match a function binding with two alternatives.
   (LL _ (ValD _ FunBind {fun_matches=
-              MG{mg_alts=
+              MG{mg_origin=FromSource, mg_alts=
                      (LL _
                             [ x1@(LL _ Match{..}) -- Match fields.
                             , x2]), ..} -- Match group fields.

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -82,7 +82,7 @@ naming seen originalDecl =
         replacedDecl = replaceNames suggestedNames originalDecl
 
 shorten :: LHsDecl GhcPs -> LHsDecl GhcPs
-shorten (LL locDecl (ValD ttg0 bind@(FunBind _ _ matchGroup@(MG _ (LL locMatches matches) _) _ _))) =
+shorten (LL locDecl (ValD ttg0 bind@(FunBind _ _ matchGroup@(MG _ (LL locMatches matches) FromSource) _ _))) =
     LL locDecl (ValD ttg0 bind {fun_matches = matchGroup {mg_alts = LL locMatches $ map shortenMatch matches}})
 shorten (LL locDecl (ValD ttg0 bind@(PatBind _ _ grhss@(GRHSs _ rhss _) _))) =
     LL locDecl (ValD ttg0 bind {pat_rhs = grhss {grhssGRHSs = map shortenLGRHS rhss}})

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -132,7 +132,8 @@ declSpans :: LHsDecl GhcPs -> [(SrcSpan, Idea)]
 declSpans
    (LL _ (ValD _
      FunBind {fun_matches=MG {
-                  mg_alts=(LL _ [LL _ Match {
+                   mg_origin=FromSource
+                 , mg_alts=(LL _ [LL _ Match {
                        m_ctxt=ctx
                      , m_grhss=GRHSs{grhssGRHSs=[locGrhs]
                                  , grhssLocalBinds=where_}}])}})) =

--- a/src/Hint/Unsafe.hs
+++ b/src/Hint/Unsafe.hs
@@ -52,7 +52,7 @@ unsafeHint _ (ModuleEx _ _ (L _ m) _) = \(L loc d) ->
      -- 'x' does not declare a new function.
      | d@(ValD _
            FunBind {fun_id=L _ (Unqual x)
-                      , fun_matches=MG{mg_alts=L _ [L _ Match {m_pats=[]}]}}) <- [d]
+                      , fun_matches=MG{mg_origin=FromSource,mg_alts=L _ [L _ Match {m_pats=[]}]}}) <- [d]
      -- 'x' is a synonym for an appliciation involing 'unsafePerformIO'
      , isUnsafeDecl d
      -- 'x' is not marked 'NOINLINE'.
@@ -68,7 +68,7 @@ unsafeHint _ (ModuleEx _ _ (L _ m) _) = \(L loc d) ->
         ) <- hsmodDecls m]
 
 isUnsafeDecl :: HsDecl GhcPs -> Bool
-isUnsafeDecl (ValD _ FunBind {fun_matches=MG {mg_alts=LL _ alts}}) =
+isUnsafeDecl (ValD _ FunBind {fun_matches=MG {mg_origin=FromSource,mg_alts=LL _ alts}}) =
   any isUnsafeApp (childrenBi alts) || any isUnsafeDecl (childrenBi alts)
 isUnsafeDecl _ = False
 


### PR DESCRIPTION
Change match group occurrences `MG ... _` to `MG ... FromSource` (excluding generated match groups).