### PR TITLE
Avoid the null...head anti-pattern

### DIFF
--- a/src/GHC/Util/Scope.hs
+++ b/src/GHC/Util/Scope.hs
@@ -19,6 +19,7 @@ import GHC.Util.RdrName
 import Outputable
 
 import Data.List
+import Data.List.Extra
 import Data.Maybe
 
 -- A scope is a list of import declarations.
@@ -66,10 +67,10 @@ scopeMatch' (a, x) (b, y)
 -- scope that will refer to the same thing. If the resulting name is
 -- ambiguous, pick a plausible candidate.
 scopeMove' :: (Scope', Located RdrName) -> Scope' -> Located RdrName
-scopeMove' (a, x@(fromQual' -> Just name)) (Scope' b)
-  | null imps = head $ real ++ [x]
-  | all ideclQualified imps = noLoc $ mkRdrQual (unLoc $ head (mapMaybe ideclAs imps ++ map ideclName imps)) name
-  | otherwise = unqual' x
+scopeMove' (a, x@(fromQual' -> Just name)) (Scope' b) = case imps of
+  [] -> head $ real ++ [x]
+  (imp:_) | all ideclQualified imps -> noLoc $ mkRdrQual (unLoc . fromMaybe (ideclName imp) $ firstJust ideclAs imps) name
+          | otherwise -> unqual' x
   where
     real :: [Located RdrName]
     real = [noLoc $ mkRdrQual (mkModuleName m) name | m <- possModules' a x]

--- a/src/GHC/Util/Scope.hs
+++ b/src/GHC/Util/Scope.hs
@@ -70,7 +70,7 @@ scopeMove' :: (Scope', Located RdrName) -> Scope' -> Located RdrName
 scopeMove' (a, x@(fromQual' -> Just name)) (Scope' b) = case imps of
   [] -> head $ real ++ [x]
   imp:_ | all ideclQualified imps -> noLoc $ mkRdrQual (unLoc . fromMaybe (ideclName imp) $ firstJust ideclAs imps) name
-          | otherwise -> unqual' x
+        | otherwise -> unqual' x
   where
     real :: [Located RdrName]
     real = [noLoc $ mkRdrQual (mkModuleName m) name | m <- possModules' a x]

--- a/src/GHC/Util/Scope.hs
+++ b/src/GHC/Util/Scope.hs
@@ -69,7 +69,7 @@ scopeMatch' (a, x) (b, y)
 scopeMove' :: (Scope', Located RdrName) -> Scope' -> Located RdrName
 scopeMove' (a, x@(fromQual' -> Just name)) (Scope' b) = case imps of
   [] -> head $ real ++ [x]
-  (imp:_) | all ideclQualified imps -> noLoc $ mkRdrQual (unLoc . fromMaybe (ideclName imp) $ firstJust ideclAs imps) name
+  imp:_ | all ideclQualified imps -> noLoc $ mkRdrQual (unLoc . fromMaybe (ideclName imp) $ firstJust ideclAs imps) name
           | otherwise -> unqual' x
   where
     real :: [Located RdrName]


### PR DESCRIPTION
Checking `null` of a list and then using `head` if it's not is an anti-pattern. Case-match instead.