### PR TITLE
Remove use of HSE extensions entirely

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -60,7 +60,6 @@ library
         cpphs >= 1.20.1,
         cmdargs >= 0.10,
         yaml >= 0.5.0,
-        haskell-src-exts >= 1.21 && < 1.24,
         uniplate >= 1.5,
         ansi-terminal >= 0.6.2,
         extra >= 1.7.1,

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -163,7 +163,7 @@ allowFields v allow = do
 parseGHC :: (ParseMode -> String -> GHC.ParseResult v) -> Val -> Parser v
 parseGHC parser v = do
     x <- parseString v
-    case parser defaultParseMode{extensions=toHseEnabledExtensions configExtensions} x of
+    case parser defaultParseMode{extensions=configExtensions} x of
         GHC.POk _ x -> pure x
         GHC.PFailed _ loc err ->
           let msg = Outputable.showSDoc baseDynFlags $

--- a/src/Extension.hs
+++ b/src/Extension.hs
@@ -1,16 +1,12 @@
 module Extension(
   defaultExtensions,
   configExtensions,
-  toHseEnabledExtensions,
   extensionImpliedEnabledBy,
   extensionImplies
   ) where
 
-import Text.Read
 import Data.List.Extra
 import qualified Data.Map as Map
-import Data.Maybe
-import qualified Language.Haskell.Exts.Extension as HSE
 import GHC.LanguageExtensions.Type
 import qualified Language.Haskell.GhclibParserEx.DynFlags as GhclibParserEx
 
@@ -26,6 +22,8 @@ badExtensions =
 reallyBadExtensions =
   [ TransformListComp -- steals the group keyword
   {- , XmlSyntax , RegularPatterns -} -- steals a-b and < operators
+  , AlternativeLayoutRule -- Does not play well with 'MultiWayIf'
+  , NegativeLiterals -- Was not enabled by HSE and enabling breaks tests.
   ]
 
 -- | Extensions we turn on by default when parsing. Aim to parse as
@@ -37,14 +35,6 @@ defaultExtensions = enumerate \\ badExtensions
 --   of variations - in particular, we might require spaces in some places.
 configExtensions :: [Extension]
 configExtensions = enumerate \\ reallyBadExtensions
-
--- Note that this silenty ignores extensions that HSE doesn't
--- know. This function won't be here for much longer so shouldn't be a
--- problem.
-toHseEnabledExtensions :: [Extension] -> [HSE.Extension]
-toHseEnabledExtensions = mapMaybe ((HSE.EnableExtension <$>) . readMaybe . show')
-  where
-    show' e = if ex == "Cpp" then "CPP" else ex where ex = show e
 
 -- | This extension implies the following extensions are
 -- enabled/disabled.

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -17,7 +17,6 @@ import Data.Maybe
 import Timing
 import Language.Preprocessor.Cpphs
 import Data.Either
-import Language.Haskell.Exts ( Extension(..))
 import DynFlags(Language(..))
 import qualified Data.Map as Map
 import System.IO.Extra
@@ -32,14 +31,13 @@ import qualified SrcLoc as GHC
 import qualified ErrUtils
 import qualified Outputable
 import qualified Lexer as GHC
-import qualified GHC.LanguageExtensions.Type as GHC
+import GHC.LanguageExtensions.Type
 import qualified ApiAnnotation as GHC
 import qualified BasicTypes as GHC
 import qualified DynFlags as GHC
 
 import GHC.Util (parsePragmasIntoDynFlags, parseFileGhcLib, parseExpGhcLib, parseDeclGhcLib, parseImportGhcLib, baseDynFlags)
 import qualified Language.Haskell.GhclibParserEx.Fixity as GhclibParserEx
-import qualified Language.Haskell.GhclibParserEx.DynFlags as GhclibParserEx
 
 -- | What C pre processor should be used.
 data CppFlags
@@ -66,7 +64,7 @@ defaultParseMode :: ParseMode
 defaultParseMode =
   ParseMode {
       baseLanguage = Nothing
-    , extensions = toHseEnabledExtensions defaultExtensions
+    , extensions = defaultExtensions
     , fixities = defaultFixities
     }
 
@@ -134,20 +132,11 @@ ghcFixitiesFromParseMode = map toFixity . fixities
 
 
 -- GHC enabled/disabled extensions given an HSE parse mode.
-ghcExtensionsFromParseMode :: ParseMode
-                           -> ([GHC.Extension], [GHC.Extension])
-ghcExtensionsFromParseMode ParseMode {extensions=exts}=
-   partitionEithers $ mapMaybe toEither exts
-   where
-     toEither ke = case ke of
-       EnableExtension e  -> Left  <$> GhclibParserEx.readExtension (show e)
-       DisableExtension e -> Right <$> GhclibParserEx.readExtension (show e)
-       UnknownExtension ('N':'o':e) -> Right <$> GhclibParserEx.readExtension e
-       UnknownExtension e -> Left <$> GhclibParserEx.readExtension e
+ghcExtensionsFromParseMode :: ParseMode -> ([Extension], [Extension])
+ghcExtensionsFromParseMode ParseMode {extensions=exts}= (exts, [])
 
 -- GHC extensions to enable/disable given HSE parse flags.
-ghcExtensionsFromParseFlags :: ParseFlags
-                             -> ([GHC.Extension], [GHC.Extension])
+ghcExtensionsFromParseFlags :: ParseFlags -> ([Extension], [Extension])
 ghcExtensionsFromParseFlags ParseFlags {hseFlags=mode} = ghcExtensionsFromParseMode mode
 
 -- GHC fixities given HSE parse flags.

--- a/src/Hint/Pragma.hs
+++ b/src/Hint/Pragma.hs
@@ -32,7 +32,6 @@
 module Hint.Pragma(pragmaHint) where
 
 import Hint.Type(ModuHint,ModuleEx(..),Idea(..),Severity(..),toSS',rawIdea')
-import Language.Haskell.Exts(prettyExtension,glasgowExts)
 import Data.List.Extra
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe
@@ -43,6 +42,7 @@ import ApiAnnotation
 import SrcLoc
 
 import GHC.Util
+import DynFlags
 
 pragmaHint :: ModuHint
 pragmaHint _ modu =
@@ -110,7 +110,7 @@ languageDupes _ = []
 strToLanguage :: String -> Maybe [String]
 strToLanguage "-cpp" = Just ["CPP"]
 strToLanguage x | "-X" `isPrefixOf` x = Just [drop 2 x]
-strToLanguage "-fglasgow-exts" = Just $ map prettyExtension glasgowExts
+strToLanguage "-fglasgow-exts" = Just $ map show glasgowExtsFlags
 strToLanguage _ = Nothing
 
 -- In 'optToLanguage p langexts', 'p' is an 'OPTIONS_GHC' pragma,


### PR DESCRIPTION
Remove use of HSE's `Extension`. As far as I can tell, `HSE/All.hs` is now "HSE free" - parse modes and parse flags are expressed only in ghc-lib types.