### PR TITLE
Upgrade haskell-src-exts

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,10 @@
 # * https://github.com/commercialhaskell/stackage/issues/4731
 resolver: nightly-2020-01-25
 packages: [.]
-extra-deps: [ghc-lib-parser-8.8.2, ghc-lib-parser-ex-8.8.3.0]
+extra-deps:
+  - ghc-lib-parser-8.8.2
+  - ghc-lib-parser-ex-8.8.3.0
+  - haskell-src-exts-1.23.0
 ghc-options:
     "$locals": -Wunused-imports -Worphans -Wunused-top-binds -Wunused-local-binds -Wincomplete-patterns
 # If the compiler is 8.8.*, by default, ghc-lib-parser won't be a


### PR DESCRIPTION
- Newly added tests break unless on `haskell-src-exts-1.23.0`; fix cabal;
- This version isn't in the stackage nightlies yet; fix stack.yaml