### PR TITLE
Debug match

### DIFF
--- a/src/GHC/Util/FreeVars.hs
+++ b/src/GHC/Util/FreeVars.hs
@@ -25,7 +25,6 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Prelude
 
-
 ( ^+ ) :: Set OccName -> Set OccName -> Set OccName
 ( ^+ ) = Set.union
 ( ^- ) :: Set OccName -> Set OccName -> Set OccName
@@ -33,6 +32,12 @@ import Prelude
 
 -- See [Note : Spack leaks lurking here?] below.
 data Vars' = Vars'{bound' :: Set OccName, free' :: Set OccName}
+
+-- Useful for debugging.
+instance Show Vars' where
+  show (Vars' bs fs) = "bound : " ++
+    show (map occNameString (Set.toList bs)) ++
+    ", free : " ++ show (map occNameString (Set.toList fs))
 
 instance Semigroup Vars' where
     Vars' x1 x2 <> Vars' y1 y2 = Vars' (x1 ^+ y1) (x2 ^+ y2)
@@ -217,7 +222,7 @@ instance AllVars' (LHsBind GhcPs) where
 instance AllVars' (LMatch GhcPs (LHsExpr GhcPs)) where
   allVars' (dL -> L _ (Match _ FunRhs {mc_fun=name} pats grhss)) = allVars' (VarPat noExt name :: Pat GhcPs) <> allVars' pats <> allVars' grhss -- A pattern matching on an argument of a function binding.
   allVars' (dL -> L _ (Match _ (StmtCtxt ctxt) pats grhss)) = allVars' ctxt <> allVars' pats <> allVars' grhss -- Pattern of a do-stmt, list comprehension, pattern guard etc.
-  allVars' (dL -> L _ (Match _ _ pats grhss)) = allVars' pats <> allVars' grhss -- Everything else.
+  allVars' (dL -> L _ (Match _ _ pats grhss)) = inVars' (allVars' pats) (allVars' grhss) -- Everything else.
 
   allVars' _ = mempty -- New ctor.
 
@@ -234,7 +239,7 @@ instance AllVars' (GRHSs GhcPs (LHsExpr GhcPs)) where
   allVars' _ = mempty -- New ctor.
 
 instance AllVars' (LGRHS GhcPs (LHsExpr GhcPs)) where
-  allVars' (dL -> L _ (GRHS _ guards expr)) =  let gs = allVars' guards in Vars' (bound' gs) (free' gs ^+ (freeVars' expr ^- bound' gs))
+  allVars' (dL -> L _ (GRHS _ guards expr)) = Vars' (bound' gs) (free' gs ^+ (freeVars' expr ^- bound' gs)) where gs = allVars' guards
 
   allVars' _ = mempty -- New ctor.
 

--- a/src/GHC/Util/HsExpr.hs
+++ b/src/GHC/Util/HsExpr.hs
@@ -289,7 +289,7 @@ replaceBranches' x = ([], \[] -> x)
 -- removed from haskell-src-exts-util-0.2.2.
 needBracketOld' :: Int -> LHsExpr GhcPs -> LHsExpr GhcPs -> Bool
 needBracketOld' i parent child
-  | isDotApp' parent, isDotApp' child, i == 1 = False
+  | isDotApp' parent, isDotApp' child, i == 2 = False
   | otherwise = needBracket' i parent child
 
 transformBracketOld' :: (LHsExpr GhcPs -> Maybe (LHsExpr GhcPs)) -> LHsExpr GhcPs -> LHsExpr GhcPs

--- a/src/GHC/Util/Unify.hs
+++ b/src/GHC/Util/Unify.hs
@@ -167,7 +167,10 @@ unifyPat' nm (LL _ (VarPat _ x)) (LL _ (VarPat _ y)) =
   Just $ Subst' [(rdrNameStr' x, strToVar'(rdrNameStr' y))]
 unifyPat' nm (LL _ (VarPat _ x)) (LL _ (WildPat _)) =
   let s = rdrNameStr' x in Just $ Subst' [(s, strToVar'("_" ++ s))]
-unifyPat' nm x y = unifyDef' nm x y
+unifyPat' nm (LL _ (ConPatIn x _)) (LL _ (ConPatIn y _)) | rdrNameStr' x /= rdrNameStr' y =
+  Nothing
+unifyPat' nm x y =
+  unifyDef' nm x y
 
 unifyType' :: NameMatch' -> LHsType GhcPs -> LHsType GhcPs -> Maybe (Subst' (LHsExpr GhcPs))
 unifyType' nm (LL loc (HsTyVar _ _ x)) y =

--- a/src/Hint/Match.hs
+++ b/src/Hint/Match.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternGuards, ViewPatterns, RecordWildCards, FlexibleContexts, ScopedTypeVariables #-}
 
--- Kepp until 'checkSide', 'checkDefine', ... are used.
+-- Keep until 'checkSide', 'checkDefine', ... are used.
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 {-
@@ -333,8 +333,8 @@ checkSide' x bind = maybe True bool x
       isType "LitInt" (GHC.LL _ (GHC.HsOverLit _ (GHC.OverLit _ GHC.HsIntegral{} _))) = True
       isType "Var" (GHC.LL _ GHC.HsVar{}) = True
       isType "App" (GHC.LL _ GHC.HsApp{}) = True
-      isType "InfixAp" (GHC.LL _ GHC.OpApp{}) = True
-      isType "Paren" (GHC.LL _ GHC.HsPar{}) = True
+      isType "InfixApp" (GHC.LL _ x@GHC.OpApp{}) = True
+      isType "Paren" (GHC.LL _ x@GHC.HsPar{}) = True
       isType "Tuple" (GHC.LL _ GHC.ExplicitTuple{}) = True
 
       isType typ (GHC.LL _ x) =


### PR DESCRIPTION
Fix match test failures.

(1) Rephrase free vars patch.
    - Equivalent, more elegant code : no change expected.
(2) Parenthesize sections in `dotApps'`.
(3) Fix spelling mistake for string literal (`"isInfixAp"` / `"isInfixApp`") in `checkSides`.

TL;DR 3 failures all due to slight output format differences.

- There are 687 tests
- 170 are match tests
- 41  are from `Test.hs`; these are excluded
- there are 129 other match tests
- there are 4 test failures:
  - one is a grep test
  - the remaining 3 failures are due to output format

(0)
```
TEST FAILURE IN tests/_grep_2
DIFFER ON LINE: 1
GOT : <EOF>
WANT: tests/grep2.hs:1:8:
FULL OUTPUT FOR GOT:
```
(1)
```
GOT :   if isNothing x then (- 1.0) else fromJust x
WANT:   if isNothing x then (-1.0) else fromJust x
```
(2)
```Found:
  concat . map f . baz . bar
Perhaps:
  (concatMap f . (baz . bar))

WANTED: concatMap f . baz . bar

(3)
```Found:
  typeOf (undefined :: Foo Int)
Perhaps:
  typeRep (Proxy :: Proxy Foo Int)

WANTED: typeRep (Proxy :: Proxy (Foo Int))
```