### PR TITLE
Update pass criteria for refactoring tests

### DIFF
--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -74,7 +74,7 @@ foo = (case x of y -> z; q -> w) :: Int
 main = do a += b . c; return $ a . b
 
 -- <$> bracket tests
-yes = (foo . bar x) <$> baz q -- foo . bar x <$> baz q @NoRefactor hlint bug: ideaRefactoring = []
+yes = (foo . bar x) <$> baz q -- foo . bar x <$> baz q @NoRefactor: refactoring for "(v1 . v2) <$> v3" is not implemented
 no = foo . bar x <$> baz q
 
 -- annotations

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -192,7 +192,7 @@ foo = Foo{x}
 foo = bar{x}
 {-# LANGUAGE NamedFieldPuns #-} --
 {-# LANGUAGE StaticPointers #-} \
-static = 42 -- @NoRefactor: cannot refactor parse errors
+static = 42 --
 </TEST>
 -}
 

--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -26,7 +26,7 @@ f (Just a) = \a -> a + a -- f (Just _) a = a + a @NoRefactor
 f a = \x -> x + x where _ = test
 f (test -> a) = \x -> x + x
 f = \x -> x + x -- f x = x + x
-fun x y z = f x y z -- fun = f @NoRefactor: hlint bug, ideaRefactoring = []
+fun x y z = f x y z -- fun = f @NoRefactor: refactoring for eta reduce is not implemented
 fun x y z = f x x y z -- fun x = f x x @NoRefactor
 fun x y z = f g z -- fun x y = f g @NoRefactor
 fun x = f . g $ x -- fun = f . g @NoRefactor

--- a/src/Hint/NewType.hs
+++ b/src/Hint/NewType.hs
@@ -5,7 +5,7 @@
     quantified data types because it is not valid.
 
 <TEST>
-data Foo = Foo Int -- newtype Foo = Foo Int @NoRefactor hlint bug: ideaRefactoring = []
+data Foo = Foo Int -- newtype Foo = Foo Int @NoRefactor: refactoring for "Use newtype" is not implemented
 data Foo = Foo Int deriving (Show, Eq) -- newtype Foo = Foo Int deriving (Show, Eq) @NoRefactor
 data Foo = Foo { field :: Int } deriving Show -- newtype Foo = Foo { field :: Int } deriving Show @NoRefactor
 data Foo a b = Foo a -- newtype Foo a b = Foo a @NoRefactor

--- a/src/Hint/Pattern.hs
+++ b/src/Hint/Pattern.hs
@@ -16,7 +16,7 @@ foo b | c <- f b = c \
       | c <- f b = c
 foo x = yes x x where yes x y = if a then b else if c then d else e -- yes x y ; | a = b ; | c = d ; | otherwise = e
 foo x | otherwise = y -- foo x = y
-foo x = x + x where --
+foo x = x + x where -- @NoRefactor: refactoring for "Redundant where" is not implemented
 foo x | a = b | True = d -- foo x | a = b ; | otherwise = d
 foo (Bar _ _ _ _) = x -- Bar{}
 foo (Bar _ x _ _) = x


### PR DESCRIPTION
Previously:
- If there's no hint, the refactoring output should be identical to the input (ignoring spaces and semicolons)
- If there's a hint, `ideaTo` should be a substring of the refactoring output (ignoring spaces and semicolons)

Now, additionally:
- If `ideaTo == Nothing` (meaning the hint is a parse error), skip the refactoring test.

  It doesn't make sense to test refactoring when there's a parse error.

- If `ideaTo == Just ""` (i.e., the suggestion is "perhaps you should remove it"), the refactoring output should be a _proper subsequence_ of the input (ignoring spaces and semicolons).

  This ensures the "redundant x" hints are tested properly. Previously refactoring tests for "redundant x" hints trivially pass (as long as `refactor` doesn't crash) because `""` is a substring of any string.