### PR TITLE
Update ghc-lib-parser-ex

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -76,7 +76,7 @@ library
       build-depends:
           ghc-lib-parser == 8.10.*
     build-depends:
-        ghc-lib-parser-ex >= 8.10.0.8 && < 8.10.1
+        ghc-lib-parser-ex >= 8.10.0.9 && < 8.10.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -239,6 +239,8 @@ import Language.Haskell.GhclibParserEx.GHC.Hs.Pat
 import Language.Haskell.GhclibParserEx.GHC.Hs.Expr
 import Language.Haskell.GhclibParserEx.GHC.Hs.Types
 import Language.Haskell.GhclibParserEx.GHC.Hs.Decls
+import Language.Haskell.GhclibParserEx.GHC.Hs.Binds
+import Language.Haskell.GhclibParserEx.GHC.Hs.ImpExp
 import Language.Haskell.GhclibParserEx.GHC.Driver.Session
 import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
 import Language.Haskell.GhclibParserEx.GHC.Types.Name.Reader
@@ -427,14 +429,6 @@ used MagicHash = hasS f ||^ hasS isPrimLiteral
     f :: RdrName -> Bool
     f s = "#" `isSuffixOf` occNameStr s
 used PatternSynonyms = hasS isPatSynBind ||^ hasS isPatSynIE
-  where
-    isPatSynBind :: HsBind GhcPs -> Bool
-    isPatSynBind PatSynBind{} = True
-    isPatSynBind _ = False
-
-    isPatSynIE :: IEWrappedName RdrName -> Bool
-    isPatSynIE IEPattern{} = True
-    isPatSynIE _ = False
 used _= const True
 
 hasDerive :: [String] -> Located (HsModule GhcPs) -> Bool

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,10 +3,10 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.10.1.20200412
-  - ghc-lib-parser-ex-8.10.0.8
+  - ghc-lib-parser-ex-8.10.0.9
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
-#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.9.tar.gz
+#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.10.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
   - extra-1.7.1
 ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds -Werror=orphans}


### PR DESCRIPTION
## 8.10.0.9 released 2020-05-16
- New modules
  - `Language.Haskell.GhclibParserEx.GHC.Hs.Binds`
  - `Language.Haskell.GhclibParserEx.GHC.Hs.ImpExp`
