### PR TITLE
Move lens, other, custom fixities to Fixity

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -71,5 +71,3 @@
 - ignore: {name: Use const, within: Config.Yaml}
 # temporary disable while we have unused top binds here
 - ignore: {name : Avoid restricted flags, within: [GHC.Util.HsExpr, Hint.Match]}
-# It is used and on Ubuntu 8.8, GHC errors if it's not enabled.
-- ignore: {name : Unused LANGUAGE pragma, within: [GHC.Util.Language.Haskell.GHC.ExactPrint.Types]}

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -18,8 +18,7 @@ import Timing
 import Language.Preprocessor.Cpphs
 import Data.Either
 import Language.Haskell.Exts as HSE.Type
-    ( Language(..), Extension(..), Fixity(..)
-    , infixr_, infix_, infixl_)
+    ( Language(..), Extension(..), Fixity(..) )
 import qualified Data.Map as Map
 import System.IO.Extra
 import Data.Functor
@@ -67,68 +66,16 @@ defaultParseMode =
   ParseMode {
       baseLanguage = Haskell2010
     , extensions = []
-    , fixities = Just preludeFixities
+    , fixities = Just $ toHseFixities preludeFixities
     }
-  where
-    preludeFixities = toHseFixities GhclibParserEx.preludeFixities
-
-lensFixities :: [Fixity]
-lensFixities = concat
-    -- List as provided at https://github.com/ndmitchell/hlint/issues/416
-    [infixr_ 4 ["%%@~","<%@~","%%~","<+~","<*~","<-~","<//~","<^~","<^^~","<**~"]
-    ,infix_ 4 ["%%@=","<%@=","%%=","<+=","<*=","<-=","<//=","<^=","<^^=","<**="]
-    ,infixr_ 2 ["<<~"]
-    ,infixr_ 9 ["#."]
-    ,infixl_ 8 [".#"]
-    ,infixr_ 8 ["^!","^@!"]
-    ,infixl_ 1 ["&","<&>","??"]
-    ,infixl_ 8 ["^.","^@."]
-    ,infixr_ 9 ["<.>","<.",".>"]
-    ,infixr_ 4 ["%@~",".~","+~","*~","-~","//~","^~","^^~","**~","&&~","<>~","||~","%~"]
-    ,infix_ 4 ["%@=",".=","+=","*=","-=","//=","^=","^^=","**=","&&=","<>=","||=","%="]
-    ,infixr_ 2 ["<~"]
-    ,infixr_ 2 ["`zoom`","`magnify`"]
-    ,infixl_ 8 ["^..","^?","^?!","^@..","^@?","^@?!"]
-    ,infixl_ 8 ["^#"]
-    ,infixr_ 4 ["<#~","#~","#%~","<#%~","#%%~"]
-    ,infix_ 4 ["<#=","#=","#%=","<#%=","#%%="]
-    ,infixl_ 9 [":>"]
-    ,infixr_ 4 ["</>~","<</>~","<.>~","<<.>~"]
-    ,infix_ 4 ["</>=","<</>=","<.>=","<<.>="]
-    ,infixr_ 4 [".|.~",".&.~","<.|.~","<.&.~"]
-    ,infix_ 4 [".|.=",".&.=","<.|.=","<.&.="]
-    ]
-
-otherFixities :: [Fixity]
-otherFixities = concat
-    -- hspec
-    [infix_ 1 ["`shouldBe`","`shouldSatisfy`","`shouldStartWith`","`shouldEndWith`","`shouldContain`","`shouldMatchList`"
-              ,"`shouldReturn`","`shouldNotBe`","`shouldNotSatisfy`","`shouldNotContain`","`shouldNotReturn`","`shouldThrow`"]
-    -- quickcheck
-    ,infixr_ 0 ["==>"]
-    ,infix_ 4 ["==="]
-    -- esqueleto
-    ,infix_ 4 ["==."]
-    -- lattices
-    ,infixr_ 5 ["\\/"] -- \/
-    ,infixr_ 6 ["/\\"] -- /\
-    ]
-
-customFixities :: [Fixity]
-customFixities =
-    infixl_ 1 ["`on`"]
-        -- see https://github.com/ndmitchell/hlint/issues/425
-        -- otherwise GTK apps using `on` at a different fixity have spurious warnings
 
 -- | Default value for 'ParseFlags'.
 defaultParseFlags :: ParseFlags
 defaultParseFlags =
   ParseFlags NoCpp defaultParseMode
-    { fixities = Just $ customFixities ++ baseFixities ++ lensFixities ++ otherFixities
+    { fixities = Just $ toHseFixities (customFixities ++ baseFixities ++ lensFixities ++ otherFixities)
     , extensions = parseExtensions
     }
-  where
-    baseFixities = toHseFixities GhclibParserEx.baseFixities
 
 -- | Given some fixities, add them to the existing fixities in 'ParseFlags'.
 parseFlagsAddFixities :: [FixityInfo] -> ParseFlags -> ParseFlags


### PR DESCRIPTION
This PR moves the definitions of  lens, other and custom fixities to `Fixity`. They are now specified as `(String, Fixity)`  lists in the same style as the prelude and base fixities from `GhclibParserEx`.

- Surprisingly, the change caused a test failure:
  -  The test ``no = sort <$> f input `shouldBe` sort <$> x`` before this change produced no hints;
  - After this change, it triggers "Functor law";
  - I changed the test to expect that hint because in fact it looks kosher (`f <$> g <$> x === (f . g) <$> x`) although I'd appreciate it if you could have a look at it - the existence of the test suggests I may be missing something;
- I took the opportunity to prune an entry for a now deleted file from `.hlint.yaml`.