### PR TITLE
Min version ghc-lib-parser-ex 8.8.8.5

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -67,7 +67,7 @@ library
         refact >= 0.3,
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1,
-        ghc-lib-parser-ex >= 8.8.5.3 && < 8.8.6
+        ghc-lib-parser-ex >= 8.8.5.5 && < 8.8.6
     if !flag(ghc-lib) && impl(ghc >= 8.8.0) && impl(ghc < 8.9.0)
         build-depends:
           ghc == 8.8.*,

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,15 +6,15 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.8.3.20200224
-  - ghc-lib-parser-ex-8.8.5.3
+  - ghc-lib-parser-ex-8.8.5.5
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.8.5.3.tar.gz
   - haskell-src-exts-1.23.0
   - extra-1.7.1
-ghc-options: {"$locals": -ddump-to-file -ddump-hi}
-# dependency (rather ghc will). Enabling this stanza forces both hlint
-# and ghc-lib-parser-ex to depend on ghc-lib-parser int his case.
+ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds}
+# Enabling this stanza forces both hlint and ghc-lib-parser-ex to
+# depend on ghc-lib-parser.
 # flags:
 #   hlint:
 #     ghc-lib: true


### PR DESCRIPTION
Update ghc-lib-parser-ex to get access to prelude and base fixities.
