### PR TITLE
Add the ability to blacklist identifiers from a module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *_flymake*
 TAGS
 /dist/
+/dist-newstyle/
+/.ghc.environment*
 /.hpc/
 /.stack-work/
 /cc/.stack-work/
@@ -11,3 +13,4 @@ TAGS
 /TAGS
 \#*\#
 .\#*\#
+

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -10,7 +10,8 @@
 - extensions:
   - default: false
   - name: [DeriveDataTypeable, GeneralizedNewtypeDeriving, NoMonomorphismRestriction, OverloadedStrings]
-  - name: [PatternGuards, Rank2Types, RecordWildCards, ScopedTypeVariables, ViewPatterns, TupleSections, LambdaCase]
+  - name: [MultiWayIf, PatternGuards, RecordWildCards, ViewPatterns, TupleSections, LambdaCase]
+  - name: [Rank2Types, ScopedTypeVariables]
   - name: [ExistentialQuantification, MultiParamTypeClasses, NamedFieldPuns]
   - name: [FlexibleContexts, FlexibleInstances]
   - name: [PackageImports]

--- a/README.md
+++ b/README.md
@@ -325,9 +325,10 @@ This declares that the `nub` function can't be used in any modules, and thus is 
 - modules:
   - {name: [Data.Set, Data.HashSet], as: Set}
   - {name: Control.Arrow, within: []}
+  - {name: Control.Monad.State, badidents: [modify, get, put], message: "Use Control.Monad.State.Class instead"}
 ```
 
-This fragment requires that all imports of `Set` must be `qualified Data.Set as Set`, enforcing consistency. It also ensures the module `Control.Arrow` can't be used anywhere.
+This fragment requires that all imports of `Set` must be `qualified Data.Set as Set`, enforcing consistency. It also ensures the module `Control.Arrow` can't be used anywhere. It also prevents explicit imports of the `modify` identifier from `Control.Monad.State` (this is meant to allow you to prevent people from importing reexported identifiers).
 
 You can customize the `Note:` for restricted modules, functions and extensions, by providing a `message` field (default: `may break the code`).
 

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -114,6 +114,7 @@ data Restrict = Restrict
     ,restrictName :: [String]
     ,restrictAs :: [String] -- for RestrictModule only, what module names you can import it as
     ,restrictWithin :: [(String, String)]
+    ,restrictBadIdents :: [String]
     ,restrictMessage :: Maybe String
     } deriving Show
 

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -274,13 +274,14 @@ parseRestrict restrictType v = do
         Just def -> do
             b <- parseBool def
             allowFields v ["default"]
-            return $ Restrict restrictType b [] [] [] Nothing
+            return $ Restrict restrictType b [] [] [] [] Nothing
         Nothing -> do
             restrictName <- parseFieldOpt "name" v >>= maybe (return []) parseArrayString
             restrictWithin <- parseFieldOpt "within" v >>= maybe (return [("","")]) (parseArray >=> concatMapM parseWithin)
             restrictAs <- parseFieldOpt "as" v >>= maybe (return []) parseArrayString
+            restrictBadIdents <- parseFieldOpt "badidents" v >>= maybe (pure []) parseArrayString
             restrictMessage <- parseFieldOpt "message" v >>= maybeParse parseString
-            allowFields v $ ["as" | restrictType == RestrictModule] ++ ["name","within", "message"]
+            allowFields v $ ["as" | restrictType == RestrictModule] ++ ["badidents", "name", "within", "message"]
             return Restrict{restrictDefault=True,..}
 
 parseWithin :: Val -> Parser [(String, String)] -- (module, decl)


### PR DESCRIPTION
This allows you to prevent someone from importing a specific identifier from a module. This is useful if you want to, for example, maintain a policy that people never import identifiers that are reexported (e.g.: in MTL).

I am not sure how the hlint testing framework works, so I have not been able to test this code.