### PR TITLE
Set SrcSpan correctly in serialised list hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ TAGS
 /.hpc/
 /.stack-work/
 /cc/.stack-work/
+stack.yaml.lock
 /issues/
 /Sample.hs
 /hlint.prof

--- a/src/Hint/List.hs
+++ b/src/Hint/List.hs
@@ -217,7 +217,7 @@ useList b =
     f first _ _ = Nothing
 
     g :: Char -> LHsExpr GhcPs -> (String, LHsExpr GhcPs)
-    g c p = ([c], strToVar [c])
+    g c p = let LL _ e = strToVar [c] in ([c], LL (getLoc p) e)
 
 useCons :: View' a App2' => Bool -> a -> Maybe (LHsExpr GhcPs, [(String, R.SrcSpan)], String)
 useCons False (view' -> App2' op x y) | varToStr op == "++"


### PR DESCRIPTION
```haskell
-- List.hs
x = 12 : 345 : []
```

Before (breaks refactoring):

```
[("List.hs:1:5: Suggestion: Use list literal\nFound:\n  12 : 345 : []\nPerhaps:\n
 [12, 345]\n",[Replace {rtype = Expr, pos = SrcSpan {startLine = 1, startCol = 5,
endLine = 1, endCol = 18}, subts = [("a",SrcSpan {startLine = -1, startCol = -1,
endLine = -1, endCol = -1}),("b",SrcSpan {startLine = -1, startCol = -1,
endLine = -1, endCol = -1})], orig = "[a, b]"}])]
```

After:

```
[("List.hs:1:5: Suggestion: Use list literal\nFound:\n  12 : 345 : []\nPerhaps:\n 
[12, 345]\n",[Replace {rtype = Expr, pos = SrcSpan {startLine = 1, startCol = 5,
endLine = 1, endCol = 18}, subts = [("a",SrcSpan {startLine = 1, startCol = 5,
endLine = 1, endCol = 7}),("b",SrcSpan {startLine = 1, startCol = 10,
endLine = 1, endCol = 13})], orig = "[a, b]"}])]
```