### PR TITLE
Update to ghc-lib-parser-ex-8.8.5.7

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -67,7 +67,7 @@ library
         refact >= 0.3,
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1,
-        ghc-lib-parser-ex >= 8.8.5.6 && < 8.8.6
+        ghc-lib-parser-ex >= 8.8.5.7 && < 8.8.6
     if !flag(ghc-lib) && impl(ghc >= 8.8.0) && impl(ghc < 8.9.0)
         build-depends:
           ghc == 8.8.*,

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,13 +3,13 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.8.3.20200224
-  - ghc-lib-parser-ex-8.8.5.6
+  - ghc-lib-parser-ex-8.8.5.7
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.8.5.3.tar.gz
   - haskell-src-exts-1.23.0
   - extra-1.7.1
-ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds}
+ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds -Werror=orphans}
 # Enabling this stanza forces both hlint and ghc-lib-parser-ex to
 # depend on ghc-lib-parser.
 # flags:


### PR DESCRIPTION
Closes https://github.com/ndmitchell/hlint/issues/913. Also, change resolver in stack.yaml back to nightly-2019-08-07 since nightly-2020-03-14 is giving 404 errors.