### PR TITLE
Upgrade to ghc-lib-parser-ex-8.8.5.8

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -67,7 +67,7 @@ library
         refact >= 0.3,
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1,
-        ghc-lib-parser-ex >= 8.8.5.7 && < 8.8.6
+        ghc-lib-parser-ex >= 8.8.5.8 && < 8.8.6
     if !flag(ghc-lib) && impl(ghc >= 8.8.0) && impl(ghc < 8.9.0)
         build-depends:
           ghc == 8.8.*,

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.8.3.20200224
-  - ghc-lib-parser-ex-8.8.5.7
+  - ghc-lib-parser-ex-8.8.5.8
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.8.5.3.tar.gz


### PR DESCRIPTION
## 8.8.5.8 released 2020-03-17
- New module `Language.Haskell.GhclibParserEx.GHC.Driver.Flags`
  - Export `Bounded` instance for `Language`
    (https://github.com/shayne-fletcher/ghc-lib-parser-ex/issues/30)

