### PR TITLE
Add new hint "Newtype field name prefixed"

### DIFF
--- a/data/default.yaml
+++ b/data/default.yaml
@@ -40,6 +40,9 @@
 # Ban "module X(module X) where", to require a real export list
 # - warn: {name: Use explicit module export list}
 #
+# Keep newtype field name prefixed
+# - warn: {name: Newtype field name prefixed}
+#
 # Replace a $ b $ c with a . b $ c
 # - group: {name: dollar, enabled: true}
 #

--- a/src/Hint/NewType.hs
+++ b/src/Hint/NewType.hs
@@ -28,6 +28,12 @@ newtype Foo = Foo Int deriving (Show, Eq) --
 newtype Foo = Foo { unFoo :: Int } deriving (Show, Eq) --
 newtype Foo = Foo Int deriving stock Show
 </TEST>
+
+   Suggest constructor field name (of a newtype) to be 'un' followed by newtype name
+
+<TEST>
+newtype Foo = Foo { i :: Int } -- newtype Foo = Foo { unFoo :: Int } @NoRefactor
+</TEST>
 -}
 module Hint.NewType (newtypeHint) where
 


### PR DESCRIPTION
New hint, turned off by default, that checks if field name in `newtype` constructor is prefixed with `un` followed by the newtype Name.

Example below:
```
➜  bat Foo.hs 
───────┬───────────────────────────────────────────────────────────────────
       │ File: Foo.hs
───────┼───────────────────────────────────────────────────────────────────
   1   │ module Foo where
   2   │ 
   3   │ 
   4   │ newtype Foo = Foo { bar :: Bar }
───────┴───────────────────────────────────────────────────────────────────
➜  hlint Foo.hs 
No hints
➜  touch .hlint.yaml
➜  echo '- warn: {name: Newtype field name prefixed}' > .hlint.yaml
➜  bat .hlint.yaml 
───────┬───────────────────────────────────────────────────────────────────
       │ File: .hlint.yaml
───────┼───────────────────────────────────────────────────────────────────
   1   │ - warn: {name: Newtype field name prefixed}
───────┴───────────────────────────────────────────────────────────────────
➜  hlint Foo.hs                                                    
Foo.hs:4:1-32: Warning: Newtype field name prefixed
Found:
  newtype Foo = Foo {bar :: Bar}
Perhaps:
  newtype Foo = Foo {unFoo :: Bar}
Note: Rename field to unFoo

1 hint

```

