### PR TITLE
Bump ghc-lib

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -74,7 +74,7 @@ library
           ghc-boot-th
     else
         build-depends:
-          ghc-lib-parser == 8.8.1
+          ghc-lib-parser == 8.8.1.*
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,6 @@
 # * https://github.com/commercialhaskell/stackage/issues/4731
 resolver: nightly-2019-08-07
 packages: [.]
-extra-deps: [ghc-lib-parser-8.8.1]
+extra-deps: [ghc-lib-parser-8.8.1.20191204]
 ghc-options:
     "$locals": -Wunused-imports -Worphans -Wunused-top-binds -Wunused-local-binds -Wincomplete-patterns


### PR DESCRIPTION
The new release has set exposed to False in the cabal file which
should fix some issues in IHaskell which also depends on HLint.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
