### PR TITLE
Fix refactoring for "use uncurry"

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1051,6 +1051,7 @@
 # no  = foo $ \(a, b) -> (a, a + b)
 # yes = map (uncurry (+)) $ zip [1 .. 5] [6 .. 10] -- zipWith (curry (uncurry (+))) [1 .. 5] [6 .. 10]
 # yes = curry (uncurry (+)) -- (+)
+# yes = fst foo .= snd foo -- uncurry (.=) foo
 # no = do iter <- textBufferGetTextIter tb ; textBufferSelectRange tb iter iter
 # no = flip f x $ \y -> y*y+y
 # no = \x -> f x (g x)

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1052,6 +1052,7 @@
 # yes = map (uncurry (+)) $ zip [1 .. 5] [6 .. 10] -- zipWith (curry (uncurry (+))) [1 .. 5] [6 .. 10]
 # yes = curry (uncurry (+)) -- (+)
 # yes = fst foo .= snd foo -- uncurry (.=) foo
+# yes = fst foo `_ba__'r''` snd foo -- uncurry _ba__'r'' foo
 # no = do iter <- textBufferGetTextIter tb ; textBufferSelectRange tb iter iter
 # no = flip f x $ \y -> y*y+y
 # no = \x -> f x (g x)

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -113,11 +113,12 @@ library
         GHC.Util.ApiAnnotation
         GHC.Util.View
         GHC.Util.Brackets
+        GHC.Util.DynFlags
         GHC.Util.FreeVars
         GHC.Util.HsDecl
         GHC.Util.HsExpr
+        GHC.Util.Name
         GHC.Util.SrcLoc
-        GHC.Util.DynFlags
         GHC.Util.Scope
         GHC.Util.Unify
 

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -7,6 +7,7 @@ module GHC.Util (
   , module GHC.Util.ApiAnnotation
   , module GHC.Util.HsDecl
   , module GHC.Util.HsExpr
+  , module GHC.Util.Name
   , module GHC.Util.SrcLoc
   , module GHC.Util.DynFlags
   , module GHC.Util.Scope
@@ -23,6 +24,7 @@ import GHC.Util.FreeVars
 import GHC.Util.ApiAnnotation
 import GHC.Util.HsExpr
 import GHC.Util.HsDecl
+import GHC.Util.Name
 import GHC.Util.SrcLoc
 import GHC.Util.DynFlags
 import GHC.Util.Scope

--- a/src/GHC/Util/HsExpr.hs
+++ b/src/GHC/Util/HsExpr.hs
@@ -30,7 +30,6 @@ import GHC.Util.View
 import Control.Applicative
 import Control.Monad.Trans.State
 
-import Data.Char
 import Data.Data
 import Data.Generics.Uniplate.DataOnly
 import Data.List.Extra

--- a/src/GHC/Util/HsExpr.hs
+++ b/src/GHC/Util/HsExpr.hs
@@ -23,8 +23,9 @@ import OccName
 import Bag(bagToList)
 
 import GHC.Util.Brackets
-import GHC.Util.View
 import GHC.Util.FreeVars
+import GHC.Util.Name
+import GHC.Util.View
 
 import Control.Applicative
 import Control.Monad.Trans.State
@@ -304,7 +305,7 @@ descendBracketOld op x = (descendIndex g1 x, descendIndex g2 x)
     f2 = ((snd .) .) . f
 
     isOp = \case
-      L _ (HsVar _ var) -> (not . all isAlphaNum) (rdrNameStr var)
+      L _ (HsVar _ (L _ name)) -> isSymbolRdrName name
       _ -> False
 
 fromParen1 :: LHsExpr GhcPs -> LHsExpr GhcPs

--- a/src/GHC/Util/Name.hs
+++ b/src/GHC/Util/Name.hs
@@ -1,0 +1,7 @@
+module GHC.Util.Name (isSymbolRdrName) where
+
+import OccName
+import RdrName
+
+isSymbolRdrName :: RdrName -> Bool
+isSymbolRdrName = isSymOcc . rdrNameOcc

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -389,10 +389,8 @@ used TypeOperators = hasS tyOpInSig ||^ hasS tyOpInDecl
       (TyClD _ ClassDecl{tcdLName, tcdATs}) -> any isOp (tcdLName : [fdLName famDecl | L _ famDecl <- tcdATs])
       _ -> False
 
-    isOp :: LIdP GhcPs -> Bool
-    isOp name = case rdrNameStr name of
-      (c:_) -> not $ isAlpha c || c == '_'
-      _ -> False
+    isOp (L _ name) = isSymbolRdrName name
+
 used RecordWildCards = hasS hasFieldsDotDot ||^ hasS hasPFieldsDotDot
 used RecordPuns = hasS isPFieldPun ||^ hasS isFieldPun ||^ hasS isFieldPunUpdate
 used UnboxedTuples = hasS isUnboxedTuple ||^ hasS (== Unboxed) ||^ hasS isDeriving


### PR DESCRIPTION
Fixes a bug where `fst foo .= snd foo` is refactored into `uncurry .= foo`. Fixes https://github.com/mpickering/apply-refact/issues/7.

I spoke too soon when I said "no more known HLint refactoring bug" - I keep finding new ones :grinning: Hopefully this is the last.