### PR TITLE
Remove ticks from RdrName

### DIFF
--- a/src/Config/Compute.hs
+++ b/src/Config/Compute.hs
@@ -72,7 +72,7 @@ findExp name vs bod = [SettingMatchExp $
         rhs = apps' $ map noLoc $ HsVar noExtField (noLoc name) : map snd rep
 
         rep = zip vs $ map (mkVar . pure) ['a'..]
-        f (HsVar _ x) | Just y <- lookup (occNameString $ occName $ unLoc x) rep = y
+        f (HsVar _ x) | Just y <- lookup (rdrNameStr x) rep = y
         f (OpApp _ x dol y) | isDol dol = HsApp noExtField x $ noLoc $ HsPar noExtField y
         f x = x
 

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -22,7 +22,6 @@ import GHC.Hs.Expr hiding (Match)
 import GHC.Hs.Lit
 import FastString
 import ApiAnnotation
-import OccName
 import Outputable
 
 import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
@@ -33,8 +32,8 @@ readPragma :: AnnDecl GhcPs -> Maybe Classify
 readPragma (HsAnnotation _ _ provenance expr) = f expr
     where
         name = case provenance of
-            ValueAnnProvenance (L _ x) -> occNameString $ occName x
-            TypeAnnProvenance (L _ x) -> occNameString $ occName x
+            ValueAnnProvenance (L _ x) -> occNameStr x
+            TypeAnnProvenance (L _ x) -> occNameStr x
             ModuleAnnProvenance -> ""
 
         f (L _ (HsLit _ (HsString _ (unpackFS -> s)))) | "hlint:" `isPrefixOf` lower s =

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -37,7 +37,7 @@ import GHC.Hs
 import SrcLoc
 import RdrName
 import OccName
-import GHC.Util (baseDynFlags, Scope,scopeCreate)
+import GHC.Util (baseDynFlags, Scope, scopeCreate, occNameStr)
 import Language.Haskell.GhclibParserEx.GHC.Hs.ExtendInstances
 import Data.Char
 
@@ -300,7 +300,7 @@ guessName lhs rhs
     where
         (ls, rs) = both f (lhs, rhs)
         f :: LHsExpr GhcPs -> [String]
-        f x = [y | L _ (HsVar _ (L _ x)) <- universe x, let y = occNameString $ rdrNameOcc x, not $ isUnifyVar y, y /= "."]
+        f x = [y | L _ (HsVar _ (L _ x)) <- universe x, let y = occNameStr x, not $ isUnifyVar y, y /= "."]
 
 
 asNote :: String -> Note

--- a/src/Fixity.hs
+++ b/src/Fixity.hs
@@ -9,6 +9,7 @@ module Fixity(
 import GHC.Generics(Associativity(..))
 import GHC.Hs.Binds
 import GHC.Hs.Extension
+import GHC.Util(rdrNameStr)
 import OccName
 import RdrName
 import SrcLoc
@@ -27,7 +28,7 @@ type FixityInfo = (String, Associativity, Int)
 
 fromFixitySig :: FixitySig GhcPs -> [FixityInfo]
 fromFixitySig (FixitySig _ names (Fixity _ i dir)) =
-    [(occNameString $ occName $ unLoc name, f dir, i) | name <- names]
+    [(rdrNameStr name, f dir, i) | name <- names]
     where
         f InfixL = LeftAssociative
         f InfixR = RightAssociative

--- a/src/GHC/Util/HsDecl.hs
+++ b/src/GHC/Util/HsDecl.hs
@@ -3,8 +3,9 @@
 module GHC.Util.HsDecl (declName,bindName)
 where
 
+import GHC.Util.RdrName(occNameStr, rdrNameStr)
+
 import GHC.Hs
-import OccName
 import SrcLoc
 
 -- | @declName x@ returns the \"new name\" that is created (for
@@ -14,7 +15,7 @@ import SrcLoc
 -- want to tell users to rename binders that they aren't creating
 -- right now and therefore usually cannot change.
 declName :: LHsDecl GhcPs -> Maybe String
-declName (L _ x) = occNameString . occName <$> case x of
+declName (L _ x) = occNameStr <$> case x of
     TyClD _ FamDecl{tcdFam=FamilyDecl{fdLName}} -> Just $ unLoc fdLName
     TyClD _ SynDecl{tcdLName} -> Just $ unLoc tcdLName
     TyClD _ DataDecl{tcdLName} -> Just $ unLoc tcdLName
@@ -31,6 +32,6 @@ declName (L _ x) = occNameString . occName <$> case x of
 
 
 bindName :: LHsBind GhcPs -> Maybe String
-bindName (L _ FunBind{fun_id}) = Just $ occNameString $ occName $ unLoc fun_id
-bindName (L _ VarBind{var_id}) = Just $ occNameString $ occName var_id
+bindName (L _ FunBind{fun_id}) = Just $ rdrNameStr fun_id
+bindName (L _ VarBind{var_id}) = Just $ occNameStr var_id
 bindName _ = Nothing

--- a/src/GHC/Util/RdrName.hs
+++ b/src/GHC/Util/RdrName.hs
@@ -1,24 +1,26 @@
-module GHC.Util.RdrName (isSpecial', unqual', rdrNameStr',fromQual') where
+module GHC.Util.RdrName (isSpecial, unqual, occNameStr, rdrNameStr,fromQual) where
 
 import SrcLoc
 import Name
 import RdrName
 
-rdrNameStr' :: Located RdrName -> String
-rdrNameStr' = occNameString . rdrNameOcc . unLoc
+-- These names may not seem natural here but they work out in
+-- practice. The use of thse two functions is thoroughly ubiquitous.
+occNameStr :: RdrName -> String; occNameStr = occNameString . rdrNameOcc
+rdrNameStr :: Located RdrName -> String; rdrNameStr = occNameStr . unLoc
 
 -- Builtin type or data constructors.
-isSpecial' :: Located RdrName -> Bool
-isSpecial' (L _ (Exact n)) = isDataConName n || isTyConName n
-isSpecial' _ = False
+isSpecial :: Located RdrName -> Bool
+isSpecial (L _ (Exact n)) = isDataConName n || isTyConName n
+isSpecial _ = False
 
 -- Coerce qualified names to unqualified (by discarding the
 -- qualifier).
-unqual' :: Located RdrName -> Located RdrName
-unqual' (L loc (Qual _ n)) = cL loc $ mkRdrUnqual n
-unqual' x = x
+unqual :: Located RdrName -> Located RdrName
+unqual (L loc (Qual _ n)) = cL loc $ mkRdrUnqual n
+unqual x = x
 
-fromQual' :: Located RdrName -> Maybe OccName
-fromQual' (L _ (Qual _ x)) = Just x
-fromQual' (L _ (Unqual x)) = Just x
-fromQual' _ = Nothing
+fromQual :: Located RdrName -> Maybe OccName
+fromQual (L _ (Qual _ x)) = Just x
+fromQual (L _ (Unqual x)) = Just x
+fromQual _ = Nothing

--- a/src/GHC/Util/View.hs
+++ b/src/GHC/Util/View.hs
@@ -9,10 +9,8 @@ module GHC.Util.View (
 
 import GHC.Hs
 import SrcLoc
-import RdrName
-import OccName
 import BasicTypes
-import GHC.Util.RdrName (rdrNameStr')
+import GHC.Util.RdrName (rdrNameStr, occNameStr)
 
 fromParen :: LHsExpr GhcPs -> LHsExpr GhcPs
 fromParen (L _ (HsPar _ x)) = fromParen x
@@ -37,7 +35,7 @@ instance View (LHsExpr GhcPs) LamConst1 where
   view _ = NoLamConst1
 
 instance View (LHsExpr GhcPs) Var_ where
-    view (fromParen -> (L _ (HsVar _ (rdrNameStr' -> x)))) = Var_ x
+    view (fromParen -> (L _ (HsVar _ (rdrNameStr -> x)))) = Var_ x
     view _ = NoVar_
 
 instance View (LHsExpr GhcPs) App2 where
@@ -46,14 +44,14 @@ instance View (LHsExpr GhcPs) App2 where
   view _ = NoApp2
 
 instance View (Located (Pat GhcPs)) PVar_ where
-  view (fromPParen -> L _ (VarPat _ (L _ x))) = PVar_ $ occNameString (rdrNameOcc x)
+  view (fromPParen -> L _ (VarPat _ (L _ x))) = PVar_ $ occNameStr x
   view _ = NoPVar_
 
 instance View (Located (Pat GhcPs)) PApp_ where
   view (fromPParen -> L _ (ConPatIn (L _ x) (PrefixCon args))) =
-    PApp_ (occNameString . rdrNameOcc $ x) args
+    PApp_ (occNameStr x) args
   view (fromPParen -> L _ (ConPatIn (L _ x) (InfixCon lhs rhs))) =
-    PApp_ (occNameString . rdrNameOcc $ x) [lhs, rhs]
+    PApp_ (occNameStr x) [lhs, rhs]
   view _ = NoPApp_
 
 -- A lambda with no guards and no where clauses

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -224,7 +224,6 @@ import GHC.Hs
 import BasicTypes
 import Class
 import RdrName
-import OccName
 import ForeignCall
 
 import GHC.Util
@@ -372,7 +371,7 @@ used TypeOperators = hasS tyOpInSig ||^ hasS tyOpInDecl
       _ -> False
 
     isOp :: LIdP GhcPs -> Bool
-    isOp name = case occNameString (rdrNameOcc (unLoc name)) of
+    isOp name = case rdrNameStr name of
       (c:_) -> not $ isAlpha c || c == '_'
       _ -> False
 used RecordWildCards = hasS hasFieldsDotDot ||^ hasS hasPFieldsDotDot
@@ -412,7 +411,7 @@ used TransformListComp = hasS isTransStmt
 used MagicHash = hasS f ||^ hasS isPrimLiteral
     where
       f :: RdrName -> Bool
-      f s = "#" `isSuffixOf` (occNameString . rdrNameOcc) s
+      f s = "#" `isSuffixOf` occNameStr s
 used PatternSynonyms = hasS isPatSynBind ||^ hasS isPatSynIE
     where
       isPatSynBind :: HsBind GhcPs -> Bool
@@ -475,7 +474,7 @@ derives (L _ m) =  mconcat $ map decl (childrenBi m) ++ map idecl (childrenBi m)
         ih (L _ (HsQualTy _ _ a)) = ih a
         ih (L _ (HsParTy _ a)) = ih a
         ih (L _ (HsAppTy _ a _)) = ih a
-        ih (L _ (HsTyVar _ _ a)) = unsafePrettyPrint $ unqual' a
+        ih (L _ (HsTyVar _ _ a)) = unsafePrettyPrint $ unqual a
         ih (L _ a) = unsafePrettyPrint a -- I don't anticipate this case is called.
     derivedToStr _ = "" -- new ctor
 

--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -108,7 +108,7 @@ import BasicTypes
 import GHC.Util.Brackets (isAtom)
 import GHC.Util.FreeVars (free, allVars, freeVars, pvars, vars, varss)
 import GHC.Util.HsExpr (allowLeftSection, allowRightSection, niceLambdaR', lambda)
-import GHC.Util.RdrName (rdrNameStr')
+import GHC.Util.RdrName (rdrNameStr)
 import GHC.Util.View
 import GHC.Hs
 import Language.Haskell.GhclibParserEx.GHC.Hs.Expr (isTypeApp, isOpApp, isLambda, isQuasiQuote, isVar, isDol, strToVar)
@@ -263,7 +263,7 @@ varBody = strToVar "body"
 fromLambda :: LHsExpr GhcPs -> ([LPat GhcPs], LHsExpr GhcPs)
 fromLambda (SimpleLambda ps1 (fromLambda . fromParen -> (ps2,x))) = (transformBi (f $ pvars ps2) ps1 ++ ps2, x)
     where f :: [String] -> Pat GhcPs -> Pat GhcPs
-          f bad (VarPat _ (rdrNameStr' -> x))
+          f bad (VarPat _ (rdrNameStr -> x))
               | x `elem` bad = WildPat noExtField
           f bad x = x
 fromLambda x = ([], x)

--- a/src/Hint/List.hs
+++ b/src/Hint/List.hs
@@ -53,7 +53,6 @@ import GHC.Hs
 import SrcLoc
 import BasicTypes
 import RdrName
-import OccName
 import Name
 import FastString
 import TysWiredIn
@@ -109,7 +108,7 @@ listCompCheckGuards o ctx stmts =
         o3 = noLoc $ HsDo noExtField ctx (noLoc $ ys ++ [e])
         cons = mapMaybe qualCon xs
         qualCon :: ExprLStmt GhcPs -> Maybe String
-        qualCon (L _ (BodyStmt _ (L _ (HsVar _ (L _ x))) _ _)) = Just (occNameString . rdrNameOcc $ x)
+        qualCon (L _ (BodyStmt _ (L _ (HsVar _ (L _ x))) _ _)) = Just (occNameStr x)
         qualCon _ = Nothing
 
 listCompCheckMap ::

--- a/src/Hint/ListRec.hs
+++ b/src/Hint/ListRec.hs
@@ -49,7 +49,6 @@ import RdrName
 import GHC.Hs.Binds
 import GHC.Hs.Expr
 import GHC.Hs.Decls
-import OccName
 import BasicTypes
 
 import GHC.Util
@@ -211,7 +210,7 @@ findBranch (L _ x) = do
                         }
             } <- pure x
   (a, b, c) <- findPat ps
-  pure $ Branch (occNameString $rdrNameOcc name) a b c $ simplifyExp' body
+  pure $ Branch (occNameStr name) a b c $ simplifyExp' body
 
 findPat :: [LPat GhcPs] -> Maybe ([String], Int, BList)
 findPat ps = do

--- a/src/Hint/Match.hs
+++ b/src/Hint/Match.hs
@@ -233,7 +233,7 @@ checkDefine' declName Nothing y =
         L _ (HsApp _ fun _) -> funOrOp fun
         L _ (OpApp _ _ op _) -> funOrOp op
         other -> other
-   in declName /= varToStr (transformBi unqual' $ funOrOp y)
+   in declName /= varToStr (transformBi unqual $ funOrOp y)
 checkDefine' _ _ _ = True
 
 ---------------------------------------------------------------------

--- a/src/Hint/Pattern.hs
+++ b/src/Hint/Pattern.hs
@@ -237,7 +237,7 @@ expHint o@(L _ (HsCase _ _ (MG _ (L _ [L _ (Match _ CaseAlt [L _ (WildPat _)] (G
   where
     r = Replace Expr (toSS o) [("x", toSS e)] "x"
 expHint o@(L _ (HsCase _ (L _ (HsVar _ (L _ x))) (MG _ (L _ [L _ (Match _ CaseAlt [L _ (VarPat _ (L _ y))] (GRHSs _ [L _ (GRHS _ [] e)] (L  _ (EmptyLocalBinds _)))) ]) FromSource )))
-  | occNameString (rdrNameOcc x) == occNameString (rdrNameOcc y) =
+  | occNameStr x == occNameStr y =
       [suggest "Redundant case" o e [r]]
   where
     r = Replace Expr (toSS o) [("x", toSS e)] "x"

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -151,6 +151,6 @@ checkFunctions modu decls (def, mp) =
     | d <- decls
     , let dname = fromMaybe "" (declName d)
     , x <- universeBi d :: [Located RdrName]
-    , let ri@RestrictItem{..} = Map.findWithDefault (RestrictItem [] [("","") | def] [] Nothing) (occNameString (rdrNameOcc (unLoc x))) mp
+    , let ri@RestrictItem{..} = Map.findWithDefault (RestrictItem [] [("","") | def] [] Nothing) (rdrNameStr x) mp
     , not $ within modu dname ri
     ]


### PR DESCRIPTION
Remove ticks from `RdrName` and take the chance to reduce some repetition by consistent use of `rdrNameStr` and newly added `occNameStr`.