### PR TITLE
Expand variables in orig if the substitution has no loc

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -986,7 +986,7 @@
 # yes = if foo then do stuff; moreStuff; lastOfTheStuff else return () \
 #     -- Control.Monad.when foo $ do stuff ; moreStuff ; lastOfTheStuff @NoRefactor: hlint bug
 # yes = if foo then stuff else return () -- Control.Monad.when foo stuff
-# yes = foo $ \(a, b) -> (a, y + b) -- Data.Bifunctor.second ((+) y) @NoRefactor: hlint bug, subts = []
+# yes = foo $ \(a, b) -> (a, y + b) -- Data.Bifunctor.second ((+) y)
 # no  = foo $ \(a, b) -> (a, a + b)
 # yes = map (uncurry (+)) $ zip [1 .. 5] [6 .. 10] -- zipWith (curry (uncurry (+))) [1 .. 5] [6 .. 10]
 # yes = curry (uncurry (+)) -- (+)
@@ -1014,7 +1014,7 @@
 # yes = case x z of Nothing -> y; Just pat -> pat -- Data.Maybe.fromMaybe y (x z)
 # yes = if p then s else return () -- Control.Monad.when p s
 # warn = a $$$$ b $$$$ c ==> a . b $$$$$ c
-# yes = when (not . null $ asdf) -- unless (null asdf) @NoRefactor: hlint bug, subts = []
+# yes = when (not . null $ asdf) -- unless (null asdf)
 # yes = id 1 -- 1
 # yes = case concat (map f x) of [] -> [] -- concatMap f x
 # yes = [v | v <- xs] -- xs

--- a/src/GHC/Util/HsExpr.hs
+++ b/src/GHC/Util/HsExpr.hs
@@ -289,12 +289,14 @@ descendBracketOld' op x = (descendIndex' g1 x, descendIndex' g2 x)
     g1 = (fst .) . g
     g2 = (snd .) . g
 
-    f i (L _ (HsPar _ y)) z | not $ needBracketOld' i x y = (y, z)
-    f i y z                  | needBracketOld' i x y = (addParen' y, addParen' z)
-    f _ y z                  = (y, z)
+    f i (L _ (HsPar _ y)) z | not $ needBracketOld' i x y = (y, y `ifNoLocElse` z)
+    f i y z                 | needBracketOld' i x y = (addParen' y, addParen' (y `ifNoLocElse` z))
+    f _ y z                 = (y, y `ifNoLocElse` z)
 
     f1 = ((fst .) .) . f
     f2 = ((snd .) .) . f
+
+    ifNoLocElse y z = if getLoc y == noSrcSpan then y else z
 
 reduce' :: LHsExpr GhcPs -> LHsExpr GhcPs
 reduce' = fromParen' . transform reduce1'


### PR DESCRIPTION
This fixes a couple of refactor tests, for instance

```haskell
yes = foo $ \(a, b) -> (a, y + b)
```

Before:
```
--serialise
[("/home/ziyangliu/ana/Foo.hs:1:13: Suggestion: Use second\nFound:\n  \\ (a, b) ->
(a, y + b)\nPerhaps:\n  Data.Bifunctor.second ((+) y)\nNote: increases laziness\n",
[Replace {rtype = Expr, pos = SrcSpan {startLine = 1, startCol = 13, endLine = 1,
endCol = 34}, subts = [], orig = "Data.Bifunctor.second (f)"}])]

--refactor
yes = foo $ Data.Bifunctor.second (f)
```

The bad refactoring is caused by `subts = []`, which is in turn caused by the substitution having no loc, because the substitution is `(+) y` which does not appear in the original code.

After (`orig` is expanded):

```
--serialise
[("/home/ziyangliu/ana/Foo.hs:1:13: Suggestion: Use second\nFound:\n  \\ (a, b) ->
(a, y + b)\nPerhaps:\n  Data.Bifunctor.second ((+) y)\nNote: increases laziness\n",
[Replace {rtype = Expr, pos = SrcSpan {startLine = 1, startCol = 13, endLine = 1,
endCol = 34}, subts = [], orig = "Data.Bifunctor.second ((+) y)"}])]

--refactor
yes = foo $ Data.Bifunctor.second ((+) y)
```

