### PR TITLE
Conditionally run cpp

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -69,8 +69,7 @@ library
         extra >= 1.7.3,
         refact >= 0.3,
         aeson >= 1.1.2.0,
-        filepattern >= 0.1.1,
-        mtl >= 2.2.2
+        filepattern >= 0.1.1
 
     if !flag(ghc-lib) && impl(ghc >= 8.10.0) && impl(ghc < 8.11.0)
       build-depends:

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -69,7 +69,8 @@ library
         extra >= 1.7.3,
         refact >= 0.3,
         aeson >= 1.1.2.0,
-        filepattern >= 0.1.1
+        filepattern >= 0.1.1,
+        mtl >= 2.2.2
 
     if !flag(ghc-lib) && impl(ghc >= 8.10.0) && impl(ghc < 8.11.0)
       build-depends:

--- a/src/GHC/All.hs
+++ b/src/GHC/All.hs
@@ -9,7 +9,7 @@ module GHC.All(
     parseExpGhcWithMode, parseImportDeclGhcWithMode, parseDeclGhcWithMode,
     ) where
 
-import Control.Monad.Except
+import Control.Monad.Trans.Except
 import Util
 import Data.Char
 import Data.List.Extra
@@ -160,15 +160,15 @@ parseModuleEx :: ParseFlags -> FilePath -> Maybe String -> IO (Either ParseError
 parseModuleEx flags file str = timedIO "Parse" file $ runExceptT $ do
   str <- case str of
     Just x -> pure x
-    Nothing | file == "-" -> liftIO getContentsUTF8
-            | otherwise -> liftIO $ readFileUTF8' file
+    Nothing | file == "-" -> ExceptT $ Right <$> getContentsUTF8
+            | otherwise -> ExceptT $ Right <$> readFileUTF8' file
   str <- pure $ dropPrefix "\65279" str -- Remove the BOM if it exists, see #130.
   let enableDisableExts = ghcExtensionsFromParseFlags flags
   -- Read pragmas for the first time.
   dynFlags <- withExceptT (parsePragmasErr str) $ ExceptT (parsePragmasIntoDynFlags baseDynFlags enableDisableExts file str)
   dynFlags <- pure $ lang_set dynFlags $ baseLanguage flags
   -- Avoid running cpp unless CPP is enabled, see #1075.
-  str <- if not (xopt Cpp dynFlags) then pure str else liftIO $ runCpp (cppFlags flags) file str
+  str <- if not (xopt Cpp dynFlags) then pure str else ExceptT $ Right <$> runCpp (cppFlags flags) file str
   -- If we preprocessed the file, re-read the pragmas.
   dynFlags <- if not (xopt Cpp dynFlags) then pure dynFlags
               else withExceptT (parsePragmasErr str) $ ExceptT (parsePragmasIntoDynFlags baseDynFlags enableDisableExts file str)

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -35,6 +35,44 @@ OUTPUT
 No hints
 
 ---------------------------------------------------------------------
+RUN --cpp-define FOO tests/cpp-ext-enable.hs
+FILE tests/cpp-ext-enable.hs
+{-# LANGUAGE CPP #-}
+#if defined(FOO)
+{-# LANGUAGE Foo #-}
+#endif
+main = undefined
+EXIT 1
+OUTPUT
+tests/cpp-ext-enable.hs:1:1: Error: Parse error: Unsupported extension: Foo
+
+Found:
+  {-# LANGUAGE CPP #-}
+
+  {-# LANGUAGE Foo #-}
+
+  main = undefined
+
+1 hint
+
+---------------------------------------------------------------------
+RUN tests/cpp-ext-disable.hs
+FILE tests/cpp-ext-disable.hs
+{-# LANGUAGE CPP #-}
+#if defined(FOO)
+{-# LANGUAGE Foo #-}
+#endif
+main = undefined
+EXIT 1
+OUTPUT
+tests/cpp-ext-disable.hs:1:1-20: Warning: Avoid restricted extensions
+Found:
+  {-# LANGUAGE CPP #-}
+Note: may break the code
+
+1 hint
+
+---------------------------------------------------------------------
 RUN --cpp-simple tests/cpp-simple.hs
 FILE tests/cpp-simple.hs
 #include "Any/File.h"

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -24,6 +24,17 @@ OUTPUT
 No hints
 
 ---------------------------------------------------------------------
+RUN -XNoCPP tests/cpp-must-not-run.hs
+FILE tests/cpp-must-not-run.hs
+{-
+#error Cpp has run
+-}
+main = undefined
+EXIT 0
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
 RUN --cpp-simple tests/cpp-simple.hs
 FILE tests/cpp-simple.hs
 #include "Any/File.h"


### PR DESCRIPTION
This PR relates to discussion in issue https://github.com/ndmitchell/hlint/issues/1075.

We have been running cpp without regard for whether the `CPP` extension is enabled or not. This change avoids running cpp if `CPP` is not in effect. 

Given,
```haskell
{-# Rules
-- Foo, bar, baz
#-}
main = undefined
```
then with `hlint ~/Foo.hs` the warning
```
Warning: unknown directive #-}
in Foo.hs  at line 3 col 1
```
exhibits but with `hlint -XNoCPP ~/Foo.hs` the warning is vanquished.