### PR TITLE
Add BlockArguments to a few tests

### DIFF
--- a/src/Hint/Monad.hs
+++ b/src/Hint/Monad.hs
@@ -39,8 +39,8 @@ folder f a xs = foldM f a xs >> return () -- foldM_ f a xs
 folder f a xs = foldM f a xs >>= \_ -> return () -- foldM_ f a xs
 yes = mapM async ds >>= mapM wait >> return () -- mapM async ds >>= mapM_ wait
 main = "wait" ~> do f a $ sleep 10
-main = print do 17 + 25  @NoRefactor: needs -XBlockArguments which isn't available before GHC 8.6
-main = print do 17 -- @NoRefactor: needs -XBlockArguments which isn't available before GHC 8.6
+{-# LANGUAGE BlockArguments #-}; main = print do 17 + 25
+{-# LANGUAGE BlockArguments #-}; main = print do 17 --
 main = f $ do g a $ sleep 10 --
 main = do f a $ sleep 10 --
 main = do foo x; return 3; bar z -- do foo x; bar z


### PR DESCRIPTION
Since GHC 8.4 is no longer supported, adding BlockArguments to some tests so that refactoring tests pass.