### PR TITLE
in teaching group, suggest use of map for very simple list comprehension?

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -975,6 +975,7 @@
     - hint: {lhs: "[] /= x", rhs: not (null x), name: Use null}
     - hint: {lhs: "not (x || y)", rhs: "not x && not y", name: Apply De Morgan law}
     - hint: {lhs: "not (x && y)", rhs: "not x || not y", name: Apply De Morgan law}
+    - hint: {lhs: "[ f x | x <- l ]", rhs: map f l}
 
 # <TEST>
 # yes = concat . map f -- concatMap f


### PR DESCRIPTION
Actually, I was a bit surprised because I thought to remember that in the past hlint did on its own suggest replacing something like `[f x | x <- xs]` by `map f xs`. But maybe I was misremembering, or missing anything?