### PR TITLE
Get 'infixl_' and friends from GhclibParserEx

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -67,7 +67,7 @@ library
         refact >= 0.3,
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1,
-        ghc-lib-parser-ex >= 8.8.5.5 && < 8.8.6
+        ghc-lib-parser-ex >= 8.8.5.6 && < 8.8.6
     if !flag(ghc-lib) && impl(ghc >= 8.8.0) && impl(ghc < 8.9.0)
         build-depends:
           ghc == 8.8.*,

--- a/src/Fixity.hs
+++ b/src/Fixity.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE TupleSections #-}
 
 module Fixity(
     FixityInfo, Associativity(..),
     toHseFixity, fromHseFixity,
     fromFixitySig, toFixitySig, toFixity, toHseFixities,
-    preludeFixities, baseFixities, lensFixities, otherFixities, customFixities
+    preludeFixities, baseFixities, -- From GhclibParserEx
+    lensFixities, otherFixities, customFixities
     ) where
 
 import GHC.Generics(Associativity(..))
@@ -15,7 +15,7 @@ import OccName
 import RdrName
 import SrcLoc
 import BasicTypes
-import qualified Language.Haskell.GhclibParserEx.Fixity as GhclibParserEx
+import Language.Haskell.GhclibParserEx.Fixity
 
 -- Lots of things define a fixity. None define it quite right, so let's have our own type.
 
@@ -81,12 +81,6 @@ toFixitySig = mkFixitySig . toFixity
 toHseFixities :: [(String, Fixity)] -> [HSE.Fixity]
 toHseFixities = map (toHseFixity  . fromFixity)
 
-preludeFixities :: [(String, Fixity)]
-preludeFixities = GhclibParserEx.preludeFixities
-
-baseFixities :: [(String, Fixity)]
-baseFixities = GhclibParserEx.baseFixities
-
 -- List as provided at https://github.com/ndmitchell/hlint/issues/416.
 lensFixities :: [(String, Fixity)]
 lensFixities = concat
@@ -135,11 +129,3 @@ customFixities =
         -- See https://github.com/ndmitchell/hlint/issues/425
         -- otherwise GTK apps using `on` at a different fixity have
         -- spurious warnings.
-
-infixr_, infixl_, infix_ :: Int -> [String] -> [(String,Fixity)]
-infixr_ = fixity InfixR
-infixl_ = fixity InfixL
-infix_  = fixity InfixN
-
-fixity :: FixityDirection -> Int -> [String] -> [(String, Fixity)]
-fixity a p = map (,Fixity (SourceText "") p a)

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.8.3.20200224
-  - ghc-lib-parser-ex-8.8.5.5
+  - ghc-lib-parser-ex-8.8.5.6
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.8.5.3.tar.gz


### PR DESCRIPTION
Bump GhclibParserEx to 8.8.5.6 and get `infixl_`, `infixr_` and `fixity` from there.