### PR TITLE
Upgrade to ghc-lib-parser-ex-8.8.5.0

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -8,4 +8,4 @@
 
 - message:
   - name: Redundant build-depends entry
-  - depends: [ghc-lib, ghc, ghc-boot-th] # Only some subset is supported
+  - depends: [ghc-lib, ghc, ghc-boot-th, ghc-boot] # Only some subset is supported

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -68,11 +68,12 @@ library
         refact >= 0.3,
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1,
-        ghc-lib-parser-ex == 8.8.4.*
+        ghc-lib-parser-ex == 8.8.5.*
     if !flag(ghc-lib) && impl(ghc >= 8.8.0) && impl(ghc < 8.9.0)
         build-depends:
           ghc == 8.8.*,
-          ghc-boot-th
+          ghc-boot-th,
+          ghc-boot
     else
         build-depends:
           ghc-lib-parser == 8.8.*

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ resolver: nightly-2019-08-07 # Don't roll to an 8.8.1 or 8.8.2 resolver because 
 packages: [.]
 extra-deps:
   - ghc-lib-parser-8.8.2.20200205
-  - ghc-lib-parser-ex-8.8.4.0
+  - ghc-lib-parser-ex-8.8.5.1
   - haskell-src-exts-1.23.0
 ghc-options:
     "$locals": -Wunused-imports -Worphans -Wunused-top-binds -Wunused-local-binds -Wincomplete-patterns


### PR DESCRIPTION
## 8.8.5.0 released 2020-02-07
- Expose `impliedGFlags` and friends from `DynFlags` (https://github.com/shayne-fletcher/ghc-lib-parser-ex/issues/19, https://github.com/ndmitchell/hlint/issues/587).
