### PR TITLE
Fix bifunctor hints

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -351,13 +351,13 @@
     - warn: {lhs: bimap id id, rhs: id}
     - warn: {lhs: first f (second g x), rhs: bimap f g x}
     - warn: {lhs: second g (first f x), rhs: bimap f g x}
-    - warn: {lhs: first f1 (first f2 x), rhs: first (f1 . f2) x}
-    - warn: {lhs: second g1 (second g2 x), rhs: second (g1 . g2) x}
-    - warn: {lhs: bimap f1 f2 (bimap g1 g2 x), rhs: bimap (f1 . f2) (g1 . g2) x}
-    - warn: {lhs: first f1 (bimap f2 g x), rhs: bimap (f1 . f2) g x}
-    - warn: {lhs: second g1 (bimap f g2 x), rhs: bimap f (g1 . g2) x}
-    - warn: {lhs: bimap f1 g (first f2 x), rhs: bimap (f1 . f2) g x}
-    - warn: {lhs: bimap f g1 (second g2 x), rhs: bimap f (g1 . g2) x}
+    - warn: {lhs: first f (first g x), rhs: first (f . g) x}
+    - warn: {lhs: second f (second g x), rhs: second (f . g) x}
+    - warn: {lhs: bimap f h (bimap g i x), rhs: bimap (f . g) (h . i) x}
+    - warn: {lhs: first f (bimap g h x), rhs: bimap (f . g) h x}
+    - warn: {lhs: second g (bimap f h x), rhs: bimap f (g . h) x}
+    - warn: {lhs: bimap f h (first g x), rhs: bimap (f . g) h x}
+    - warn: {lhs: bimap f g (second h x), rhs: bimap f (g . h) x}
     - hint: {lhs: "\\(x,y) -> (f x, g y)", rhs: Data.Bifunctor.bimap f g, note: IncreasesLaziness}
     - hint: {lhs: "\\(x,y) -> (f x,y)", rhs: Data.Bifunctor.first f, note: IncreasesLaziness}
     - hint: {lhs: "\\(x,y) -> (x,f y)", rhs: Data.Bifunctor.second f, note: IncreasesLaziness}


### PR DESCRIPTION
Use single character variables so they work with other names, and fix swapped variables in the bimap-bimap hint.