### PR TITLE
Replace an occurrence of disjoint with disjointOrd

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -62,7 +62,7 @@ library
         yaml >= 0.5.0,
         uniplate >= 1.5,
         ansi-terminal >= 0.6.2,
-        extra >= 1.7.1,
+        extra >= 1.7.3,
         refact >= 0.3,
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1

--- a/src/GHC/Util/Scope.hs
+++ b/src/GHC/Util/Scope.hs
@@ -58,7 +58,7 @@ scopeMatch (a, x) (b, y)
   | isSpecial x && isSpecial y = rdrNameStr x == rdrNameStr y
   | isSpecial x || isSpecial y = False
   | otherwise =
-     rdrNameStr (unqual x) == rdrNameStr (unqual y) && not (possModules a x `disjoint` possModules b y)
+     rdrNameStr (unqual x) == rdrNameStr (unqual y) && not (possModules a x `disjointOrd` possModules b y)
 
 -- Given a name in a scope, and a new scope, create a name for the new
 -- scope that will refer to the same thing. If the resulting name is

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ extra-deps:
 # modify extra-deps like this:
 #  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.11.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
-  - extra-1.7.1
+  - extra-1.7.3
 ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds -Werror=orphans}
 # Enabling this stanza forces both hlint and ghc-lib-parser-ex to
 # depend on ghc-lib-parser.


### PR DESCRIPTION
This has a noticeable speedup on `cabal/cabal-install/Distribution/Client/Setup.hs` (one of the largest .hs files in the repo):

```
(hlint Setup.hs 20 times)
Before:
real    0m42.864s
user    0m42.619s
sys     0m0.269s

After, 12% speedup:
real    0m37.755s
user    0m37.516s
sys     0m0.257s
```

The speedup quickly diminishes when the file is smaller, since `disjoint` and `disjointOrd` have similar runtime if one of the lists is small (`disjoint` could even be a bit faster).

```
(hlint the whole cabal repo 20 times)
Before:
real    24m35.506s
user    24m28.125s
sys     0m8.527s

After, 4% speedup:
real    23m37.180s
user    23m29.249s
sys     0m8.867s
```