### PR TITLE
Update ghc-lib-parser, ghc-lib-parser-ex

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -76,7 +76,7 @@ library
       build-depends:
           ghc-lib-parser == 8.10.*
     build-depends:
-        ghc-lib-parser-ex >= 8.10.0.9 && < 8.10.1
+        ghc-lib-parser-ex >= 8.10.0.10 && < 8.10.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,11 +2,11 @@ resolver: lts-14.20 # ghc-8.6.5
 packages:
   - .
 extra-deps:
-  - ghc-lib-parser-8.10.1.20200412
-  - ghc-lib-parser-ex-8.10.0.9
+  - ghc-lib-parser-8.10.1.20200518
+  - ghc-lib-parser-ex-8.10.0.10
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
-#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.10.tar.gz
+#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.11.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
   - extra-1.7.1
 ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds -Werror=orphans}


### PR DESCRIPTION
Not essential (hlint would pick up the ghc-lib-parser change anyway and the ghc-lib-parser-ex change doesn't introduce anything new) but one of those helps me keep everything sane updates.

## 8.10.0.10 released 2020-05-18
- Upgrade to `ghc-lib-parser-8.10.1.20200518`
