### PR TITLE
Fix redundant lambda refactoring when there are generated wildcard patterns

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -68,3 +68,5 @@
 - ignore: {name: Use const, within: Config.Yaml}
 # temporary disable while we have unused top binds here
 - ignore: {name : Avoid restricted flags, within: [GHC.Util.HsExpr, Hint.Match]}
+# Better to use [Char] when that is the moral underlying type, rather than String
+- ignore: {name : Use String, within: [Hint.Lambda]}

--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -290,7 +290,7 @@ mkOrigPats pats = (zipWith munge subtsVars pats', subtsVars)
     -- Returns (chars in the pattern if the pattern contains wildcards, (whether the pattern contains wildcards, the pattern))
     f :: LPat GhcPs -> (Set Char, (Bool, LPat GhcPs))
     f p
-      | any isWildPat (universeBi p) =
+      | any isWildPat (universe p) =
           let used = Set.fromList [c | (L _ (VarPat _ (rdrNameStr -> [c]))) <- universe p]
            in (used, (True, p))
       | otherwise = (mempty, (False, p))


### PR DESCRIPTION
Fixes refactoring for `f (Just a) = \a -> a + a`. Previously refactoring output is `f (Just a) a = a + a`, now `f (Just _) a = a + a`.

The approach is to avoid replacing a pattern if it contains any wildcard, in this case `Just _`.

Care must be taken to not use any substitution variable that occurs in patterns with wildcards. For example, if the pattern is `Foo a b _`, then `a` and `b` cannot be used as substitution variables, and must be removed from `['a'..'z']`. A test case has been added to cover this.