### PR TITLE
Allow using HsYAML instead of yaml

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -17,7 +17,7 @@
   - name: [PackageImports]
   - name: [ConstraintKinds, RankNTypes, TypeFamilies]
   - name: [TemplateHaskell]
-  - {name: CPP, within: [HsColour]} # so it can be disabled to avoid GPL code
+  - {name: CPP, within: [HsColour, Config.Yaml, Test.Annotations]} # so it can be disabled to avoid GPL code
 
 - flags:
   - default: false

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -4,4 +4,4 @@
 
 - message:
   - name: Redundant build-depends entry
-  - depends: [ghc-lib-parser, ghc, ghc-boot-th, ghc-boot] # Only some subset is required
+  - depends: [ghc-lib-parser, ghc, ghc-boot-th, ghc-boot, HsYAML, HsYAML-aeson, yaml] # Only some subset is required

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -48,6 +48,11 @@ flag ghc-lib
   manual: True
   description: Force dependency on ghc-lib-parser even if GHC API in the ghc package is supported
 
+flag hsyaml
+  default: False
+  manual: True
+  description: Use HsYAML instead of yaml
+
 library
     default-language:   Haskell2010
     build-depends:
@@ -59,7 +64,6 @@ library
         data-default >= 0.3,
         cpphs >= 1.20.1,
         cmdargs >= 0.10,
-        yaml >= 0.5.0,
         uniplate >= 1.5,
         ansi-terminal >= 0.6.2,
         extra >= 1.7.3,
@@ -82,6 +86,14 @@ library
         build-depends: hscolour >= 1.21
     else
         cpp-options: -DGPL_SCARES_ME
+
+    if flag(hsyaml) && flag(gpl)
+        build-depends:
+          HsYAML >= 0.2,
+          HsYAML-aeson >= 0.2
+        cpp-options: -DHS_YAML
+    else
+        build-depends: yaml >= 0.5.0
 
     hs-source-dirs:     src
     exposed-modules:

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -87,7 +87,7 @@ library
     else
         cpp-options: -DGPL_SCARES_ME
 
-    if flag(hsyaml) && flag(gpl)
+    if flag(hsyaml)
         build-depends:
           HsYAML >= 0.2,
           HsYAML-aeson >= 0.2

--- a/src/Test/Annotations.hs
+++ b/src/Test/Annotations.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE PatternGuards, RecordWildCards, ViewPatterns #-}
+{-# LANGUAGE CPP, PatternGuards, RecordWildCards, ViewPatterns #-}
 
 -- | Check the <TEST> annotations within source and hint files.
 module Test.Annotations(testAnnotations) where
@@ -13,7 +13,6 @@ import Data.Functor
 import Data.List.Extra
 import Data.Maybe
 import Data.Tuple.Extra
-import Data.Yaml
 import System.Exit
 import System.FilePath
 import System.IO.Extra
@@ -33,6 +32,21 @@ import FastString
 import GHC.Util
 import SrcLoc
 import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
+
+#ifdef HS_YAML
+
+import qualified Data.YAML.Aeson
+import Data.YAML (Pos)
+import qualified Data.ByteString as BSS
+
+decodeEither' :: BSS.ByteString -> Either (Pos, String) ConfigYaml
+decodeEither' = Data.YAML.Aeson.decode1Strict
+
+#else
+
+import Data.Yaml
+
+#endif
 
 -- Input, Output
 -- Output = Nothing, should not match

--- a/src/Test/Annotations.hs
+++ b/src/Test/Annotations.hs
@@ -35,12 +35,12 @@ import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
 
 #ifdef HS_YAML
 
-import qualified Data.YAML.Aeson
+import Data.YAML.Aeson (decode1Strict)
 import Data.YAML (Pos)
-import qualified Data.ByteString as BSS
+import Data.ByteString (ByteString)
 
-decodeEither' :: BSS.ByteString -> Either (Pos, String) ConfigYaml
-decodeEither' = Data.YAML.Aeson.decode1Strict
+decodeEither' :: ByteString -> Either (Pos, String) ConfigYaml
+decodeEither' = decode1Strict
 
 #else
 


### PR DESCRIPTION
As discussed in https://github.com/ndmitchell/hlint/issues/144#issuecomment-630048977, this PR adds the option of using `HsYAML` instead of `yaml` behind a flag.
