### PR TITLE
Fix spans of lambda hints

### DIFF
--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -120,10 +120,10 @@ lambdaHint _ _ x
 
 lambdaDecl :: LHsDecl GhcPs -> [Idea]
 lambdaDecl
-    o@(L loc1 (ValD _
-        origBind@FunBind {fun_matches =
+    o@(L _ (ValD _
+        origBind@FunBind {fun_id = L loc1 _, fun_matches =
             MG {mg_alts =
-                L _ [L _ (Match _ ctxt pats (GRHSs _ [L loc2 (GRHS _ [] origBody)] bind))]}}))
+                L _ [L _ (Match _ ctxt pats (GRHSs _ [L _ (GRHS _ [] origBody@(L loc2 _))] bind))]}}))
     | L _ (EmptyLocalBinds noExt) <- bind
     , isLambda $ fromParen' origBody
     , null (universeBi pats :: [HsExpr GhcPs])


### PR DESCRIPTION
hlint 2.2.11:
![Screenshot from 2020-03-25 17-30-49](https://user-images.githubusercontent.com/6342538/77598283-a0de8280-6ebe-11ea-86dd-0422898a3900.png)

hlint head:
![Screenshot from 2020-03-25 17-29-13](https://user-images.githubusercontent.com/6342538/77598310-b05dcb80-6ebe-11ea-8617-c1630800f165.png)

This PR restores the 2.2.11 behavior.