### PR TITLE
Add missing IncreasesLaziness

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -228,7 +228,7 @@
     - warn: {lhs: zipWith f y (repeat z), rhs: map (\x -> f x z) y}
     - warn: {lhs: listToMaybe (filter p x), rhs: find p x}
     - warn: {lhs: zip (take n x) (take n y), rhs: take n (zip x y)}
-    - warn: {lhs: zip (take n x) (take m y), rhs: take (min n m) (zip x y), side: notEq n m, name: Redundant take}
+    - warn: {lhs: zip (take n x) (take m y), rhs: take (min n m) (zip x y), side: notEq n m, note: IncreasesLaziness, name: Redundant take}
 
     # MONOIDS
 


### PR DESCRIPTION
`zip (take 1 undefined) (take 0 [])` bottoms, but `take (min 1 0) (zip undefined [])` is `[]`.