### PR TITLE
Add missing DecreasesLaziness

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -230,7 +230,7 @@
     - warn: {lhs: zipWith f y (repeat z), rhs: map (\x -> f x z) y}
     - warn: {lhs: listToMaybe (filter p x), rhs: find p x}
     - warn: {lhs: zip (take n x) (take n y), rhs: take n (zip x y)}
-    - warn: {lhs: zip (take n x) (take m y), rhs: take (min n m) (zip x y), side: notEq n m, note: IncreasesLaziness, name: Redundant take}
+    - warn: {lhs: zip (take n x) (take m y), rhs: take (min n m) (zip x y), side: notEq n m, note: [IncreasesLaziness, DecreasesLaziness], name: Redundant take}
 
     # MONOIDS
 


### PR DESCRIPTION
The `zip/take` hint can decrease laziness too: `zip (take 0 []) (take undefined [])` is `[]`, but `take (min 0 undefined) (zip [] [])` bottoms.