### PR TITLE
Upgrade ghc-lib-parser-ex

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -76,7 +76,7 @@ library
       build-depends:
           ghc-lib-parser == 8.10.*
     build-depends:
-        ghc-lib-parser-ex >= 8.10.0.13 && < 8.10.1
+        ghc-lib-parser-ex >= 8.10.0.14 && < 8.10.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/src/GHC/Util/DynFlags.hs
+++ b/src/GHC/Util/DynFlags.hs
@@ -3,7 +3,7 @@ module GHC.Util.DynFlags (initGlobalDynFlags, baseDynFlags) where
 import DynFlags
 import GHC.LanguageExtensions.Type
 import Data.List.Extra
-import Language.Haskell.GhclibParserEx.Config
+import Language.Haskell.GhclibParserEx.GHC.Settings.Config
 
 baseDynFlags :: DynFlags
 baseDynFlags =

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,10 +3,10 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.10.1.20200523
-  - ghc-lib-parser-ex-8.10.0.13
+  - ghc-lib-parser-ex-8.10.0.14
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
-#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.14.tar.gz
+#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.15.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
   - extra-1.7.3
 ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-top-binds -Werror=orphans}


### PR DESCRIPTION
## 8.10.0.14 released 2020-06-10
- New function `isSymbolRdrName`
- New module
  - `Language.Haskell.GhclibParserEx.GHC.Settings.Config` to replace `Language.Haskell.GhclibParserEx.Config` (which remains for now but deprecated and will be removed in a future release)
