### PR TITLE
Fix sortBy hints

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -99,8 +99,8 @@
     - warn: {lhs: head (sortBy f x), rhs: minimumBy f x, side: isCompare f}
     - warn: {lhs: last (sortBy f x), rhs: maximumBy f x, side: isCompare f}
     - warn: {lhs: reverse (sortBy f x), rhs: sortBy (flip f) x, name: Avoid reverse, side: isCompare f, note: Stabilizes sort order}
-    - warn: {lhs: sortBy (comparing (flip f)), rhs: sortOn (Down . f)}
-    - warn: {lhs: sortBy (comparing f), rhs: sortOn f}
+    - warn: {lhs: sortBy (flip (comparing f)), rhs: sortOn (Down . f)}
+    - warn: {lhs: sortBy (comparing f), rhs: sortOn f, side: notEq f fst && notEq f snd}
     - warn: {lhs: reverse (sortOn f x), rhs: sortOn (Data.Ord.Down . f) x, name: Avoid reverse, note: Stabilizes sort order}
     - warn: {lhs: reverse (sort x), rhs: sortOn Data.Ord.Down x, name: Avoid reverse, note: Stabilizes sort order}
     - hint: {lhs: flip (g `on` h), rhs: flip g `on` h, name: Move flip}

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1039,7 +1039,7 @@
 # main = hello .~ Just 12 -- hello ?~ 12
 # foo = liftIO $ window `on` deleteEvent $ do a; b
 # no = sort <$> f input `shouldBe` sort <$> x
-# sortBy (comparing snd) -- sortOn snd
+# sortBy (comparing length) -- sortOn length
 # myJoin = on $ child ^. ChildParentId ==. parent ^. ParentId
 # foo = typeOf (undefined :: Foo Int) -- typeRep (Proxy :: Proxy (Foo Int))
 # foo = typeOf (undefined :: a) -- typeRep (Proxy :: Proxy a)


### PR DESCRIPTION
1. The `flip` was in the wrong place
2. `sortOn` isn't actually better than `sortBy` when the function is as cheap as `fst` or `snd`. Looking at [the definition](https://hackage.haskell.org/package/base-4.12.0.0/docs/src/Data.OldList.html#sortOn) will reveal why.