### PR TITLE
Upgrade ghc-lib-parser-ex to 8.8.6.0

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -66,7 +66,7 @@ library
         refact >= 0.3,
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1,
-        ghc-lib-parser-ex >= 8.8.5.8 && < 8.8.6
+        ghc-lib-parser-ex >= 8.8.6.0 && < 8.8.7
     if !flag(ghc-lib) && impl(ghc >= 8.8.0) && impl(ghc < 8.9.0)
         build-depends:
           ghc == 8.8.*,

--- a/src/Extension.hs
+++ b/src/Extension.hs
@@ -8,7 +8,7 @@ module Extension(
 import Data.List.Extra
 import qualified Data.Map as Map
 import GHC.LanguageExtensions.Type
-import qualified Language.Haskell.GhclibParserEx.DynFlags as GhclibParserEx
+import qualified Language.Haskell.GhclibParserEx.GHC.Driver.Session as GhclibParserEx
 
 badExtensions =
   reallyBadExtensions ++

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -36,7 +36,7 @@ import GHC.Util.Scope
 import GHC.Util.Unify
 
 import qualified Language.Haskell.GhclibParserEx.Parse as GhclibParserEx
-import Language.Haskell.GhclibParserEx.DynFlags (parsePragmasIntoDynFlags)
+import Language.Haskell.GhclibParserEx.GHC.Driver.Session (parsePragmasIntoDynFlags)
 
 import HsSyn
 import Lexer

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.8.3.20200224
-  - ghc-lib-parser-ex-8.8.5.8
+  - ghc-lib-parser-ex-8.8.6.0
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.8.5.3.tar.gz


### PR DESCRIPTION
ghc-lib-parser-ex 8.8.6.0 moves `DynFlags` to `GHC.Driver.Session`, this PR upgrades hlint to that version and accounts for the move. This is already on hackage - I forgot about stackage and got us an out-of-bounds notice for hlint  (https://github.com/commercialhaskell/stackage/issues/5255). If you land this we should be good again.