### PR TITLE
more fold-to-pictures rules in codeworld

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -983,7 +983,11 @@
     - warn: {lhs: "pictures [ p ]", rhs: p, name: Evaluate}
     - warn: {lhs: "pictures [ p, q ]", rhs: p & q, name: Evaluate}
     - hint: {lhs: foldl1 (&), rhs: pictures}
+    - hint: {lhs: foldl (&) blank, rhs: pictures}
+    - hint: {lhs: foldl' (&) blank, rhs: pictures}
+    - hint: {lhs: foldr' (&) blank, rhs: pictures}
     - hint: {lhs: foldr (&) blank, rhs: pictures}
+    - hint: {lhs: foldr1 (&), rhs: pictures}
     - hint: {lhs: scaled x x, rhs: dilated x}
     - hint: {lhs: scaledPoint x x, rhs: dilatedPoint x}
     - warn: {lhs: "brighter (- a)", rhs: "duller a"}


### PR DESCRIPTION
At least one of these cases came up, in excess of the already existing rules of a similar kind, in our course.

For completeness' sake I thought to add all four variants, to accompany the current ones in: https://github.com/ndmitchell/hlint/blob/ba18aca488f3a8ad5a0fbc20d829caea67f61c18/data/hlint.yaml#L985-L986

Even the versions replacing `foldl'` and `foldr'` invocation seem to make sense to me, since due to the definition of `(&)` in `codeworld-api` (https://hackage.haskell.org/package/codeworld-api-0.6.0/docs/src/CodeWorld.Picture.html#%26), any use of `foldl'` or `foldr'` with `(&)` doesn't really make a difference relative to `foldl` or `foldr`, because a `seq (x & y) z` is equivalent to just `z`, because `(&)` returns a data constructor, thus always a whnf, even without descending further down into arguments. (So only `deepseq` would make a difference, but `foldl'` and `foldr'` do use `seq` instead of `deepseq`.)


