### PR TITLE
more specific names for two fusion rules

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -241,8 +241,8 @@
     - warn: {lhs: foldMap id, rhs: fold}
     - warn: {lhs: fold (fmap f x), rhs: foldMap f x}
     - warn: {lhs: fold (map f x), rhs: foldMap f x}
-    - warn: {lhs: foldMap f (fmap g x), rhs: foldMap (f . g) x}
-    - warn: {lhs: foldMap f (map g x), rhs: foldMap (f . g) x}
+    - warn: {lhs: foldMap f (fmap g x), rhs: foldMap (f . g) x, name: Fuse foldMap/fmap}
+    - warn: {lhs: foldMap f (map g x), rhs: foldMap (f . g) x, name: Fuse foldMap/map}
 
     # BY
 


### PR DESCRIPTION
I found it odd that `hlint` currently gives such a warning:
```
Fuse foldr/map
Found:
  foldr f z (map g x)
Perhaps:
  foldr (f . g) z x
```
but also this:
```
Use .
Found:
  foldMap f (map g x)
Perhaps:
  foldMap (f . g) x
```
The two situations in code are very similar, and saying `Fuse ....` seems more useful to me than `Use .` also in the second situation.

This PR introduces names for rules such that the second situation will be notified analogously to the first one.