### PR TITLE
Don't default enable `StarIsType`

### DIFF
--- a/src/Extension.hs
+++ b/src/Extension.hs
@@ -16,6 +16,7 @@ badExtensions =
   , UnboxedTuples, UnboxedSums -- breaks (#) lens operator
   , QuasiQuotes -- breaks [x| ...], making whitespace free list comps break
   , {- DoRec , -} RecursiveDo -- breaks rec
+  , StarIsType  -- See https://github.com/ndmitchell/hlint/issues/971.
   ]
 
 reallyBadExtensions =


### PR DESCRIPTION
Add `StarIsType` to "bad extensions".  See https://github.com/ndmitchell/hlint/issues/971 for details as to why that might be the right thing to do.