### PR TITLE
Add missing case to isListExpr

### DIFF
--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -139,6 +139,8 @@ main = "test"
 {-# LANGUAGE OverloadedStrings #-} \
 main = id --
 {-# LANGUAGE OverloadedLists #-} \
+main = []
+{-# LANGUAGE OverloadedLists #-} \
 main = [1]
 {-# LANGUAGE OverloadedLists #-} \
 main [1] = True
@@ -432,6 +434,7 @@ used OverloadedStrings = hasS isString
 used OverloadedLists = hasS isListExpr ||^ hasS isListPat
   where
     isListExpr :: HsExpr GhcPs -> Bool
+    isListExpr (HsVar _ n) = rdrNameStr n == "[]"
     isListExpr ExplicitList{} = True
     isListExpr ArithSeq{} = True
     isListExpr _ = False


### PR DESCRIPTION
Add a missing case for the empty list in `isListExpr`. Fixes https://github.com/ndmitchell/hlint/issues/1064.