### PR TITLE
Update ghc-lib-parser-ex

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -80,7 +80,7 @@ library
       build-depends:
           ghc-lib-parser == 8.10.*
     build-depends:
-        ghc-lib-parser-ex >= 8.10.0.14 && < 8.10.1
+        ghc-lib-parser-ex >= 8.10.0.15 && < 8.10.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,10 +3,10 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-8.10.1.20200523
-  - ghc-lib-parser-ex-8.10.0.14
+  - ghc-lib-parser-ex-8.10.0.15
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
-#  - archive: /users/shaynefletcher/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.15.tar.gz
+#  - archive: /users/shayne/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.16.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
   - extra-1.7.3
   - apply-refact-0.8.1.0


### PR DESCRIPTION
## 8.10.0.15 released 2020-07-04
- New function `isImportQualifiedPost`

Just the update (one of those sanity preserving things); stops short of using `isImportQualifiedPost`. There is the option now, I'll leave whether to actually do that up to @zliu41 (I'm easy)! 

