### PR TITLE
YAML error message: show allowed keys

### DIFF
--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -186,7 +186,9 @@ allowFields v allow = do
     mp <- parseObject v
     let bad = map T.unpack (Map.keys mp) \\ allow
     when (bad /= []) $
-        parseFail v $ "Not allowed keys: " ++ unwords bad
+        parseFail v
+          $ "Not allowed keys: " ++ unwords bad
+          ++ ", Allowed keys: " ++ unwords allow
 
 parseGHC :: (ParseFlags -> String -> ParseResult v) -> Val -> Parser v
 parseGHC parser v = do


### PR DESCRIPTION
If you use `note` instead of `message` in function elements, the error
message looks like:

```
hlint: user error (Failed to read YAML configuration file /foo
  Aeson exception:
Error in $: Error when decoding YAML, Not allowed keys: note
Along path: root 9 functions 9
When at: Object
note: use an explicit match with `error` and reason
name: fromJust
within: []
)
```

leaving you guessing if it’s at all possible to add a note.

If we attach the list of allowed keys, the user at least sees that
there is a `message` field.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
