### PR TITLE
Rename 'langExts' and 'mkLangExts'

### DIFF
--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -71,7 +71,7 @@ applyHintsReal settings hints_ ms = concat $
 removeRequiresExtensionNotes :: ModuleEx -> Idea -> Idea
 removeRequiresExtensionNotes m = \x -> x{ideaNote = filter keep $ ideaNote x}
     where
-        exts = Set.fromList $ concatMap snd $ langExts $ pragmas $ ghcAnnotations m
+        exts = Set.fromList $ concatMap snd $ languagePragmas $ pragmas $ ghcAnnotations m
         keep (RequiresExtension x) = not $ x `Set.member` exts
         keep _ = True
 

--- a/src/GHC/Util/ApiAnnotation.hs
+++ b/src/GHC/Util/ApiAnnotation.hs
@@ -1,8 +1,8 @@
 
 module GHC.Util.ApiAnnotation (
     comment, commentText, isCommentMultiline
-  , pragmas, flags, langExts
-  , mkFlags, mkLangExts
+  , pragmas, flags, languagePragmas
+  , mkFlags, mkLanguagePragmas
 ) where
 
 import ApiAnnotation
@@ -83,12 +83,12 @@ flags ps =
                              <|> stripPrefixCI "OPTIONS " s]
              , let opts = words rest]
 
--- Language extensions. The first element of the pair is the (located)
--- annotation comment that enables the extensions enumerated by he
--- second element of the pair.
-langExts :: [(Located AnnotationComment, String)]
+-- Language pragmas. The first element of the
+-- pair is the (located) annotation comment that enables the
+-- pragmas enumerated by he second element of the pair.
+languagePragmas :: [(Located AnnotationComment, String)]
          -> [(Located AnnotationComment, [String])]
-langExts ps =
+languagePragmas ps =
   [(c, exts) | (c, s) <- ps
              , Just rest <- [stripPrefixCI "LANGUAGE " s]
              , let exts = map trim (splitOn "," rest)]
@@ -98,6 +98,6 @@ mkFlags :: SrcSpan -> [String] -> Located AnnotationComment
 mkFlags loc flags =
   L loc $ AnnBlockComment ("{-# " ++ "OPTIONS_GHC " ++ unwords flags ++ " #-}")
 
-mkLangExts :: SrcSpan -> [String] -> Located AnnotationComment
-mkLangExts loc exts =
+mkLanguagePragmas :: SrcSpan -> [String] -> Located AnnotationComment
+mkLanguagePragmas loc exts =
   L loc $ AnnBlockComment ("{-# " ++ "LANGUAGE " ++ intercalate ", " exts ++ " #-}")

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -236,13 +236,13 @@ extensionsHint :: ModuHint
 extensionsHint _ x =
     [ rawIdea' Hint.Type.Warning "Unused LANGUAGE pragma"
         sl
-        (comment (mkLangExts sl exts))
+        (comment (mkLanguagePragmas sl exts))
         (Just newPragma)
         ( [RequiresExtension (show gone) | (_, Just x) <- before \\ after, gone <- Map.findWithDefault [] x disappear] ++
             [ Note $ "Extension " ++ show x ++ " is " ++ reason x
             | (_, Just x) <- explainedRemovals])
-        [ModifyComment (toSS' (mkLangExts sl exts)) newPragma]
-    | (L sl _,  exts) <- langExts $ pragmas (ghcAnnotations x)
+        [ModifyComment (toSS' (mkLanguagePragmas sl exts)) newPragma]
+    | (L sl _,  exts) <- languagePragmas $ pragmas (ghcAnnotations x)
     , let before = [(x, readExtension x) | x <- filterEnabled exts]
     , let after = filter (maybe True (`Set.member` keep) . snd) before
     , before /= after
@@ -250,7 +250,7 @@ extensionsHint _ x =
             | null after && not (any (`Map.member` implied) $ mapMaybe snd before) = []
             | otherwise = before \\ after
     , let newPragma =
-            if null after then "" else comment (mkLangExts sl $ map fst after)
+            if null after then "" else comment (mkLanguagePragmas sl $ map fst after)
     ]
   where
     filterEnabled :: [String] -> [String]
@@ -264,7 +264,7 @@ extensionsHint _ x =
     -- All the extensions defined to be used.
     extensions :: Set.Set Extension
     extensions = Set.fromList $ mapMaybe readExtension $
-        concatMap (filterEnabled . snd) $ langExts (pragmas (ghcAnnotations x))
+        concatMap (filterEnabled . snd) $ languagePragmas (pragmas (ghcAnnotations x))
 
     -- Those extensions we detect to be useful.
     useful :: Set.Set Extension

--- a/src/Hint/Pattern.hs
+++ b/src/Hint/Pattern.hs
@@ -87,7 +87,7 @@ patternHint _scope modu x =
     concatMap (patHint strict True) (universeBi $ transformBi noPatBind x) ++
     concatMap expHint (universeBi x)
   where
-    exts = nubOrd $ concatMap snd (langExts (pragmas (ghcAnnotations modu))) -- language extensions enabled at source
+    exts = nubOrd $ concatMap snd (languagePragmas (pragmas (ghcAnnotations modu))) -- language extensions enabled at source
     strict = "Strict" `elem` exts
 
     noPatBind :: LHsBind GhcPs -> LHsBind GhcPs

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -43,7 +43,7 @@ restrictHint settings scope m =
     let anns = ghcAnnotations m
         ps   = pragmas anns
         opts = flags ps
-        exts = langExts ps in
+        exts = languagePragmas ps in
     checkPragmas modu opts exts restrict ++
     maybe [] (checkImports modu $ hsmodImports (unLoc (ghcModule m))) (Map.lookup RestrictModule restrict) ++
     maybe [] (checkFunctions modu $ hsmodDecls (unLoc (ghcModule m))) (Map.lookup RestrictFunction restrict)


### PR DESCRIPTION
For your consideration. Previously `langExts` returned any and all strings found in a `LANGUAGE` pragma. Now it weeds out those strings that aren't extensions (in the sense of inhabitants of `Extension`).  The point is that the function is made more faithful to its name. This PR relates to issue https://github.com/ndmitchell/hlint/issues/961.