### PR TITLE
Upgrade to ghc-lib-parser-8.8.2.20200205

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@
 resolver: nightly-2019-08-07 # Don't roll to an 8.8.1 or 8.8.2 resolver because of the Windows linker bug
 packages: [.]
 extra-deps:
-  - ghc-lib-parser-8.8.2
+  - ghc-lib-parser-8.8.2.20200205
   - ghc-lib-parser-ex-8.8.4.0
   - haskell-src-exts-1.23.0
 ghc-options:


### PR DESCRIPTION
This changes `extra-deps` in stack.yaml to use `ghc-lib-parser 8.8.2.20200205`. Not critical that this gets merged but it's helpful to me to keep this straight. No changes to any functionality or tests expected here.