### PR TITLE
Upgrade ghc-lib

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -76,7 +76,7 @@ library
       build-depends:
           ghc-lib-parser == 8.10.*
     build-depends:
-        ghc-lib-parser-ex >= 8.10.0.10 && < 8.10.1
+        ghc-lib-parser-ex >= 8.10.0.11 && < 8.10.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,8 @@ resolver: lts-14.20 # ghc-8.6.5
 packages:
   - .
 extra-deps:
-  - ghc-lib-parser-8.10.1.20200518
-  - ghc-lib-parser-ex-8.10.0.10
+  - ghc-lib-parser-8.10.1.20200523
+  - ghc-lib-parser-ex-8.10.0.11
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.11.tar.gz


### PR DESCRIPTION
Non-critical. Update ghc-lib, ghc-lib-parser-ex.  

## 8.10.0.11 released 2020-05-18
- Upgrade to `ghc-lib-parser-8.10.1.20200523`
