### PR TITLE
Debug match

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -4,7 +4,7 @@
 
 - message:
   - name: Weeds exported
-  - module: [HSE.Util, GHC.Util.FreeVars, GHC.Util.HsExpr, GHC.Util.View, GHC.Util.W, Hint.Type, Idea,GHC.Util.Brackets,GHC.Util.Language.Haskell.GHC.ExactPrint.Types,GHC.Util.Refact.Utils, GHC.Util.Unify, GHC.Util.Scope]
+  - module: [HSE.Util, GHC.Util.FreeVars, GHC.Util.HsExpr, GHC.Util.View, GHC.Util.W, Hint.Type, Idea,GHC.Util.Brackets,GHC.Util.Language.Haskell.GHC.ExactPrint.Types,GHC.Util.Refact.Utils, GHC.Util.Unify, GHC.Util.Scope,Hint.Match]
 
 - message:
   - name: Redundant build-depends entry

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -56,7 +56,8 @@ applyHintsReal settings hints_ ms = concat $
     , let classifiers = cls ++ mapMaybe readPragma (universeBi (hseModule m)) ++ concatMap readComment (ghcComments m)
     , seq (length classifiers) True -- to force any errors from readPragma or readComment
     , let decHints = hintDecl hints settings nm m -- partially apply
-    , let decHints' = hintDecl' hints settings nm m -- partially apply
+    , (nm',m') <- mns'
+    , let decHints' = hintDecl' hints settings nm' m' -- partially apply
     , let order n = map (\i -> i{ideaModule= f $ moduleName (hseModule m) : ideaModule i, ideaDecl = f $ n ++ ideaDecl i}) . sortOn ideaSpan
     , let merge = mergeBy (comparing ideaSpan)] ++
     [map (classify cls) (hintModules hints settings mns)]
@@ -64,6 +65,7 @@ applyHintsReal settings hints_ ms = concat $
         f = nubOrd . filter (/= "")
         cls = [x | SettingClassify x <- settings]
         mns = map (\x -> (scopeCreate (hseModule x), x)) ms
+        mns' = map (\x -> (scopeCreate' (GHC.unLoc $ ghcModule x), x)) ms
         hints = (if length ms <= 1 then noModules else id) hints_
         noModules h = h{hintModules = \_ _ -> []} `mappend` mempty{hintModule = \s a b -> hintModules h s [(a,b)]}
 

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -17,7 +17,7 @@ module GHC.Util (
   , module GHC.Util.RdrName
   , module GHC.Util.Unify
 
-  , parsePragmasIntoDynFlags, parseFileGhcLib, parseExpGhcLib
+  , parsePragmasIntoDynFlags, parseFileGhcLib, parseExpGhcLib, parseImportGhcLib
   ) where
 
 import GHC.Util.View
@@ -53,15 +53,19 @@ import Data.List.Extra
 import System.FilePath
 import Language.Preprocessor.Unlit
 
-parseExpGhcLib :: String
-                -> DynFlags
-                -> ParseResult (LHsExpr GhcPs)
-parseExpGhcLib str flags =
-  Lexer.unP Parser.parseExpression parseState
+parseGhcLib :: P a -> String -> DynFlags -> ParseResult a
+parseGhcLib p str flags =
+  Lexer.unP p parseState
   where
     location = mkRealSrcLoc (mkFastString "<string>") 1 1
     buffer = stringToStringBuffer str
     parseState = mkPState flags buffer location
+
+parseExpGhcLib :: String -> DynFlags -> ParseResult (LHsExpr GhcPs)
+parseExpGhcLib = parseGhcLib Parser.parseExpression
+
+parseImportGhcLib :: String -> DynFlags -> ParseResult (LImportDecl GhcPs)
+parseImportGhcLib = parseGhcLib Parser.parseImport
 
 parseFileGhcLib :: FilePath
                 -> String

--- a/src/GHC/Util/Refact/Fixity.hs
+++ b/src/GHC/Util/Refact/Fixity.hs
@@ -26,7 +26,7 @@ import Data.Tuple
 
 -- | Rearrange infix expressions to account for fixity.
 -- The set of fixities is wired in and includes all fixities in base.
-applyFixities :: Anns -> [(String, Fixity)] -> Module -> (Anns, Module)
+applyFixities :: (Data a) => Anns -> [(String, Fixity)] -> a -> (Anns, a)
 applyFixities as fixities m = let (as', m') = swap $ runState (everywhereM (mkM (expFix fixities)) m) as
                                   (as'', m'') = swap $ runState (everywhereM (mkM (patFix fixities)) m') as'
                               in (as'', m'') --error (showAnnData as 0 m ++ showAnnData as' 0 m')

--- a/src/GHC/Util/Scope.hs
+++ b/src/GHC/Util/Scope.hs
@@ -36,7 +36,7 @@ scopeCreate' xs = Scope' $ [prelude | not $ any isPrelude res] ++ res
 
     -- The import declaraions contained by the module 'xs'.
     res :: [LImportDecl GhcPs]
-    res = [x | x <- hsmodImports xs, pkg x /= Just (StringLiteral NoSourceText (fsLit "hint"))]
+    res = [x | x <- hsmodImports xs , pkg x /= Just (StringLiteral NoSourceText (fsLit "hint"))]
 
     -- Mock up an import declaraion corresponding to 'import Prelude'.
     prelude :: LImportDecl GhcPs
@@ -59,7 +59,8 @@ scopeMatch' :: (Scope', Located RdrName) -> (Scope', Located RdrName) -> Bool
 scopeMatch' (a, x) (b, y)
   | isSpecial' x && isSpecial' y = rdrNameStr' x == rdrNameStr' y
   | isSpecial' x || isSpecial' y = False
-  | otherwise = rdrNameStr' x == rdrNameStr' y && not (null $ possModules' a x `intersect` possModules' b y)
+  | otherwise =
+     rdrNameStr' (unqual' x) == rdrNameStr' (unqual' y) && not (null $ possModules' a x `intersect` possModules' b y)
 
 -- Given a name in a scope, and a new scope, create a name for the new
 -- scope that will refer to the same thing. If the resulting name is

--- a/src/GHC/Util/Unify.hs
+++ b/src/GHC/Util/Unify.hs
@@ -16,7 +16,7 @@ import Data.Tuple.Extra
 import Util
 
 import HsSyn
-import SrcLoc
+import SrcLoc as GHC
 import Outputable hiding ((<>))
 import RdrName
 import OccName
@@ -99,7 +99,7 @@ unify' nm root x y
     | Just (x, y) <- cast (x, y) = unifyExp' nm root x y
     | Just (x, y) <- cast (x, y) = unifyPat' nm x y
     | Just (x, y) <- cast (x, y) = unifyType' nm x y
-    | Just (x :: SrcSpan) <- cast x = Just mempty
+    | Just (x :: GHC.SrcSpan) <- cast x = Just mempty
     | otherwise = unifyDef' nm x y
 
 unifyDef' :: Data a => NameMatch' -> a -> a -> Maybe (Subst' (LHsExpr GhcPs))

--- a/src/HSE/Unify.hs
+++ b/src/HSE/Unify.hs
@@ -19,7 +19,6 @@ import Data.Tuple.Extra
 import Util
 import Prelude
 
-
 ---------------------------------------------------------------------
 -- SUBSTITUTION DATA TYPE
 
@@ -126,7 +125,8 @@ unifyExp nm root x@(App _ x1 x2) (App _ y1 y2) =
             -- because the matching engine auto-generates hints in dot-form
         InfixApp _ y11 dot y12 <- return $ fromParen y1
         guard $ isDot dot
-        unifyExp nm root x (App an y11 (App an y12 y2)))
+        unifyExp nm root x (App an y11 (App an y12 y2))
+    )
 
 -- Options: match directly, then expand through $, then desugar infix
 unifyExp nm root x (InfixApp _ lhs2 op2 rhs2)

--- a/src/Hint/All.hs
+++ b/src/Hint/All.hs
@@ -77,8 +77,14 @@ builtinHints = [(drop 4 $ show h, builtin h) | h <- [minBound .. maxBound]]
 
 -- | Transform a list of 'HintBuiltin' or 'HintRule' into a 'Hint'.
 resolveHints :: [Either HintBuiltin HintRule] -> Hint
-resolveHints xs = mconcat $ mempty{hintDecl=const $ readMatch rights} : map builtin (nubOrd lefts)
-    where (lefts,rights) = partitionEithers xs
+resolveHints xs =
+  if False then
+      -- GHC
+    mconcat $ mempty{hintDecl'=const $ readMatch' rights} : map builtin (nubOrd lefts)
+  else
+      -- HSE
+    mconcat $ mempty{ hintDecl=const $  readMatch rights} : map builtin (nubOrd lefts)
+  where (lefts,rights) = partitionEithers xs
 
 -- | Transform a list of 'HintRule' into a 'Hint'.
 hintRules :: [HintRule] -> Hint

--- a/src/Hint/Type.hs
+++ b/src/Hint/Type.hs
@@ -12,9 +12,10 @@ import Prelude
 import Refact   as Export
 import HsExtension
 import HsDecls
+import GHC.Util.Scope
 
 type DeclHint = Scope -> ModuleEx -> Decl_ -> [Idea]
-type DeclHint' = Scope -> ModuleEx -> LHsDecl GhcPs -> [Idea]
+type DeclHint' = Scope' -> ModuleEx -> LHsDecl GhcPs -> [Idea]
 type ModuHint = Scope -> ModuleEx -> [Idea]
 type CrossHint = [(Scope, ModuleEx)] -> [Idea]
 
@@ -23,7 +24,7 @@ data Hint {- PUBLIC -} = Hint
     { hintModules :: [Setting] -> [(Scope, ModuleEx)] -> [Idea] -- ^ Given a list of modules (and their scope information) generate some 'Idea's.
     , hintModule :: [Setting] -> Scope -> ModuleEx -> [Idea] -- ^ Given a single module and its scope information generate some 'Idea's.
     , hintDecl :: [Setting] -> Scope -> ModuleEx -> Decl SrcSpanInfo -> [Idea]
-    , hintDecl' :: [Setting] -> Scope -> ModuleEx -> LHsDecl GhcPs -> [Idea]
+    , hintDecl' :: [Setting] -> Scope' -> ModuleEx -> LHsDecl GhcPs -> [Idea]
         -- ^ Given a declaration (with a module and scope) generate some 'Idea's.
         --   This function will be partially applied with one module/scope, then used on multiple 'Decl' values.
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ resolver: nightly-2019-08-07
 packages: [.]
 extra-deps: [ghc-lib-parser-8.8.1]
 ghc-options:
-    "$locals": -Wunused-imports -Worphans -Wunused-top-binds -Wincomplete-patterns
+    "$locals": -Wunused-imports -Worphans -Wunused-top-binds -Wunused-local-binds -Wincomplete-patterns


### PR DESCRIPTION
This PR fixes up yaml parsing so that GHC scopes are populated. `resolveHints` continues to use the HSE `readMatch` function, all tests pass. To switch to the ghc implementation, `readMatch'` toggle the manifest constant `HLINT_GHC_MATCH_ENABLE` in `Hint/All.hs`. Many tests pass but there remain some failures that need debugging before we can make the switch.