### PR TITLE
Upgrade to ghc-8.10.2

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -80,7 +80,7 @@ library
       build-depends:
           ghc-lib-parser == 8.10.*
     build-depends:
-        ghc-lib-parser-ex >= 8.10.0.15 && < 8.10.1
+        ghc-lib-parser-ex >= 8.10.0.16 && < 8.10.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,11 +2,11 @@ resolver: lts-14.20 # ghc-8.6.5
 packages:
   - .
 extra-deps:
-  - ghc-lib-parser-8.10.1.20200523
-  - ghc-lib-parser-ex-8.10.0.15
+  - ghc-lib-parser-8.10.2.20200808
+  - ghc-lib-parser-ex-8.10.0.16
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
-#  - archive: /users/shayne/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.16.tar.gz
+#  - archive: /users/shayne/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.17.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
   - extra-1.7.3
   - apply-refact-0.8.2.0


### PR DESCRIPTION
Upgrade to `ghc-lib-parser-8.10.2.20200808` (ghc-8.10.2) & `ghc-lib-parser-ex-8.10.0.16`.