### PR TITLE
Update ghc-lib, ghc-lib-parser-ex

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -76,7 +76,7 @@ library
       build-depends:
           ghc-lib-parser == 8.10.*
     build-depends:
-        ghc-lib-parser-ex >= 8.10.0.4 && < 8.10.1
+        ghc-lib-parser-ex >= 8.10.0.5 && < 8.10.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -35,7 +35,7 @@ import GHC.Util.RdrName
 import GHC.Util.Scope
 import GHC.Util.Unify
 
-import qualified Language.Haskell.GhclibParserEx.Parse as GhclibParserEx
+import qualified Language.Haskell.GhclibParserEx.GHC.Parser as GhclibParserEx
 import Language.Haskell.GhclibParserEx.GHC.Driver.Session (parsePragmasIntoDynFlags)
 
 import GHC.Hs

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,11 +2,11 @@ resolver: lts-14.20 # ghc-8.6.5
 packages:
   - .
 extra-deps:
-  - ghc-lib-parser-8.10.1.20200324
-  - ghc-lib-parser-ex-8.10.0.4
+  - ghc-lib-parser-8.10.1.20200412
+  - ghc-lib-parser-ex-8.10.0.5
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
-#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.5.tar.gz
+#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.6.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
   - extra-1.7.1
 ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds -Werror=orphans}


### PR DESCRIPTION
## 8.10.0.5 released 2020-05-02
- New modules
  - `Language.Haskell.GhclibParserEx.GHC.Parser`, `Language.Haskell.GhcLibParserEx.GHC.Utils.Outputable` to replace `Language.Haskell.GhclibParserEx.Parse` and `Language.Haskell.GhclibParserEx.Outputable` (which remain for now but deprecated and will be removed in a future release)
