### PR TITLE
Update to ghc-lib-parser-8.8.3.20200224.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,10 +2,14 @@
 # * https://github.com/commercialhaskell/stackage/issues/4673
 # * https://github.com/commercialhaskell/stackage/issues/4731
 resolver: nightly-2019-08-07 # Don't roll to an 8.8.1 or 8.8.2 resolver because of the Windows linker bug
-packages: [.]
+packages:
+  - .
 extra-deps:
-  - ghc-lib-parser-8.8.2.20200205
+  - ghc-lib-parser-8.8.3.20200224
   - ghc-lib-parser-ex-8.8.5.2
+# To test hlint against experimental builds of ghc-lib-parser-ex,
+# modify extra-deps like this:
+#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.8.5.3.tar.gz
   - haskell-src-exts-1.23.0
   - extra-1.6.19
 ghc-options:


### PR DESCRIPTION
As before, non-critical, just helping me keep things straight. Change `stack.yaml` to reference the just released `ghc-lib-parser-8.8.3.20200224`.