### PR TITLE
Upgrade to ghc-lib-parser-ex-8.8.3.0

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -68,7 +68,7 @@ library
         refact >= 0.3,
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1,
-        ghc-lib-parser-ex == 8.8.2
+        ghc-lib-parser-ex == 8.8.3.*
     if !flag(ghc-lib) && impl(ghc >= 8.8.0) && impl(ghc < 8.9.0)
         build-depends:
           ghc == 8.8.*,

--- a/src/GHC/Util/DynFlags.hs
+++ b/src/GHC/Util/DynFlags.hs
@@ -3,7 +3,7 @@ module GHC.Util.DynFlags (baseDynFlags) where
 import DynFlags
 import GHC.LanguageExtensions.Type
 import Data.List.Extra
-import Language.Haskell.GhclibParserEx.Parse
+import Language.Haskell.GhclibParserEx.Config
 
 baseDynFlags :: DynFlags
 baseDynFlags =

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@
 # * https://github.com/commercialhaskell/stackage/issues/4731
 resolver: nightly-2019-08-07
 packages: [.]
-extra-deps: [ghc-lib-parser-8.8.2, ghc-lib-parser-ex-8.8.2]
+extra-deps: [ghc-lib-parser-8.8.2, ghc-lib-parser-ex-8.8.3.0]
 ghc-options:
     "$locals": -Wunused-imports -Worphans -Wunused-top-binds -Wunused-local-binds -Wincomplete-patterns
 # If the compiler is 8.8.*, by default, ghc-lib-parser won't be a


### PR DESCRIPTION
## 8.8.3.0 released 2020-01-25
- Change in versioning scheme;
- New modules:
  - `Language.Haskell.GhclibParserEx.Config`
  - `Language.Haskell.GhclibParserEx.DynFlags`
- `parsePragmasIntoDynFlags` signature change.
