### PR TITLE
Embed data files

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -15,6 +15,7 @@
   - name: [FlexibleContexts, FlexibleInstances]
   - name: [PackageImports]
   - name: [ConstraintKinds, RankNTypes, TypeFamilies]
+  - name: [TemplateHaskell]
   - {name: CPP, within: [HsColour]} # so it can be disabled to avoid GPL code
 
 - flags:

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -54,6 +54,8 @@ library
         base == 4.*, process, filepath, directory, containers,
         unordered-containers, vector, text, bytestring,
         transformers,
+        file-embed,
+        utf8-string,
         data-default >= 0.3,
         cpphs >= 1.20.1,
         cmdargs >= 0.10,
@@ -100,6 +102,7 @@ library
         Refact
         Timing
         CC
+        EmbedData
         Config.Compute
         Config.Haskell
         Config.Read

--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -30,6 +30,7 @@ import System.Info.Extra
 import System.Process
 import System.FilePattern
 
+import EmbedData
 import Util
 import Paths_hlint
 import Data.Version
@@ -215,13 +216,15 @@ mode = cmdArgsMode $ modes
 --   * If someone passes cmdWithHints, only look at files they explicitly request
 --   * If someone passes an explicit hint name, automatically merge in data/hlint.yaml
 --   We want more important hints to go last, since they override
-cmdHintFiles :: Cmd -> IO [FilePath]
+cmdHintFiles :: Cmd -> IO [(FilePath, Maybe String)]
 cmdHintFiles cmd = do
+    let explicit1 = [hlintYaml | null $ cmdWithHints cmd]
     let explicit2 = cmdGivenHints cmd
     bad <- filterM (notM . doesFileExist) explicit2
+    let explicit2' = map (,Nothing) explicit2
     when (bad /= []) $
         fail $ unlines $ "Failed to find requested hint files:" : map ("  "++) bad
-    if cmdWithHints cmd /= [] then return explicit2 else do
+    if cmdWithHints cmd /= [] then return $ explicit1 ++ explicit2' else do
         -- we follow the stylish-haskell config file search policy
         -- 1) current directory or its ancestors; 2) home directory
         curdir <- getCurrentDirectory
@@ -230,7 +233,7 @@ cmdHintFiles cmd = do
         implicit <- findM doesFileExist $
             map (</> ".hlint.yaml") (ancestors curdir ++ home) -- to match Stylish Haskell
             ++ ["HLint.hs"] -- the default in HLint 1.*
-        return $ maybeToList implicit ++ explicit2
+        return $ explicit1 ++ map (,Nothing) (maybeToList implicit) ++ explicit2'
     where
         ancestors = init . map joinPath . reverse . inits . splitPath
 

--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -217,12 +217,11 @@ mode = cmdArgsMode $ modes
 --   We want more important hints to go last, since they override
 cmdHintFiles :: Cmd -> IO [FilePath]
 cmdHintFiles cmd = do
-    let explicit1 = [cmdDataDir cmd </> "hlint.yaml" | null $ cmdWithHints cmd]
     let explicit2 = cmdGivenHints cmd
-    bad <- filterM (notM . doesFileExist) $ explicit1 ++ explicit2
+    bad <- filterM (notM . doesFileExist) explicit2
     when (bad /= []) $
         fail $ unlines $ "Failed to find requested hint files:" : map ("  "++) bad
-    if cmdWithHints cmd /= [] then return $ explicit1 ++ explicit2 else do
+    if cmdWithHints cmd /= [] then return explicit2 else do
         -- we follow the stylish-haskell config file search policy
         -- 1) current directory or its ancestors; 2) home directory
         curdir <- getCurrentDirectory
@@ -231,7 +230,7 @@ cmdHintFiles cmd = do
         implicit <- findM doesFileExist $
             map (</> ".hlint.yaml") (ancestors curdir ++ home) -- to match Stylish Haskell
             ++ ["HLint.hs"] -- the default in HLint 1.*
-        return $ explicit1 ++ maybeToList implicit ++ explicit2
+        return $ maybeToList implicit ++ explicit2
     where
         ancestors = init . map joinPath . reverse . inits . splitPath
 

--- a/src/Config/Read.hs
+++ b/src/Config/Read.hs
@@ -6,14 +6,12 @@ import Config.Haskell
 import Config.Yaml
 import Data.List.Extra
 import System.FilePath
-import EmbedData
 
 
 readFilesConfig :: [(FilePath, Maybe String)] -> IO [Setting]
 readFilesConfig files = do
-        yaml <- mapM (uncurry readFileConfigYaml) yaml'
+        yaml <- mapM (uncurry readFileConfigYaml) yaml
         haskell <- mapM (uncurry readFileConfigHaskell) haskell
         return $ concat haskell ++ settingsFromConfigYaml yaml
     where
         (yaml, haskell) = partition (\(x,_) -> lower (takeExtension x) `elem` [".yml",".yaml"]) files
-        yaml' = if any ((takeFileName (fst hlintYaml) ==) . takeFileName . fst) yaml then yaml else hlintYaml : yaml

--- a/src/Config/Read.hs
+++ b/src/Config/Read.hs
@@ -6,11 +6,12 @@ import Config.Haskell
 import Config.Yaml
 import Data.List.Extra
 import System.FilePath
+import EmbedData
 
 
 readFilesConfig :: [(FilePath, Maybe String)] -> IO [Setting]
 readFilesConfig files = do
-        yaml <- mapM (uncurry readFileConfigYaml) yaml
+        yaml <- mapM (uncurry readFileConfigYaml) (hlintYaml : yaml)
         haskell <- mapM (uncurry readFileConfigHaskell) haskell
         return $ concat haskell ++ settingsFromConfigYaml yaml
     where

--- a/src/Config/Read.hs
+++ b/src/Config/Read.hs
@@ -11,8 +11,9 @@ import EmbedData
 
 readFilesConfig :: [(FilePath, Maybe String)] -> IO [Setting]
 readFilesConfig files = do
-        yaml <- mapM (uncurry readFileConfigYaml) (hlintYaml : yaml)
+        yaml <- mapM (uncurry readFileConfigYaml) yaml'
         haskell <- mapM (uncurry readFileConfigHaskell) haskell
         return $ concat haskell ++ settingsFromConfigYaml yaml
     where
         (yaml, haskell) = partition (\(x,_) -> lower (takeExtension x) `elem` [".yml",".yaml"]) files
+        yaml' = if any ((takeFileName (fst hlintYaml) ==) . takeFileName . fst) yaml then yaml else hlintYaml : yaml

--- a/src/EmbedData.hs
+++ b/src/EmbedData.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module EmbedData
+  ( hlintYaml,
+    defaultYaml,
+    reportTemplate,
+  )
+where
+
+import Data.ByteString.UTF8
+import Data.FileEmbed
+
+hlintYaml :: (FilePath, Maybe String)
+hlintYaml = ("data/hlint.yaml", Just $ toString $(embedFile "data/hlint.yaml"))
+
+defaultYaml :: String
+defaultYaml = toString $(embedFile "data/default.yaml")
+
+reportTemplate :: String
+reportTemplate = toString $(embedFile "data/report_template.html")

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -20,7 +20,6 @@ import Data.Version.Extra
 import System.Process.Extra
 import Data.Maybe
 import System.Directory
-import System.FilePath
 
 import CmdLine
 import Config.Read
@@ -37,6 +36,7 @@ import Test.Proof
 import Parallel
 import HSE.All
 import CC
+import EmbedData
 
 
 -- | This function takes a list of command line arguments, and returns the given hints.
@@ -119,9 +119,8 @@ hlintMain args cmd@CmdMain{..}
         ideas <- if null cmdFiles then return [] else withVerbosity Quiet $
             runHlintMain args cmd{cmdJson=False,cmdSerialise=False,cmdRefactor=False} Nothing
         let bad = nubOrd $ map ideaHint ideas
-        src <- readFile $ cmdDataDir </> "default.yaml"
-        if null bad then putStr src else do
-            let group1:groups = splitOn ["",""] $ lines src
+        if null bad then putStr defaultYaml else do
+            let group1:groups = splitOn ["",""] $ lines defaultYaml
             let group2 = "# Warnings currently triggered by your code" :
                          ["- ignore: {name: " ++ show x ++ "}" | x <- bad]
             putStr $ unlines $ intercalate ["",""] $ group1:group2:groups

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, TupleSections #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 
 module HLint(hlint, readAllSettings) where
@@ -87,7 +87,7 @@ hlintTest :: Cmd -> IO ()
 hlintTest cmd@CmdTest{..} =
     if not $ null cmdProof then do
         files <- cmdHintFiles cmd
-        s <- readFilesConfig $ map (,Nothing) files
+        s <- readFilesConfig files
         let reps = if cmdReports == ["report.html"] then ["report.txt"] else cmdReports
         mapM_ (proof reps s) cmdProof
      else do
@@ -153,7 +153,7 @@ readAllSettings args1 cmd@CmdMain{..} = do
     files <- cmdHintFiles cmd
     settings1 <-
         readFilesConfig $
-        map (,Nothing) files
+        files
         ++ [("CommandLine.hs",Just x) | x <- cmdWithHints]
         ++ [("CommandLine.yaml",Just (enableGroup x)) | x <- cmdWithGroups]
     let args2 = [x | SettingArgument x <- settings1]

--- a/src/Report.hs
+++ b/src/Report.hs
@@ -7,18 +7,16 @@ import Data.Tuple.Extra
 import Data.List.Extra
 import Data.Maybe
 import Data.Version
-import System.FilePath
-import System.IO.Extra
 import HSE.All
 import Timing
 import Paths_hlint
 import HsColour
+import EmbedData
 
 
 writeTemplate :: FilePath -> [(String,[String])] -> FilePath -> IO ()
-writeTemplate dataDir content to = do
-    src <- readFile' $ dataDir </> "report_template.html"
-    writeFile to $ unlines $ concatMap f $ lines src
+writeTemplate dataDir content to =
+    writeFile to $ unlines $ concatMap f $ lines reportTemplate
     where
         f ('$':xs) = fromMaybe ['$':xs] $ lookup xs content
         f x = [x]


### PR DESCRIPTION
closes:#699

Embeds data files so the hlint executable is self contained.
This allows for easy packaging with stack and cabal.
And enables hlint to be used as a library without shipping data files.

From https://github.com/ndmitchell/hlint/issues/620#issuecomment-570777653
> ndmitchell would you reconsider the TH approach?
> 
> It's not just nicer for using `hlint` as a library it's nicer when using the executable too. I'm on a 256G laptop and I delete `~/.stack` when ever it gets past 10G. I install hlint using `stack install`, so when I delete `~/.stack` `hlint` has to be rebuilt, just to get 3 data files.
> 
> Here's a [commit](https://github.com/Avi-D-coder/hlint/commit/b50d9cf08e409d4ca20abf37fb541baebff60391) using `file-embed`. The TH is relegated to one file. The executable actually gets slightly smaller `48117184` to `48020968` (GHC 8.8).