### PR TITLE
Update to ghc-lib-parser-ex-8.10.0.2

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -67,24 +67,16 @@ library
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1
 
-    -- We currently target the 8.10 parse tree.
     if !flag(ghc-lib) && impl(ghc >= 8.10.0) && impl(ghc < 8.11.0)
       build-depends:
-        -- Not explicitly instructed to link ghc-lib-parser and we are
-        -- compiling with an 8.10 compiler so we link native ghc libraries.
         ghc == 8.10.*,
         ghc-boot-th,
         ghc-boot
     else
       build-depends:
-        -- Either explicitly instructed to link ghc-lib-parser or we
-        -- are compiling with a non-8.10 compiler.
           ghc-lib-parser == 8.10.*
     build-depends:
-        -- Note : ghc-lib-parser-ex supports the ghc-lib flag too. If
-        -- you set that flag for hlint, be sure to set it consistently
-        -- for ghc-lib-parser-ex also.
-        ghc-lib-parser-ex >= 8.10.0.1 && < 8.10.1
+        ghc-lib-parser-ex >= 8.10.0.2 && < 8.10.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,21 +1,19 @@
-resolver: nightly-2020-03-14 # ghc-8.8.3
+resolver: lts-14.20 # ghc-8.6.5
 packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.10.1.20200324
-  - ghc-lib-parser-ex-8.10.0.1
+  - ghc-lib-parser-ex-8.10.0.2
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
-#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.1.tar.gz
+#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.2.tar.gz
   - extra-1.7.1
 ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds -Werror=orphans}
-# Since we are compiling with 8.8.3, hlint will automatically link
-# ghc-lib-parser rather than ghc native libs (since we target the 8.10
-# parse tree). ghc-lib-parser-ex on the other hand will assume ghc
-# native libs by default *for all ghc versions* unless told explicitly
-# to link ghc-lib-parser. For clarity and consistency, force both.
-flags:
-  hlint:
-    ghc-lib: true
-  ghc-lib-parser-ex:
-    ghc-lib: true
+# Enabling this stanza forces both hlint and ghc-lib-parser-ex to
+# depend on ghc-lib-parser.
+# flags:
+#   hlint:
+#     ghc-lib: true
+#   ghc-lib-parser-ex:
+#     auto: false
+#     no-ghc-lib: false


### PR DESCRIPTION
Solves the configure problem so that hlint works out of the box with no flags and no compromises.

## 8.10.0.2 released 2020-03-30
- Rework cabal flags; allow full configurability with a good default:
  - Have two flags `auto` and `no-ghc-lib`. Default behavior exactly as `hlint` linking `ghc-lib-parser-8.10.*` if not on `ghc-8.10.*` and `ghc-8.10.*` otherwise.
