### PR TITLE
Use suggested replacement as refactoring template if any substitution has no loc

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1159,7 +1159,6 @@
 # no = sort <$> f input `shouldBe` sort <$> x
 # sortBy (comparing length) -- sortOn length
 # myJoin = on $ child ^. ChildParentId ==. parent ^. ParentId
-# @NoRefactor hlint bug: foo = typeRep (Proxy :: Proxy Foo Int) (missing brackets) \
 # foo = typeOf (undefined :: Foo Int) -- typeRep (Proxy :: Proxy (Foo Int))
 # foo = typeOf (undefined :: a) -- typeRep (Proxy :: Proxy a)
 # {-# RULES "Id-fmap-id" forall (x :: Id a). fmap id x = x #-}

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1161,7 +1161,7 @@
 # myJoin = on $ child ^. ChildParentId ==. parent ^. ParentId
 # @NoRefactor hlint bug: foo = typeRep (Proxy :: Proxy Foo Int) (missing brackets) \
 # foo = typeOf (undefined :: Foo Int) -- typeRep (Proxy :: Proxy (Foo Int))
-# foo = typeOf (undefined :: a) -- typeRep (Proxy :: Proxy a) @NoRefactor hlint bug: incorrect serialisation
+# foo = typeOf (undefined :: a) -- typeRep (Proxy :: Proxy a)
 # {-# RULES "Id-fmap-id" forall (x :: Id a). fmap id x = x #-}
 # import Data.Map (fromList) \
 # fromList [] -- Data.Map.empty

--- a/src/GHC/Util/HsExpr.hs
+++ b/src/GHC/Util/HsExpr.hs
@@ -289,14 +289,12 @@ descendBracketOld' op x = (descendIndex' g1 x, descendIndex' g2 x)
     g1 = (fst .) . g
     g2 = (snd .) . g
 
-    f i (L _ (HsPar _ y)) z | not $ needBracketOld' i x y = (y, y `ifNoLocElse` z)
-    f i y z                 | needBracketOld' i x y = (addParen' y, addParen' (y `ifNoLocElse` z))
-    f _ y z                 = (y, y `ifNoLocElse` z)
+    f i (L _ (HsPar _ y)) z | not $ needBracketOld' i x y = (y, z)
+    f i y z                 | needBracketOld' i x y = (addParen' y, addParen' z)
+    f _ y z                 = (y, z)
 
     f1 = ((fst .) .) . f
     f2 = ((snd .) .) . f
-
-    ifNoLocElse y z = if getLoc y == noSrcSpan then y else z
 
 fromParen1' :: LHsExpr GhcPs -> LHsExpr GhcPs
 fromParen1' (L _ (HsPar _ x)) = x

--- a/src/Hint/Match.hs
+++ b/src/Hint/Match.hs
@@ -157,7 +157,7 @@ matchIdea' sb declName HintRule{..} parent x = do
   guard $ checkSide' (unextendInstances <$> hintRuleSide) $ ("original", x) : ("result", res) : fromSubst' u
   guard $ checkDefine' declName parent res
 
-  (u, tpl) <- pure $ if any ((== noSrcSpan) . getLoc . snd) (fromSubst' u) then (mempty, e) else (u, tpl)
+  (u, tpl) <- pure $ if any ((== noSrcSpan) . getLoc . snd) (fromSubst' u) then (mempty, res) else (u, tpl)
   tpl <- pure (performSpecial' tpl)
 
   pure (res, tpl, hintRuleNotes, [(s, toSS' pos) | (s, pos) <- fromSubst' u, getLoc pos /= noSrcSpan])

--- a/src/Hint/Match.hs
+++ b/src/Hint/Match.hs
@@ -142,7 +142,6 @@ matchIdea' sb declName HintRule{..} parent x = do
       (e, tpl) = substitute' u rhs'
       noParens = [varToStr $ fromParen' x | L _ (HsApp _ (varToStr -> "_noParen_") x) <- universe tpl]
 
-  tpl <- pure (performSpecial' tpl)
   u <- pure (removeParens noParens u)
 
   let res = addBracketTy' (addBracket' parent $ performSpecial' $ fst $ substitute' u $ unqualify' sa sb rhs')
@@ -157,6 +156,9 @@ matchIdea' sb declName HintRule{..} parent x = do
 
   guard $ checkSide' (unextendInstances <$> hintRuleSide) $ ("original", x) : ("result", res) : fromSubst' u
   guard $ checkDefine' declName parent res
+
+  (u, tpl) <- pure $ if any ((== noSrcSpan) . getLoc . snd) (fromSubst' u) then (mempty, e) else (u, tpl)
+  tpl <- pure (performSpecial' tpl)
 
   pure (res, tpl, hintRuleNotes, [(s, toSS' pos) | (s, pos) <- fromSubst' u, getLoc pos /= noSrcSpan])
 


### PR DESCRIPTION
Previously `foo = typeOf (undefined :: a)` fails to refactor, because
```
template = typeRep (Proxy :: Proxy a)
substs = [ a -> undefined ]
```
So hlint is telling apply-refact to refactor it into `typeRep (Proxy :: Proxy undefined)`.

The template is not `typeRep (Proxy :: Proxy b)` because the substitution `b -> a` has no loc, so `b` is expanded into `a` in the template (#895).

This can be fixed by: if any substitution in `u` has no loc, set `u` to `mempty`, and use the suggested replacement (`res`) as the refactoring template (`tpl`). In the example above it becomes
```
template = typeRep (Proxy :: Proxy a)
substs = []
``` 
