### PR TITLE
Respect disabling extensions from the command line

### DIFF
--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -164,7 +164,7 @@ allowFields v allow = do
 parseGHC :: (ParseFlags -> String -> ParseResult v) -> Val -> Parser v
 parseGHC parser v = do
     x <- parseString v
-    case parser defaultParseFlags{extensions=configExtensions} x of
+    case parser defaultParseFlags{enabledExtensions=configExtensions, disabledExtensions=[]} x of
         POk _ x -> pure x
         PFailed ps ->
           let (_, errs) = getMessages ps baseDynFlags

--- a/src/HSE/All.hs
+++ b/src/HSE/All.hs
@@ -44,20 +44,21 @@ data CppFlags
 data ParseFlags = ParseFlags
     {cppFlags :: CppFlags -- ^ How the file is preprocessed (defaults to 'NoCpp').
     ,baseLanguage :: Maybe Language -- ^ Base language (e.g. Haskell98, Haskell2010), defaults to 'Nothing'.
-    ,extensions :: [Extension] -- ^ List of extensions enabled for parsing, defaults to many non-conflicting extensions.
+    ,enabledExtensions :: [Extension] -- ^ List of extensions enabled for parsing, defaults to many non-conflicting extensions.
+    ,disabledExtensions :: [Extension] -- ^ List of extensions disabled for parsing, usually empty.
     ,fixities :: [FixityInfo] -- ^ List of fixities to be aware of, defaults to those defined in @base@.
     }
 
 -- | Default value for 'ParseFlags'.
 defaultParseFlags :: ParseFlags
-defaultParseFlags = ParseFlags NoCpp Nothing defaultExtensions defaultFixities
+defaultParseFlags = ParseFlags NoCpp Nothing defaultExtensions [] defaultFixities
 
 -- | Given some fixities, add them to the existing fixities in 'ParseFlags'.
 parseFlagsAddFixities :: [FixityInfo] -> ParseFlags -> ParseFlags
 parseFlagsAddFixities fx x = x{fixities = fx ++ fixities x}
 
-parseFlagsSetLanguage :: (Maybe Language, [Extension]) -> ParseFlags -> ParseFlags
-parseFlagsSetLanguage (l, es) x = x{baseLanguage = l, extensions = es}
+parseFlagsSetLanguage :: (Maybe Language, ([Extension], [Extension])) -> ParseFlags -> ParseFlags
+parseFlagsSetLanguage (l, (es, ds)) x = x{baseLanguage = l, enabledExtensions = es, disabledExtensions = ds}
 
 
 runCpp :: CppFlags -> FilePath -> String -> IO String
@@ -105,7 +106,7 @@ ghcFailOpParseModuleEx ppstr file str (loc, err) = do
 
 -- GHC extensions to enable/disable given HSE parse flags.
 ghcExtensionsFromParseFlags :: ParseFlags -> ([Extension], [Extension])
-ghcExtensionsFromParseFlags ParseFlags{extensions=exts}= (exts, [])
+ghcExtensionsFromParseFlags ParseFlags{enabledExtensions=es, disabledExtensions=ds}= (es, ds)
 
 -- GHC fixities given HSE parse flags.
 ghcFixitiesFromParseFlags :: ParseFlags -> [(String, Fixity)]

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -196,7 +196,7 @@ static = 42 --
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE Trustworthy, NamedFieldPuns #-} -- {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE Haskell2010 #-}
-{-# LANGUAGE NoStarIsType #-} \
+{-# LANGUAGE NoStarIsType, ExplicitNamespaces #-} \
 import GHC.TypeLits(KnownNat, type (+), type (*))
 </TEST>
 -}


### PR DESCRIPTION
Support `-XNoFoo`. Fixes https://github.com/ndmitchell/hlint/issues/971.

Tested on this program with `stack run -- -XNoStarIsType ~/Quux.hs` where Quux.hs contains
```haskell
{-# LANGUAGE ExplicitNamespaces #-}

import GHC.TypeLits(KnownNat, type (+), type (*))
```
There were two test failures : one relates to the added test in `Extension.hs` missing the `ExplicitNamespaces` extension, I fixed it incidentally. The other I think is unrelated to this work and probably relates to a work in progress by @ndmitchell 