### PR TITLE
Fix a few more missing SrcSpans

### DIFF
--- a/src/Hint/List.hs
+++ b/src/Hint/List.hs
@@ -43,7 +43,7 @@ import Data.List.Extra
 import Data.Maybe
 import Prelude
 
-import Hint.Type(DeclHint',Idea,suggest',toSS')
+import Hint.Type(DeclHint',Idea,suggest',toRefactSrcSpan',toSS')
 
 import Refact.Types hiding (SrcSpan)
 import qualified Refact.Types as R
@@ -180,7 +180,7 @@ usePList :: Pat GhcPs -> Maybe (Pat GhcPs, [(String, R.SrcSpan)], String)
 usePList =
   fmap  ( (\(e, s) ->
              (noLoc (ListPat noExt e)
-             , map (fmap toSS') s
+             , map (fmap toRefactSrcSpan' . fst) s
              , unsafePrettyPrint (noLoc $ ListPat noExt (map snd s) :: Pat GhcPs))
           )
           . unzip
@@ -191,8 +191,8 @@ usePList =
     f first (ident:cs) (view' -> PApp_' ":" [a, b]) = ((a, g ident a) :) <$> f False cs b
     f first _ _ = Nothing
 
-    g :: Char -> Pat GhcPs -> (String, Pat GhcPs)
-    g c p = ([c], VarPat noExt (noLoc $ mkVarUnqual (fsLit [c])))
+    g :: Char -> Pat GhcPs -> ((String, SrcSpan), Pat GhcPs)
+    g c (getLoc -> loc) = (([c], loc), VarPat noExt (noLoc $ mkVarUnqual (fsLit [c])))
 
 useString :: p -> LHsExpr GhcPs -> Maybe (LHsExpr GhcPs, [a], String)
 useString b (LL _ (ExplicitList _ _ xs)) | not $ null xs, Just s <- mapM fromChar xs =

--- a/src/Hint/Pattern.hs
+++ b/src/Hint/Pattern.hs
@@ -209,7 +209,7 @@ patHint lang strict o@(LL _ (BangPat _ pat@(LL _ x)))
     f (SigPat _ (LL _ p) _) = f p
     f _ = False
     r = Replace R.Pattern (toSS' o) [("x", toSS' pat)] "x"
-patHint False _ o@(LL _ (LazyPat _ (LL _ x)))
+patHint False _ o@(LL _ (LazyPat _ pat@(LL _ x)))
   | f x = [warn' "Redundant irrefutable pattern" o x [r]]
   where
     f :: Pat GhcPs -> Bool
@@ -218,7 +218,7 @@ patHint False _ o@(LL _ (LazyPat _ (LL _ x)))
     f WildPat{} = True
     f VarPat{} = True
     f _ = False
-    r = Replace R.Pattern (toSS' o) [("x", toSS' x)] "x"
+    r = Replace R.Pattern (toSS' o) [("x", toSS' pat)] "x"
 patHint _ _ o@(LL _ (AsPat _ v (LL _ (WildPat _)))) =
   [warn' "Redundant as-pattern" o v []]
 patHint _ _ _ = []

--- a/src/Hint/Pattern.hs
+++ b/src/Hint/Pattern.hs
@@ -195,7 +195,7 @@ patHint _ _ o@(LL _ (ConPatIn name (PrefixCon args)))
 patHint _ _ o@(LL _ (VarPat _ (L _ name)))
   | occNameString (rdrNameOcc name) == "otherwise" =
     [warn' "Used otherwise as a pattern" o (noLoc (WildPat noExt) :: Pat GhcPs) []]
-patHint lang strict o@(LL _ (BangPat _ (LL _ x)))
+patHint lang strict o@(LL _ (BangPat _ pat@(LL _ x)))
   | strict, f x = [warn' "Redundant bang pattern" o x [r]]
   where
     f :: Pat GhcPs -> Bool
@@ -208,7 +208,7 @@ patHint lang strict o@(LL _ (BangPat _ (LL _ x)))
     f ListPat {} = True
     f (SigPat _ (LL _ p) _) = f p
     f _ = False
-    r = Replace R.Pattern (toSS' o) [("x", toSS' x)] "x"
+    r = Replace R.Pattern (toSS' o) [("x", toSS' pat)] "x"
 patHint False _ o@(LL _ (LazyPat _ (LL _ x)))
   | f x = [warn' "Redundant irrefutable pattern" o x [r]]
   where

--- a/src/Refact.hs
+++ b/src/Refact.hs
@@ -1,5 +1,5 @@
 module Refact
-    ( toRefactSrcSpan
+    ( toRefactSrcSpan, toRefactSrcSpan'
     , toSS, toSS'
     , toSrcSpan'
     ) where
@@ -14,6 +14,9 @@ toRefactSrcSpan ss = R.SrcSpan (srcSpanStartLine ss)
                                (srcSpanStartColumn ss)
                                (srcSpanEndLine ss)
                                (srcSpanEndColumn ss)
+
+toRefactSrcSpan' :: GHC.SrcSpan -> R.SrcSpan
+toRefactSrcSpan' = toRefactSrcSpan . ghcSpanToHSE
 
 toSS :: Annotated a => a S -> R.SrcSpan
 toSS = toRefactSrcSpan . srcInfoSpan . ann
@@ -31,4 +34,4 @@ toSrcSpan' x = case GHC.getLoc x of
         R.SrcSpan 0 0 0 0
 
 toSS' :: GHC.HasSrcSpan e => e -> R.SrcSpan
-toSS' = toRefactSrcSpan . ghcSpanToHSE . GHC.getLoc
+toSS' = toRefactSrcSpan' . GHC.getLoc


### PR DESCRIPTION
Fixes the following:

```
[("Foo.hs:1:17: Warning: Redundant bang pattern\nFound:\n  !True\n
Perhaps:\n  True\n",[Replace {rtype = Pattern, pos = SrcSpan {startLine = 1,
startCol = 17, endLine = 1, endCol = 22}, subts = [("x",SrcSpan {startLine = -1,
startCol = -1, endLine = -1, endCol = -1})], orig = "x"}])]
```

```
[("Foo.hs:1:11: Warning: Redundant irrefutable pattern\nFound:\n  ~x\n
Perhaps:\n  x\n",[Replace {rtype = Pattern, pos = SrcSpan {startLine = 1,
startCol = 11, endLine = 1, endCol = 13}, subts = [("x",SrcSpan {startLine = -1,
startCol = -1, endLine = -1, endCol = -1})], orig = "x"}])]
```

```
[("Foo.hs:1:5: Suggestion: Use list literal pattern\nFound:\n  (1 : 2 : [])\n
Perhaps:\n  [1, 2]\n",[Replace {rtype = Pattern, pos = SrcSpan {startLine = 1,
startCol = 5, endLine = 1, endCol = 13}, subts = [("a",SrcSpan {startLine = -1,
startCol = -1, endLine = -1, endCol = -1}),("b",SrcSpan {startLine = -1,
startCol = -1, endLine = -1, endCol = -1})], orig = "[a, b]"}])]
```