### PR TITLE
Call error on `-XFoo` if `Foo` is not a known extension

### DIFF
--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -329,7 +329,7 @@ getExtensions args =
         f (a, e) ('N':'o':x) | Just x <- GhclibParserEx.readExtension x, let xs = expandDisable x =
             (deletes xs a, xs ++ deletes xs e)
         f (a, e) x | Just x <- GhclibParserEx.readExtension x = (x : delete x a, delete x e)
-        f (a, e) x = (a, e) -- Ignore unknown extension.
+        f (a, e) x = error $ "Unknown extension: '" ++ x ++ "'"
 
         deletes [] ys = ys
         deletes (x:xs) ys = deletes xs $ delete x ys


### PR DESCRIPTION
Error out if given `-XFoo` or `-XNoFoo` if `Foo` is not a known extension.

![Screen Shot 2020-08-03 at 6 08 27 PM](https://user-images.githubusercontent.com/1500167/89231929-5a0f4080-d5b4-11ea-8103-631033cfaf42.png)

The simplest possible strategy that maybe fixes https://github.com/ndmitchell/hlint/issues/1093.
