### PR TITLE
avoid foldr' on lists

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1011,7 +1011,7 @@
     - warn: {lhs: foldl f c (reverse x), rhs: foldr (flip f) c x, note: IncreasesLaziness, name: Use right fold instead of left fold}
     - warn: {lhs: foldl1 f (reverse x), rhs: foldr1 (flip f) x, note: IncreasesLaziness, name: Use right fold instead of left fold}
     - warn: {lhs: foldr' f c (reverse x), rhs: foldl' (flip f) c x, name: Use left fold instead of right fold}
-    - warn: {lhs: foldl' f c (reverse x), rhs: foldr' (flip f) c x, name: Use right fold instead of left fold}
+    - warn: {lhs: foldl' f c (reverse x), rhs: foldr (flip f) c x, note: IncreasesLaziness, name: Use right fold instead of left fold}
 
 - group:
     # used for tests, enabled when testing this file


### PR DESCRIPTION
That's the one thing I perceive as still open from https://github.com/ndmitchell/hlint/issues/1057 at the moment: that using `foldr'` on a right-associative data structure like standard lists is not a good idea, and shouldn't be proposed, not even in a teaching setting.