### PR TITLE
Added package, group, rules for CodeWorld

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -50,6 +50,11 @@
     - import Data.Attoparsec.Text
     - import Data.Attoparsec.ByteString
 
+- package:
+    name: codeworld-api
+    modules:
+    - import CodeWorld
+
 - group:
     name: default
     enabled: true
@@ -948,6 +953,17 @@
     - hint: {lhs: maybe (f x) (f . g), rhs: f . maybe x g, note: IncreasesLaziness, name: Too strict maybe}
     - hint: {lhs: maybe (f x) f y, rhs: f (Data.Maybe.fromMaybe x y), note: IncreasesLaziness, name: Too strict maybe}
 
+- group:
+    name: codeworld
+    enabled: false
+    imports:
+    - package base
+    - package codeworld-api
+    rules:
+    - warn: {lhs: "pictures [ p ]", rhs: p, name: Evaluate}
+    - warn: {lhs: "pictures [ p, q ]", rhs: p & q, name: Evaluate}
+    - hint: {lhs: foldl1 (&), rhs: pictures}
+    - hint: {lhs: foldr (&) blank, rhs: pictures}
 
 - group:
     name: teaching


### PR DESCRIPTION
I'm not sure how "widely used" a package has to be to warrant its own set of hlint rules. But I found some rules useful in providing style feedback to students programming on/with the CodeWorld website (https://github.com/google/codeworld, https://code.world/haskell#), which is based on the codeworld-api package (https://hackage.haskell.org/package/codeworld-api). Maybe they would be useful to have in hlint for others as well.

So here they are, in an off-by-default rules group. There are certainly others (since the CodeWorld primitives satisfy many algebraic properties) that could be added in due course.