### PR TITLE
make 'isLitString' work again

### DIFF
--- a/src/Hint/Match.hs
+++ b/src/Hint/Match.hs
@@ -201,6 +201,7 @@ checkSide x bind = maybe True bool x
       isType "NegZero" (asInt -> Just x) | x <= 0 = True
       isType "LitInt" (L _ (HsLit _ HsInt{})) = True
       isType "LitInt" (L _ (HsOverLit _ (OverLit _ HsIntegral{} _))) = True
+      isType "LitString" (L _ (HsLit _ HsString{})) = True
       isType "Var" (L _ HsVar{}) = True
       isType "App" (L _ HsApp{}) = True
       isType "InfixApp" (L _ x@OpApp{}) = True


### PR DESCRIPTION
After the transition to the GHC parser the ```isLit*``` pattern is only supported for ```Int```. We were using ```isLitString``` for some local rules (see https://github.com/ndmitchell/hlint/pull/686#issuecomment-505625644) that we would like to see working again.