### PR TITLE
Enable refactoring for use section

### DIFF
--- a/builtin.md
+++ b/builtin.md
@@ -1567,7 +1567,7 @@ Bar {}
 <tr>
 <td rowspan=2>Use section</td>
 <td>Suggestion</td>
-<td>No</td>
+<td>Yes</td>
 </tr>
 <tr>
 <td colspan=2>


### PR DESCRIPTION
Added a new `View` instance to extract `RdrName` from `LHsExpr`, so that all cases are handled correctly.

Using the `LHsExpr` directly would lead to extra parentheses (`(+)` vs `+`), while using the string obtained from `rdrNameStr` would lose the module name (`Prelude.+` vs `+`).