### PR TITLE
Improve the situation with parse error messages

### DIFF
--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -87,7 +87,7 @@ parseModuleApply flags s file src = do
     case res of
       Right r -> pure $ Right r
       Left (ParseError sl msg ctxt) ->
-            pure $ Left $ classify [x | SettingClassify x <- s] $ rawIdeaN Error "Parse error" sl ctxt Nothing []
+            pure $ Left $ classify [x | SettingClassify x <- s] $ rawIdeaN Error msg sl ctxt Nothing []
 
 
 -- | Find which hints a list of settings implies.

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -219,7 +219,7 @@ parseModuleEx flags file str = timedIO "Parse" file $ do
             -- location so we skip that for now. Synthesize a parse
             -- error.
             let loc = GHC.mkSrcLoc (mkFastString file) (1 :: Int) (1 :: Int)
-            pure $ Left (ParseError (GHC.mkSrcSpan loc loc) msg "")
+            pure $ Left (ParseError (GHC.mkSrcSpan loc loc) msg ppstr)
 
 
 -- | Given a line number, and some source code, put bird ticks around the appropriate bit.

--- a/tests/json.test
+++ b/tests/json.test
@@ -28,7 +28,7 @@ RUN tests/json-parse-error.hs --json
 FILE tests/json-parse-error.hs
 @
 OUTPUT
-[{"module":[],"decl":[],"severity":"Error","hint":"Parse error","file":"tests/json-parse-error.hs","startLine":1,"startColumn":1,"endLine":1,"endColumn":2,"from":"> @\n","to":null,"note":[],"refactorings":"[]"}]
+[{"module":[],"decl":[],"severity":"Error","hint":"tests/json-parse-error.hs:1:1: error: parse error on input `@'","file":"tests/json-parse-error.hs","startLine":1,"startColumn":1,"endLine":1,"endColumn":2,"from":"> @\n","to":null,"note":[],"refactorings":"[]"}]
 
 ---------------------------------------------------------------------
 RUN tests/json-note.hs --json

--- a/tests/lhs.test
+++ b/tests/lhs.test
@@ -25,7 +25,8 @@ BUG 331
 module
 \end{code}
 OUTPUT
-tests/lhs-line-numbers2.lhs:10:1: Error: Parse error
+tests/lhs-line-numbers2.lhs:10:1: Error: tests/lhs-line-numbers2.lhs:10:1: error:
+    parse error (possibly incorrect indentation or mismatched brackets)
 Found:
     \end{code}
 

--- a/tests/parse-error.test
+++ b/tests/parse-error.test
@@ -3,7 +3,12 @@ RUN "--ignore=Parse error" tests/ignore-parse-error.hs
 FILE tests/ignore-parse-error.hs
 where
 OUTPUT
-No hints
+tests/ignore-parse-error.hs:1:1-5: Error: tests/ignore-parse-error.hs:1:1: error:
+    parse error on input `where'
+Found:
+  > where
+
+1 hint
 
 ---------------------------------------------------------------------
 RUN tests/ignore-parse-error2.hs
@@ -12,7 +17,8 @@ module Foo where
 
 where
 OUTPUT
-tests/ignore-parse-error2.hs:3:1-5: Error: Parse error
+tests/ignore-parse-error2.hs:3:1-5: Error: tests/ignore-parse-error2.hs:3:1: error:
+    parse error on input `where'
 Found:
     module Foo where
 
@@ -24,7 +30,9 @@ RUN tests/ignore-parse-error3.hs
 FILE tests/ignore-parse-error3.hs
 {-# LANGUAGE InvalidExtension #-}
 OUTPUT
-tests/ignore-parse-error3.hs:1:1: Error: Parse error
-Found you should remove it.
+tests/ignore-parse-error3.hs:1:1: Error: Unsupported extension: InvalidExtension
+
+Found:
+  {-# LANGUAGE InvalidExtension #-}
 
 1 hint


### PR DESCRIPTION
We now display the actual GHC message rather than "Parse error". As an example, in the case of the recently considered invalid extension case we print,
```
tests/ignore-parse-error3.hs:1:1: Error: Unsupported extension: InvalidExtension

Found:
  {-# LANGUAGE InvalidExtension #-}

1 hint
```
If the error results from parsing dynamic pragmas, we just use the entire module source for the context at this time (rather than "").

Closes https://github.com/ndmitchell/hlint/issues/915.