### PR TITLE
Add a rule for "maybe Nothing Just"

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -516,6 +516,7 @@
     # MAYBE
 
     - warn: {lhs: maybe x id, rhs: Data.Maybe.fromMaybe x}
+    - warn: {lhs: maybe Nothing Just, rhs: id, name: Redundant maybe}
     - warn: {lhs: maybe False (const True), rhs: Data.Maybe.isJust}
     - warn: {lhs: maybe True (const False), rhs: Data.Maybe.isNothing}
     - warn: {lhs: maybe False (== x), rhs: (== Just x)}


### PR DESCRIPTION
This seems contrived at first glance, but I've seen it in real code, such as https://github.com/jgm/pandoc/blob/b47a3cdcb6b9ecc302567fa28b05459810e03095/src/Text/Pandoc/PDF.hs#L156-L159