### PR TITLE
Unqualify Control.Applicative.<$>

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -390,7 +390,7 @@
     - warn: {lhs: f <$> g <$> x, rhs: f . g <$> x, name: Functor law}
     - warn: {lhs: fmap id, rhs: id, name: Functor law}
     - warn: {lhs: id <$> x, rhs: x, name: Functor law}
-    - hint: {lhs: fmap f $ x, rhs: f Control.Applicative.<$> x, side: isApp x || isAtom x}
+    - hint: {lhs: fmap f $ x, rhs: f <$> x, side: isApp x || isAtom x}
     - hint: {lhs: \x -> a <$> b x, rhs: fmap a . b}
     - hint: {lhs: x *> pure y, rhs: x Data.Functor.$> y}
     - hint: {lhs: x *> return y, rhs: x Data.Functor.$> y}
@@ -1094,7 +1094,7 @@
 # pairs (x:xs) = map (x,) xs ++ pairs xs
 # {-# ANN foo "HLint: ignore" #-};foo = map f (map g x) -- @Ignore ???
 # {-# HLINT ignore foo #-};foo = map f (map g x) -- @Ignore ???
-# yes = fmap lines $ abc 123 -- lines Control.Applicative.<$> abc 123
+# yes = fmap lines $ abc 123 -- lines <$> abc 123
 # no = fmap lines $ abc $ def 123
 # test = foo . not . not -- id
 # test = map (not . not) xs -- id


### PR DESCRIPTION
`<$>` has been in Prelude since base 4.8, so the "Control.Applicative." can be safely removed.