### PR TITLE
Add/modify sequenceA hints

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -241,7 +241,6 @@
 
     - warn: {lhs: sequenceA (map f x), rhs: traverse f x}
     - warn: {lhs: sequenceA (fmap f x), rhs: traverse f x}
-    - warn: {lhs: sequence (fmap f x), rhs: traverse f x}
     - warn: {lhs: sequenceA_ (map f x), rhs: traverse_ f x}
     - warn: {lhs: sequenceA_ (fmap f x), rhs: traverse_ f x}
     - warn: {lhs: foldMap id, rhs: fold}
@@ -264,7 +263,7 @@
 
     # FOLDS
 
-    - warn: {lhs: foldr  (>>) (return ()), rhs: sequence_}
+    - warn: {lhs: foldr  (>>) (return ()), rhs: sequenceA_}
     - warn: {lhs: foldr  (&&) True, rhs: and}
     - warn: {lhs: foldl  (&&) True, rhs: and, note: IncreasesLaziness}
     - warn: {lhs: foldr1 (&&) , rhs: and, note: "RemovesError on `[]`"}
@@ -485,14 +484,18 @@
     - warn: {lhs: sequence_ (zipWith f x y), rhs: Control.Monad.zipWithM_ f x y}
     - warn: {lhs: sequence (replicate n x), rhs: Control.Monad.replicateM n x}
     - warn: {lhs: sequence_ (replicate n x), rhs: Control.Monad.replicateM_ n x}
+    - warn: {lhs: sequenceA (zipWith f x y), rhs: Control.Monad.zipWithM f x y}
+    - warn: {lhs: sequenceA_ (zipWith f x y), rhs: Control.Monad.zipWithM_ f x y}
+    - warn: {lhs: sequenceA (replicate n x), rhs: Control.Monad.replicateM n x}
+    - warn: {lhs: sequenceA_ (replicate n x), rhs: Control.Monad.replicateM_ n x}
     - warn: {lhs: mapM f (replicate n x), rhs: Control.Monad.replicateM n (f x)}
     - warn: {lhs: mapM_ f (replicate n x), rhs: Control.Monad.replicateM_ n (f x)}
     - warn: {lhs: mapM f (map g x), rhs: mapM (f . g) x, name: Fuse mapM/map}
     - warn: {lhs: mapM_ f (map g x), rhs: mapM_ (f . g) x, name: Fuse mapM_/map}
     - warn: {lhs: traverse f (map g x), rhs: traverse (f . g) x, name: Fuse traverse/map}
     - warn: {lhs: traverse_ f (map g x), rhs: traverse_ (f . g) x, name: Fuse traverse_/map}
-    - warn: {lhs: mapM id, rhs: sequence}
-    - warn: {lhs: mapM_ id, rhs: sequence_}
+    - warn: {lhs: mapM id, rhs: sequenceA}
+    - warn: {lhs: mapM_ id, rhs: sequenceA_}
 
     # APPLICATIVE / TRAVERSABLE
 

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -263,7 +263,7 @@
 
     # FOLDS
 
-    - warn: {lhs: foldr  (>>) (return ()), rhs: sequenceA_}
+    - warn: {lhs: foldr  (>>) (return ()), rhs: sequence_}
     - warn: {lhs: foldr  (&&) True, rhs: and}
     - warn: {lhs: foldl  (&&) True, rhs: and, note: IncreasesLaziness}
     - warn: {lhs: foldr1 (&&) , rhs: and, note: "RemovesError on `[]`"}
@@ -494,8 +494,8 @@
     - warn: {lhs: mapM_ f (map g x), rhs: mapM_ (f . g) x, name: Fuse mapM_/map}
     - warn: {lhs: traverse f (map g x), rhs: traverse (f . g) x, name: Fuse traverse/map}
     - warn: {lhs: traverse_ f (map g x), rhs: traverse_ (f . g) x, name: Fuse traverse_/map}
-    - warn: {lhs: mapM id, rhs: sequenceA}
-    - warn: {lhs: mapM_ id, rhs: sequenceA_}
+    - warn: {lhs: mapM id, rhs: sequence}
+    - warn: {lhs: mapM_ id, rhs: sequence_}
 
     # APPLICATIVE / TRAVERSABLE
 
@@ -514,6 +514,8 @@
     - hint: {lhs: pure . f =<< m, rhs: f <$> m}
     - warn: {lhs: empty <|> x, rhs: x, name: "Alternative law, left identity"}
     - warn: {lhs: x <|> empty, rhs: x, name: "Alternative law, right identity"}
+    - warn: {lhs: traverse id, rhs: sequenceA}
+    - warn: {lhs: traverse_ id, rhs: sequenceA_}
 
 
     # LIST COMP


### PR DESCRIPTION
- When a rule LHS contains `sequence` or `sequence_`, add the corresponding `sequenceA` or `sequenceA_` version
- ~When a rule RHS contains `sequence` or `sequence_`, suggest `sequenceA` or `sequenceA_` instead~
- Removed a duplicate hint.