### PR TITLE
Check scopes of restricted functions

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -33,7 +33,10 @@
   - {name: unsafeInterleaveIO, within: Parallel}
   - {name: unsafePerformIO, within: [Util.exitMessageImpure, Test.Util.ref, Timing]}
   - {name: unsafeCoerce, within: [Util.gzip, GHC.Util.Refact.Utils]}
-  - {name: nub, within: []}
+  - {name: Data.List.nub, within: []}
+  - {name: Data.List.nubBy, within: []}
+  - {name: Data.List.NonEmpty.nub, within: []}
+  - {name: Data.List.NonEmpty.nubBy, within: []}
 
 
 #####################################################################

--- a/src/GHC/Util/Scope.hs
+++ b/src/GHC/Util/Scope.hs
@@ -4,7 +4,7 @@
 
 module GHC.Util.Scope (
    Scope
-  ,scopeCreate,scopeMatch,scopeMove
+  ,scopeCreate,scopeMatch,scopeMove,possModules
 ) where
 
 import GHC.Hs


### PR DESCRIPTION
Fixes #861. This allows qualified restricted functions such as `{name: Data.List.nub, within: []}`. Previously this doesn't match anything, including `nub` and `Data.List.nub`.

If this is merged, a release would be appreciated. We would like to ban `Data.Map.fromList` but not `Ddata.Set.fromList`, and this patch allows us to do so.