### PR TITLE
two new hints: Redundant take (in context of zip)

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -227,6 +227,8 @@
     - warn: {lhs: zipWith f (repeat x), rhs: map (f x)}
     - warn: {lhs: zipWith f y (repeat z), rhs: map (\x -> f x z) y}
     - warn: {lhs: listToMaybe (filter p x), rhs: find p x}
+    - warn: {lhs: zip (take n x) (take n y), rhs: take n (zip x y)}
+    - warn: {lhs: zip (take n x) (take m y), rhs: take (min n m) (zip x y), side: notEq n m, name: Redundant take}
 
     # MONOIDS
 


### PR DESCRIPTION
I found this pattern in student code (in the context of dealing with infinite lists, so either `x` or `y` or both were infinite lists, of which finite prefixes were taken, then zipped).

The rules might be of interest for general use, so I added them to the `default` group. But I could alternatively change the pull request to add them to the `teaching` group instead.

Moreover, analogous rules for `zipWith` instead of `zip` would be conceivably reasonable as well.