### PR TITLE
Do not require @NoRefactor for hints that don't support refactoring

### DIFF
--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -40,7 +40,7 @@ issue909 = foo (\((x :: z) -> y) -> 9 + x * 7)
 issue909 = foo (\((x : z) -> y) -> 9 + x * 7) -- \(x : z -> y) -> 9 + x * 7
 issue909 = let ((x:: y) -> z) = q in q
 issue909 = do {((x :: y) -> z) <- e; return 1}
-issue970 = (f x +) (g x) -- f x + (g x) @NoRefactor
+issue970 = (f x +) (g x) -- f x + (g x)
 issue969 = (Just \x -> x || x) *> Just True
 
 -- type bracket reduction
@@ -63,7 +63,7 @@ yes = white $ keysymbol -- white keysymbol
 yes = operator foo $ operator -- operator foo operator
 no = operator foo $ operator bar
 yes = return $ Record{a=b}
-no = f $ [1,2..5] -- f [1,2..5] @NoRefactor: apply-refact bug; see apply-refact #51
+no = f $ [1,2..5] -- f [1,2..5] @NoRefactor: apply-refact bug; fixed in apply-refact #51
 
 -- $/bracket rotation tests
 yes = (b $ c d) ++ e -- b (c d) ++ e

--- a/src/Hint/Duplicate.hs
+++ b/src/Hint/Duplicate.hs
@@ -7,15 +7,15 @@ If you have n the same, error out
 
 <TEST>
 main = do a; a; a; a
-main = do a; a; a; a; a; a -- ??? @NoRefactor: refactoring not supported for duplication hints.
-main = do a; a; a; a; a; a; a -- ??? @NoRefactor
-main = do (do b; a; a; a); do (do c; a; a; a) -- ??? @NoRefactor
-main = do a; a; a; b; a; a; a -- ??? @NoRefactor
+main = do a; a; a; a; a; a -- ???
+main = do a; a; a; a; a; a; a -- ???
+main = do (do b; a; a; a); do (do c; a; a; a) -- ???
+main = do a; a; a; b; a; a; a -- ???
 main = do a; a; a; b; a; a
-foo = a where {a = 1; b = 2; c = 3}; bar = a where {a = 1; b = 2; c = 3} -- ??? @NoRefactor
-{-# ANN main "HLint: ignore Reduce duplication" #-}; main = do a; a; a; a; a; a -- @Ignore ??? @NoRefactor
-{-# HLINT ignore main "Reduce duplication" #-}; main = do a; a; a; a; a; a -- @Ignore ??? @NoRefactor
-{- HLINT ignore main "Reduce duplication" -}; main = do a; a; a; a; a; a -- @Ignore ??? @NoRefactor
+foo = a where {a = 1; b = 2; c = 3}; bar = a where {a = 1; b = 2; c = 3} -- ???
+{-# ANN main "HLint: ignore Reduce duplication" #-}; main = do a; a; a; a; a; a -- @Ignore ???
+{-# HLINT ignore main "Reduce duplication" #-}; main = do a; a; a; a; a; a -- @Ignore ???
+{- HLINT ignore main "Reduce duplication" -}; main = do a; a; a; a; a; a -- @Ignore ???
 </TEST>
 -}
 

--- a/src/Hint/Export.hs
+++ b/src/Hint/Export.hs
@@ -3,10 +3,10 @@
 
 <TEST>
 main = 1
-module Foo where foo = 1 -- module Foo(module Foo) where @NoRefactor
+module Foo where foo = 1 -- module Foo(module Foo) where
 module Foo(foo) where foo = 1
-module Foo(module Foo) where foo = 1 -- @Ignore module Foo(...) where @NoRefactor
-module Foo(module Foo, foo) where foo = 1 -- module Foo(..., foo) where @NoRefactor
+module Foo(module Foo) where foo = 1 -- @Ignore module Foo(...) where
+module Foo(module Foo, foo) where foo = 1 -- module Foo(..., foo) where
 </TEST>
 -}
 {-# LANGUAGE TypeFamilies #-}

--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -27,20 +27,20 @@ f (Foo a b c) = \c -> c + c -- f (Foo a b _) c = c + c
 f a = \x -> x + x where _ = test
 f (test -> a) = \x -> x + x
 f = \x -> x + x -- f x = x + x
-fun x y z = f x y z -- fun = f @NoRefactor: refactoring for eta reduce is not implemented
-fun x y z = f x x y z -- fun x = f x x @NoRefactor
-fun x y z = f g z -- fun x y = f g @NoRefactor
-fun x = f . g $ x -- fun = f . g @NoRefactor
+fun x y z = f x y z -- fun = f
+fun x y z = f x x y z -- fun x = f x x
+fun x y z = f g z -- fun x y = f g
+fun x = f . g $ x -- fun = f . g
 f = foo (\y -> g x . h $ y) -- g x . h
 f = foo (\y -> g x . h $ y) -- @Message Avoid lambda
-f = foo ((*) x) -- (x *) @NoRefactor
+f = foo ((*) x) -- (x *)
 f = (*) x
-f = foo (flip op x) -- (`op` x) @NoRefactor
-f = foo (flip op x) -- @Message Use section @NoRefactor
+f = foo (flip op x) -- (`op` x)
+f = foo (flip op x) -- @Message Use section
 foo x = bar (\ d -> search d table) -- (`search` table)
 foo x = bar (\ d -> search d table) -- @Message Avoid lambda using `infix`
 f = flip op x
-f = foo (flip (*) x) -- (* x) @NoRefactor
+f = foo (flip (*) x) -- (* x)
 f = foo (flip (-) x)
 f = foo (\x y -> fun x y) -- @Warning fun
 f = foo (\x y z -> fun x y z) -- @Warning fun
@@ -51,11 +51,11 @@ f = foo (\x -> x # y)
 f = foo (\x -> \y -> x x y y) -- \x y -> x x y y
 f = foo (\x -> \x -> foo x x) -- \_ x -> foo x x
 f = foo (\(foo -> x) -> \y -> x x y y)
-f = foo (\(x:xs) -> \x -> foo x x) -- \(_:xs) x -> foo x x @NoRefactor
+f = foo (\(x:xs) -> \x -> foo x x) -- \(_:xs) x -> foo x x
 f = foo (\x -> \y -> \z -> x x y y z z) -- \x y z -> x x y y z z
 x ! y = fromJust $ lookup x y
 f = foo (\i -> writeIdea (getClass i) i)
-f = bar (flip Foo.bar x) -- (`Foo.bar` x) @NoRefactor
+f = bar (flip Foo.bar x) -- (`Foo.bar` x)
 f = a b (\x -> c x d)  -- (`c` d)
 yes = \x -> a x where -- a
 yes = \x y -> op y x where -- flip op
@@ -68,24 +68,24 @@ f = bar &+& \x -> f (g x)
 foo = [\column -> set column [treeViewColumnTitle := printf "%s (match %d)" name (length candidnates)]]
 foo = [\x -> x]
 foo = [\m x -> insert x x m]
-foo a b c = bar (flux ++ quux) c where flux = a -- foo a b = bar (flux ++ quux) @NoRefactor
+foo a b c = bar (flux ++ quux) c where flux = a -- foo a b = bar (flux ++ quux)
 foo a b c = bar (flux ++ quux) c where flux = c
 yes = foo (\x -> Just x) -- @Warning Just
 foo = bar (\x -> (x `f`)) -- f
 foo = bar (\x -> shakeRoot </> "src" </> x)
-baz = bar (\x -> (x +)) -- (+) @NoRefactor
+baz = bar (\x -> (x +)) -- (+)
 xs `withArgsFrom` args = f args
-foo = bar (\x -> case x of Y z -> z) -- \(Y z) -> z @NoRefactor
-yes = blah (\ x -> case x of A -> a; B -> b) -- \ case A -> a; B -> b @NoRefactor
-yes = blah (\ x -> case x of A -> a; B -> b) -- @Note may require `{-# LANGUAGE LambdaCase #-}` adding to the top of the file @NoRefactor
+foo = bar (\x -> case x of Y z -> z) -- \(Y z) -> z
+yes = blah (\ x -> case x of A -> a; B -> b) -- \ case A -> a; B -> b
+yes = blah (\ x -> case x of A -> a; B -> b) -- @Note may require `{-# LANGUAGE LambdaCase #-}` adding to the top of the file
 no = blah (\ x -> case x of A -> a x; B -> b x)
-yes = blah (\ x -> (y, x)) -- (y,) @NoRefactor
-yes = blah (\ x -> (y, x, z+q)) -- (y, , z+q) @NoRefactor
-yes = blah (\ x -> (y, x, y, u, v)) -- (y, , y, u, v) @NoRefactor
-yes = blah (\ x -> (y, x, z+q)) -- @Note may require `{-# LANGUAGE TupleSections #-}` adding to the top of the file @NoRefactor
+yes = blah (\ x -> (y, x)) -- (y,)
+yes = blah (\ x -> (y, x, z+q)) -- (y, , z+q)
+yes = blah (\ x -> (y, x, y, u, v)) -- (y, , y, u, v)
+yes = blah (\ x -> (y, x, z+q)) -- @Note may require `{-# LANGUAGE TupleSections #-}` adding to the top of the file
 yes = blah (\ x -> (y, x, z+x))
 tmp = map (\ x -> runST $ action x)
-yes = map (\f -> dataDir </> f) dataFiles -- (dataDir </>) @NoRefactor
+yes = map (\f -> dataDir </> f) dataFiles -- (dataDir </>) @NoRefactor hlint bug
 {-# LANGUAGE TypeApplications #-}; noBug545 = coerce ((<>) @[a])
 {-# LANGUAGE QuasiQuotes #-}; authOAuth2 name = authOAuth2Widget [whamlet|Login via #{name}|] name
 {-# LANGUAGE QuasiQuotes #-}; authOAuth2 = foo (\name -> authOAuth2Widget [whamlet|Login via #{name}|] name)

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -16,24 +16,24 @@
 
 <TEST>
 data Yes = Foo | Bar'Test
-data Yes = Bar | Test_Bar -- data Yes = Bar | TestBar @NoRefactor
+data Yes = Bar | Test_Bar -- data Yes = Bar | TestBar
 data No = a :::: b
 data Yes = Foo {bar_cap :: Int}
 data No = FOO | BarBAR | BarBBar
-yes_foo = yes_foo + yes_foo -- yesFoo = ... @NoRefactor
-yes_fooPattern Nothing = 0 -- yesFooPattern Nothing = ... @NoRefactor
+yes_foo = yes_foo + yes_foo -- yesFoo = ...
+yes_fooPattern Nothing = 0 -- yesFooPattern Nothing = ...
 no = 1 where yes_foo = 2
 a -== b = 1
 myTest = 1; my_test = 1
 semiring'laws = 1
-data Yes = FOO_A | Foo_B -- data Yes = FOO_A | FooB @NoRefactor
+data Yes = FOO_A | Foo_B -- data Yes = FOO_A | FooB
 case_foo = 1
 test_foo = 1
-cast_foo = 1 -- castFoo = ... @NoRefactor
+cast_foo = 1 -- castFoo = ...
 replicateM_ = 1
 _foo__ = 1
 section_1_1 = 1
-runMutator# = 1  @NoRefactor
+runMutator# = 1
 foreign import ccall hexml_node_child :: IO ()
 </TEST>
 -}

--- a/src/Hint/NewType.hs
+++ b/src/Hint/NewType.hs
@@ -5,25 +5,25 @@
     quantified data types because it is not valid.
 
 <TEST>
-data Foo = Foo Int -- newtype Foo = Foo Int @NoRefactor: refactoring for "Use newtype" is not implemented
-data Foo = Foo Int deriving (Show, Eq) -- newtype Foo = Foo Int deriving (Show, Eq) @NoRefactor
-data Foo = Foo { field :: Int } deriving Show -- newtype Foo = Foo { field :: Int } deriving Show @NoRefactor
-data Foo a b = Foo a -- newtype Foo a b = Foo a @NoRefactor
+data Foo = Foo Int -- newtype Foo = Foo Int
+data Foo = Foo Int deriving (Show, Eq) -- newtype Foo = Foo Int deriving (Show, Eq)
+data Foo = Foo { field :: Int } deriving Show -- newtype Foo = Foo { field :: Int } deriving Show
+data Foo a b = Foo a -- newtype Foo a b = Foo a
 data Foo = Foo { field1, field2 :: Int}
-data S a = forall b . Show b => S b @NoRefactor: apply-refact 0.6 requires RankNTypes pragma
+data S a = forall b . Show b => S b
 {-# LANGUAGE RankNTypes #-}; data S a = forall b . Show b => S b
-{-# LANGUAGE RankNTypes #-}; data Foo = Foo (forall a. a) -- newtype Foo = Foo (forall a. a) @NoRefactor
+{-# LANGUAGE RankNTypes #-}; data Foo = Foo (forall a. a) -- newtype Foo = Foo (forall a. a)
 data Color a = Red a | Green a | Blue a
 data Pair a b = Pair a b
 data Foo = Bar
 data Foo a = Eq a => MkFoo a
-data Foo a = () => Foo a -- newtype Foo a = Foo a @NoRefactor
-data X = Y {-# UNPACK #-} !Int -- newtype X = Y Int @NoRefactor
-data A = A {b :: !C} -- newtype A = A {b :: C} @NoRefactor
-data A = A Int#  @NoRefactor
+data Foo a = () => Foo a -- newtype Foo a = Foo a @NoRefactor: apply-refact bug; output: data Foo a = ()    Foo a
+data X = Y {-# UNPACK #-} !Int -- newtype X = Y Int
+data A = A {b :: !C} -- newtype A = A {b :: C}
+data A = A Int#
 {-# LANGUAGE UnboxedTuples #-}; data WithAnn x = WithAnn (# Ann, x #)
 {-# LANGUAGE UnboxedTuples #-}; data WithAnn x = WithAnn {getWithAnn :: (# Ann, x #)}
-data A = A () -- newtype A = A () @NoRefactor
+data A = A () -- newtype A = A ()
 newtype Foo = Foo Int deriving (Show, Eq) --
 newtype Foo = Foo { getFoo :: Int } deriving (Show, Eq) --
 newtype Foo = Foo Int deriving stock Show

--- a/src/Hint/Pattern.hs
+++ b/src/Hint/Pattern.hs
@@ -16,7 +16,7 @@ foo b | c <- f b = c \
       | c <- f b = c
 foo x = yes x x where yes x y = if a then b else if c then d else e -- yes x y ; | a = b ; | c = d ; | otherwise = e
 foo x | otherwise = y -- foo x = y
-foo x = x + x where -- @NoRefactor: refactoring for "Redundant where" is not implemented
+foo x = x + x where --
 foo x | a = b | True = d -- foo x | a = b ; | otherwise = d
 foo (Bar _ _ _ _) = x -- Bar{}
 foo (Bar _ x _ _) = x
@@ -25,7 +25,7 @@ foo = case f v of _ -> x -- x
 foo = case v of v -> x -- x
 foo = case v of z -> z
 foo = case v of _ | False -> x
-foo x | x < -2 * 3 = 4 @NoRefactor: ghc-exactprint bug; -2 becomes 2.
+foo x | x < -2 * 3 = 4 @NoRefactor: apply-refact bug, fixed in apply-refact #61
 foo = case v of !True -> x -- True
 {-# LANGUAGE BangPatterns #-}; foo = case v of !True -> x -- True
 {-# LANGUAGE BangPatterns #-}; foo = case v of !(Just x) -> x -- (Just x)
@@ -42,7 +42,7 @@ foo = let ~(x:xs) = y in z
 {-# LANGUAGE BangPatterns #-}; foo = 1 where !False = True
 {-# LANGUAGE BangPatterns #-}; foo = 1 where g (Just !True) = Nothing -- True
 {-# LANGUAGE BangPatterns #-}; foo = 1 where Just !True = Nothing
-foo otherwise = 1 -- _ @NoRefactor
+foo otherwise = 1 -- _
 foo ~x = y -- x
 {-# LANGUAGE Strict #-} foo ~x = y
 {-# LANGUAGE BangPatterns #-}; foo !(x, y) = x -- (x, y)

--- a/src/Hint/Pragma.hs
+++ b/src/Hint/Pragma.hs
@@ -14,11 +14,11 @@
 {-# OPTIONS     -cpp #-} -- {-# LANGUAGE CPP #-}
 {-# OPTIONS_YHC -cpp #-}
 {-# OPTIONS_GHC -XFoo #-} -- {-# LANGUAGE Foo #-}
-{-# OPTIONS_GHC -fglasgow-exts #-} -- ??? @NoRefactor
+{-# OPTIONS_GHC -fglasgow-exts #-} -- ??? @NoRefactor: refactor output has one LANGUAGE pragma per extension, while hlint suggestion has a single LANGUAGE pragma
 {-# LANGUAGE RebindableSyntax, EmptyCase, DuplicateRecordFields, RebindableSyntax #-} -- {-# LANGUAGE RebindableSyntax, EmptyCase, DuplicateRecordFields #-}
 {-# LANGUAGE RebindableSyntax #-}
-{-# OPTIONS_GHC -cpp -foo #-} -- {-# LANGUAGE CPP #-} {-# OPTIONS_GHC -foo #-} @NoRefactor -foo is not a valid flag
-{-# OPTIONS_GHC -cpp -w #-} -- {-# LANGUAGE CPP #-} {-# OPTIONS_GHC -w #-} @NoRefactor: the two pragmas are switched in the refactoring output
+{-# OPTIONS_GHC -cpp -foo #-} -- {-# LANGUAGE CPP #-} {-# OPTIONS_GHC -foo #-} @NoRefactor -foo is not a valid flag; apply-refact can't parse it
+{-# OPTIONS_GHC -cpp -w #-} -- {-# LANGUAGE CPP #-} {-# OPTIONS_GHC -w #-} @NoRefactor: hlint bug: the two pragmas are switched in the refactoring output
 {-# OPTIONS_GHC -cpp #-} \
 {-# LANGUAGE CPP, Text #-} --
 {-# LANGUAGE RebindableSyntax #-} \


### PR DESCRIPTION
The goals are (1) document exactly which hints don't support refactoring, and (2) no longer require `@NoRefactor` for those hints (which is the vast majority of `@NoRefactor`); use `@NoRefactor` only for other issues like bugs.

If a test case has a hint where `ideaRefactorings = []`, the hint must be added to the list of hints that don't support refactorings, and no `@NoRefactoring` is required (I would also like to check the other direction, namely every hint in the list indeed has an empty `ideaRefactoring`, but this is currently not possible since some hints such as "Redundant return" sometimes support refactoring and sometimes don't).

This uncovers two previously unknown hlint refactoring bugs and one apply-refact bug.