### PR TITLE
Clarify missing refactor error message

### DIFF
--- a/src/Refact.hs
+++ b/src/Refact.hs
@@ -50,7 +50,12 @@ refactorPath rpath = do
             pure $ if versionBranch ver >= [0,1,0,0]
                        then Right exc
                        else Left "Your version of refactor is too old, please upgrade to the latest version"
-        Nothing -> pure $ Left $ unlines [ "Could not find refactor", "Tried with: " ++ excPath ]
+        Nothing -> pure $ Left $ unlines
+                       [ "Could not find 'refactor' executable"
+                       , "Tried to find '" ++ excPath ++ "' on the PATH"
+                       , "'refactor' is provided by the 'apply-refact' package and has to be installed"
+                       , "<https://github.com/mpickering/apply-refact>"
+                       ]
 
 runRefactoring :: FilePath -> FilePath -> FilePath -> String -> IO ExitCode
 runRefactoring rpath fin hints opts =  do


### PR DESCRIPTION
I didn't know about the external tool `refactor`. This is the error message that currently occurs. I think it might be helpful to clarify `refactor` is an executable and not a command line argument, a hint that can be refactored or other internal stuff.

```shell
hlint src/Log.hs
src/Log.hs:20:35: Warning: Redundant bracket
Found:
  (minLogLevel)
Perhaps:
  minLogLevel

1 hint

hlint src/Log.hs --refactor
hlint: Could not find refactor
Tried with: refactor

CallStack (from HasCallStack):
  error, called at src/HLint.hs:251:20 in hlint-2.2.2-JJ80rphq264GBRgLnOQWMf:HLint
```