### PR TITLE
Add ParseMode', defaultParseMode'; upgrade ghc-lib-parser-ex-8.8.5.4

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -3,5 +3,9 @@
 ##########################
 
 - message:
+  - name: Weeds exported
+  - identifier: [ParseMode', defaultParseMode', isAssocLeft, isAssocNone] # Last two weeder bugs?
+
+- message:
   - name: Redundant build-depends entry
   - depends: [ghc-lib, ghc, ghc-boot-th, ghc-boot] # Only some subset is supported

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -9,6 +9,8 @@ module HSE.All(
     ParseError(..), ModuleEx(..),
     parseModuleEx, ghcComments,
     parseExpGhcWithMode, parseImportDeclGhcWithMode, parseDeclGhcWithMode,
+-- Not used yet.
+    ParseMode', defaultParseMode'
     ) where
 
 import Util
@@ -70,6 +72,29 @@ defaultParseMode = ParseMode {
         fixities = Just preludeFixities
         }
 
+data Language' =
+    Haskell98'
+  | Haskell2010'
+  | HaskellAllDisabled'
+  | UnknownLanguage' String
+  deriving (Eq, Ord, Read, Show)
+
+data ParseMode' = ParseMode'
+  {
+  -- | base language (e.g. Haskell98, Haskell2010)
+     ghcBaseLanguage :: Language'
+  -- | list of extensions enabled for parsing
+  , ghcExtensions :: [GHC.Extension]
+  -- | list of fixities to be aware of
+   , ghcFixities :: Maybe [(String, GHC.Fixity)]
+  }
+
+defaultParseMode' :: ParseMode'
+defaultParseMode' = ParseMode'
+  {   ghcBaseLanguage = Haskell2010'
+    , ghcExtensions = []
+    , ghcFixities = Just GhclibParserEx.preludeFixities
+  }
 
 lensFixities :: [Fixity]
 lensFixities = concat

--- a/src/HSE/Util.hs
+++ b/src/HSE/Util.hs
@@ -1,41 +1,12 @@
 
 module HSE.Util(
-    getFixity,
-    toInfixDecl, extensionImpliedBy,
-    extensionImplies,
+    extensionImpliedBy,
+    extensionImplies
     ) where
 
-import Control.Monad
-import Data.List.Extra
 import qualified Data.Map as Map
-import Data.Maybe
-import Data.Functor
-import Prelude
 import qualified Language.Haskell.GhclibParserEx.DynFlags as GhclibParserEx
-import Language.Haskell.Exts(QName(..), Name(..), Decl(..), Fixity(..), Op(..), Extension(..), parseExtension)
-
----------------------------------------------------------------------
--- ACCESSOR/TESTER
-
-
-fromQual :: QName a -> Maybe (Name a)
-fromQual (Qual _ _ x) = Just x
-fromQual (UnQual _ x) = Just x
-fromQual _ = Nothing
-
----------------------------------------------------------------------
--- FIXITIES
-
-getFixity :: Decl a -> [Fixity]
-getFixity (InfixDecl sl a mp ops) = [Fixity (void a) (fromMaybe 9 mp) (UnQual () $ void $ f op) | op <- ops]
-    where f (VarOp _ x) = x
-          f (ConOp _ x) = x
-getFixity _ = []
-
-toInfixDecl :: Fixity -> Decl ()
-toInfixDecl (Fixity a b c) = InfixDecl () a (Just b) $ maybeToList $ VarOp () <$> fromQual c
-
-
+import Language.Haskell.Exts(Extension(..), parseExtension)
 
 -- | This extension implies the following extensions
 extensionImplies :: Extension -> [Extension]

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,15 +6,15 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.8.3.20200224
-  - ghc-lib-parser-ex-8.8.5.3
+  - ghc-lib-parser-ex-8.8.5.5
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
-#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.8.5.3.tar.gz
+#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.8.5.5.tar.gz
   - haskell-src-exts-1.23.0
   - extra-1.7.1
-ghc-options: {"$locals": -ddump-to-file -ddump-hi}
-# dependency (rather ghc will). Enabling this stanza forces both hlint
-# and ghc-lib-parser-ex to depend on ghc-lib-parser int his case.
+ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds}
+# Enabling this stanza forces both hlint and ghc-lib-parser-ex to
+# depend on ghc-lib-parser.
 # flags:
 #   hlint:
 #     ghc-lib: true


### PR DESCRIPTION
Smallest of starts on parse flags:
- Publish and upgrade to ghc-lib-parser-ex-8.8.5.4 exposing `preludeFixities`, `baseFixities`, `lensFixities` and `otherFixities`;
- Add type `ParseMode'` and function `defaultParseMode'` to `All.hs`.
