### PR TITLE
more rules suggesting even/odd

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -617,6 +617,10 @@
     - hint: {lhs: 0 == rem n 2, rhs: even n}
     - hint: {lhs: rem n 2 /= 0, rhs: odd n}
     - hint: {lhs: 0 /= rem n 2, rhs: odd n}
+    - hint: {lhs: mod n 2 == 0, rhs: even n}
+    - hint: {lhs: 0 == mod n 2, rhs: even n}
+    - hint: {lhs: mod n 2 /= 0, rhs: odd n}
+    - hint: {lhs: 0 /= mod n 2, rhs: odd n}
     - hint: {lhs: not (even x), rhs: odd x}
     - hint: {lhs: not (odd x), rhs: even x}
     - hint: {lhs: x ** 0.5, rhs: sqrt x}


### PR DESCRIPTION
There are already these rules: https://github.com/ndmitchell/hlint/blob/f1b8d330cac9683dd5337a38e730a5f9915a97bf/data/hlint.yaml#L616-L619
This pull request adds the analogous rules for `mod` in place of `rem`.