### PR TITLE
Remove more incorrect hints

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -885,8 +885,6 @@
     - warn: {lhs: "null (intersect a b)", rhs: "disjoint a b"}
     - warn: {lhs: "[minBound .. maxBound]", rhs: "enumerate"}
     - warn: {lhs: "zipWithFrom (,)", rhs: "zipFrom"}
-    - warn: {lhs: "zip [i..]", rhs: "zipFrom i"}
-    - warn: {lhs: "zipWith f [i..]", rhs: "zipWithFrom f i"}
     - warn: {lhs: "dropWhile isSpace", rhs: "trimStart"}
     - warn: {lhs: "dropWhileEnd isSpace", rhs: "trimEnd"}
     - warn: {lhs: "trimEnd (trimStart a)", rhs: "trim a"}


### PR DESCRIPTION
`length (zipFrom LT "foobar")` bottoms, whereas `length (zip [LT ..] "foobar")` returns 3.