### PR TITLE
Update ghc-lib-parser-ex

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -76,7 +76,7 @@ library
       build-depends:
           ghc-lib-parser == 8.10.*
     build-depends:
-        ghc-lib-parser-ex >= 8.10.0.6 && < 8.10.1
+        ghc-lib-parser-ex >= 8.10.0.7 && < 8.10.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,10 +3,10 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.10.1.20200412
-  - ghc-lib-parser-ex-8.10.0.6
+  - ghc-lib-parser-ex-8.10.0.7
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
-#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.7.tar.gz
+#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.8.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
   - extra-1.7.1
 ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds -Werror=orphans}


### PR DESCRIPTION
## 8.10.0.7 released 2020-05-13
- New function `fixitiesFromModule`
