### PR TITLE
Run refactor even if no hints

### DIFF
--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -182,8 +182,9 @@ getIdeas cmd@CmdMain{..} settings = do
         then [i | i <- ideas, ideaHint i `elem` cmdOnly]
         else ideas
 
+-- #746: run refactor even if no hint, which ensures consistent output
+-- whether there are hints or not.
 handleRefactoring :: [Idea] -> [String] -> Cmd -> IO ()
-handleRefactoring [] _ _ = pure () -- No refactorings to apply
 handleRefactoring ideas files cmd@CmdMain{..} =
     case cmdFiles of
         [file] -> do


### PR DESCRIPTION
Fixes #746 - makes the output of `--refactor` consistent when there are hints vs no hints.
Also makes the output of `hlint Foo.hs --refactor` consistent with `hlint Foo.hs --serialise | refactor`.

An alternative approach is to just echo the input if there's no hint (instead of calling refactor), but it would ignore refactor options, such as `--refactor-options="--inplace"`.

By the way, `apply-refact` still attempts to refactor the input even if there's no hint. I doubt it is desirable; I don't see why it's not a no-op but in any case it should be fixed by `apply-refact`. From hlint perspective it should just call `apply-refact` regardless.

Test:
```haskell
-- Foo.hs
foo = 42
bar = "string"
```

```
$ ~/.cabal/bin/hlint Foo.hs --refactor
foo = 42
bar = "string"
```