### PR TITLE
ghc-lib-parser 8.8.2.20200205

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Changelog for HLint (* = breaking change)
 
+2.2.10, released 2020-02-02
     #846, add splitAt warnings
     #774, don't warn about 'Redundant compare' in == and /=
 2.2.9, released 2020-01-27

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Changelog for HLint (* = breaking change)
 
+    #852, change maybe to fromMaybe, when the function is duplicated
     #851, add a rule for maybe Nothing Just
 2.2.10, released 2020-02-02
     #846, add splitAt warnings

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Changelog for HLint (* = breaking change)
 
+    #851, add a rule for maybe Nothing Just
 2.2.10, released 2020-02-02
     #846, add splitAt warnings
     #774, don't warn about 'Redundant compare' in == and /=

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Changelog for HLint (* = breaking change)
 
+    #854, add more generalise-for-conciseness hints for Either/Maybe
     #852, change maybe to fromMaybe, when the function is duplicated
     #851, add a rule for maybe Nothing Just
 2.2.10, released 2020-02-02

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -553,6 +553,7 @@
     - hint: {lhs: maybe Nothing id, rhs: join}
     - hint: {lhs: maybe Nothing f x, rhs: f =<< x}
     - hint: {lhs: maybe (f x) (f . g), rhs: f . maybe x g, note: IncreasesLaziness, name: Too strict maybe}
+    - hint: {lhs: maybe (f x) f y, rhs: f (Data.Maybe.fromMaybe x y), note: IncreasesLaziness, name: Too strict maybe}
     - warn: {lhs: maybe x f (fmap g y), rhs: maybe x (f . g) y, name: Redundant fmap}
     - warn: {lhs: isJust (fmap f x), rhs: isJust x}
     - warn: {lhs: isNothing (fmap f x), rhs: isNothing x}

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -516,6 +516,7 @@
     # MAYBE
 
     - warn: {lhs: maybe x id, rhs: Data.Maybe.fromMaybe x}
+    - warn: {lhs: maybe Nothing Just, rhs: id, name: Redundant maybe}
     - warn: {lhs: maybe False (const True), rhs: Data.Maybe.isJust}
     - warn: {lhs: maybe True (const False), rhs: Data.Maybe.isNothing}
     - warn: {lhs: maybe False (== x), rhs: (== Just x)}

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -814,9 +814,17 @@
     - warn: {lhs: Data.Maybe.fromMaybe mempty, rhs: Data.Foldable.fold}
     - warn: {lhs: Data.Maybe.fromMaybe False, rhs: or}
     - warn: {lhs: Data.Maybe.fromMaybe True, rhs: and}
+    - warn: {lhs: Data.Maybe.fromMaybe 0, rhs: sum}
+    - warn: {lhs: Data.Maybe.fromMaybe 1, rhs: product}
+    - warn: {lhs: Data.Maybe.fromMaybe empty, rhs: Data.Foldable.asum}
+    - warn: {lhs: Data.Maybe.fromMaybe mzero, rhs: Data.Foldable.msum}
     - warn: {lhs: Data.Either.fromRight mempty, rhs: Data.Foldable.fold}
     - warn: {lhs: Data.Either.fromRight False, rhs: or}
     - warn: {lhs: Data.Either.fromRight True, rhs: and}
+    - warn: {lhs: Data.Either.fromRight 0, rhs: sum}
+    - warn: {lhs: Data.Either.fromRight 1, rhs: product}
+    - warn: {lhs: Data.Either.fromRight empty, rhs: Data.Foldable.asum}
+    - warn: {lhs: Data.Either.fromRight mzero, rhs: Data.Foldable.msum}
     - warn: {lhs: if f x then Just x else Nothing, rhs: mfilter f (Just x)}
     - hint: {lhs: maybe (pure ()), rhs: traverse_, note: IncreasesLaziness}
     - hint: {lhs: fromMaybe (pure ()), rhs: sequenceA_, note: IncreasesLaziness}

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -1,7 +1,7 @@
 cabal-version:      >= 1.18
 build-type:         Simple
 name:               hlint
-version:            2.2.9
+version:            2.2.10
 license:            BSD3
 license-file:       LICENSE
 category:           Development

--- a/src/GHC/Util/FreeVars.hs
+++ b/src/GHC/Util/FreeVars.hs
@@ -30,7 +30,7 @@ import Prelude
 ( ^- ) :: Set OccName -> Set OccName -> Set OccName
 ( ^- ) = Set.difference
 
--- See [Note : Spack leaks lurking here?] below.
+-- See [Note : Space leaks lurking here?] below.
 data Vars' = Vars'{bound' :: Set OccName, free' :: Set OccName}
 
 -- Useful for debugging.

--- a/src/Hint/Import.hs
+++ b/src/Hint/Import.hs
@@ -73,8 +73,9 @@ importHint _ ModuleEx {ghcModule=L _ HsModule{hsmodImports=ms}} =
   concatMap preferHierarchicalImports ms
 
 reduceImports :: [LImportDecl GhcPs] -> [Idea]
-reduceImports ms =
-  [rawIdea' Hint.Type.Warning "Use fewer imports" (getLoc $ head ms) (f ms) (Just $ f x) [] rs
+reduceImports [] = []
+reduceImports ms@(m:_) =
+  [rawIdea' Hint.Type.Warning "Use fewer imports" (getLoc m) (f ms) (Just $ f x) [] rs
   | Just (x, rs) <- [simplify ms]]
   where f = unlines . map unsafePrettyPrint
 

--- a/src/Hint/Monad.hs
+++ b/src/Hint/Monad.hs
@@ -133,8 +133,8 @@ monadStep :: ([ExprLStmt GhcPs] -> LHsExpr GhcPs)
            -> [ExprLStmt GhcPs] -> [Idea]
 
 -- Rewrite 'do return x; $2' as 'do $2'.
-monadStep wrap o@(LL _ (BodyStmt _ (fromRet -> Just (ret, _)) _ _ ) : x : xs)
-  = [warn' ("Redundant " ++ ret) (wrap o) (wrap $ x:xs) [Delete Stmt (toSS' (head o))]]
+monadStep wrap os@(o@(LL _ (BodyStmt _ (fromRet -> Just (ret, _)) _ _ )) : xs@(_:_))
+  = [warn' ("Redundant " ++ ret) (wrap os) (wrap xs) [Delete Stmt (toSS' o)]]
 
 -- Rewrite 'do a <- $1; return a' as 'do $1'.
 monadStep wrap o@[ g@(LL _ (BindStmt _ (LL _ (VarPat _ (L _ p))) x _ _ ))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,7 @@
-# Because hsdev hasn't upgraded we need our own Snapshot, see:
-# * https://github.com/commercialhaskell/stackage/issues/4673
-# * https://github.com/commercialhaskell/stackage/issues/4731
 resolver: nightly-2019-08-07 # Don't roll to an 8.8.1 or 8.8.2 resolver because of the Windows linker bug
 packages: [.]
 extra-deps:
-  - ghc-lib-parser-8.8.2
+  - ghc-lib-parser-8.8.2.20200205
   - ghc-lib-parser-ex-8.8.4.0
   - haskell-src-exts-1.23.0
 ghc-options:


### PR DESCRIPTION
This changes `extra-deps` in stack.yaml to use `ghc-lib-parser 8.8.2.20200205`. Not critical that this gets merged but it's helpful to me to keep this straight. No changes to any functionality or tests expected here.