### PR TITLE
Add brackets to refactor templates when needed

### DIFF
--- a/src/GHC/Util/HsExpr.hs
+++ b/src/GHC/Util/HsExpr.hs
@@ -222,18 +222,20 @@ needBracketOld' i parent child
 transformBracketOld' :: (LHsExpr GhcPs -> Maybe (LHsExpr GhcPs)) -> LHsExpr GhcPs -> (LHsExpr GhcPs, LHsExpr GhcPs)
 transformBracketOld' op = first snd . g
   where
-    g = first f . descendBracketOld' (fst . g)
+    g = first f . descendBracketOld' g
     f x = maybe (False, x) (True, ) (op x)
 
 -- Descend, and if something changes then add/remove brackets
 -- appropriately. Returns (suggested replacement, refactor template).
 -- Whenever a bracket is added to the suggested replacement, a
 -- corresponding bracket is added to the refactor template.
-descendBracketOld' :: (LHsExpr GhcPs -> (Bool, LHsExpr GhcPs)) -> LHsExpr GhcPs -> (LHsExpr GhcPs, LHsExpr GhcPs)
+descendBracketOld' :: (LHsExpr GhcPs -> ((Bool, LHsExpr GhcPs), LHsExpr GhcPs))
+                   -> LHsExpr GhcPs
+                   -> (LHsExpr GhcPs, LHsExpr GhcPs)
 descendBracketOld' op x = (descendIndex' g1 x, descendIndex' g2 x)
   where
-    g i y = if a then (f1 i b y, f2 i b y) else (b, y)
-      where (a, b) = op y
+    g i y = if a then (f1 i b z, f2 i b z) else (b, z)
+      where ((a, b), z) = op y
 
     g1 = (fst .) . g
     g2 = (snd .) . g

--- a/src/GHC/Util/Unify.hs
+++ b/src/GHC/Util/Unify.hs
@@ -58,7 +58,10 @@ validSubst' eq = fmap Subst' . mapM f . groupSort . fromSubst'
           f _ = Nothing
 
 -- Peform a substition.
-substitute' :: Subst' (LHsExpr GhcPs) -> LHsExpr GhcPs -> LHsExpr GhcPs
+-- Returns (suggested replacement, refactor template), both with brackets added
+-- as needed.
+-- Example: (traverse foo (bar baz), traverse f (x))
+substitute' :: Subst' (LHsExpr GhcPs) -> LHsExpr GhcPs -> (LHsExpr GhcPs, LHsExpr GhcPs)
 substitute' (Subst' bind) = transformBracketOld' exp . transformBi pat . transformBi typ
   where
     exp :: LHsExpr GhcPs -> Maybe (LHsExpr GhcPs)


### PR DESCRIPTION
Fixes #656 
Also fixes
```
- sequenceA $ fmap sum $ sequenceA foo
+ traverse sum sequenceA foo
```
reported in #499. This is caused by hlint asking apply-refact to substitute `sequenceA foo` for `x` in the refactor template, `traverse f x`. The one reported in #656 is similar.

This PR adds brackets to the refactor template whenever brackets are added to the suggested replacement. In this particular case the refactor template becomes `traverse f (x)`, which refactors correctly.