### PR TITLE
Match module wildcards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ stack.yaml.lock
 \#*\#
 .\#*\#
 
+*.dump-hi

--- a/data/wildcard.yaml
+++ b/data/wildcard.yaml
@@ -1,0 +1,1 @@
+- ignore: { name: Use const, within: '**.*Spec' }

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -114,7 +114,7 @@ classify xs i = let s = foldl' (f i) (ideaSeverity i) xs in s `seq` i{ideaSeveri
         f :: Idea -> Severity -> Classify -> Severity
         f i r c | classifyHint c ~~= ideaHint i && classifyModule c ~= ideaModule i && classifyDecl c ~= ideaDecl i = classifySeverity c
                 | otherwise = r
-        x ~= y = x == "" || x `elem` y || any (wildcardMatch x) y
+        x ~= y = x == "" || any (wildcardMatch x) y
         x  ~~= y = x == "" || x == y || ((x ++ ":") `isPrefixOf` y)
 
 -- | Returns true if the pattern matches the string. For example:
@@ -131,6 +131,4 @@ classify xs i = let s = foldl' (f i) (ideaSeverity i) xs in s `seq` i{ideaSeveri
 --
 -- See this issue for details: <https://github.com/ndmitchell/hlint/issues/402>.
 wildcardMatch :: FilePattern -> String -> Bool
-wildcardMatch p m =
-    let f x = if x == '.' then '/' else x
-    in '*' `elem` p && fmap f p ?== fmap f m
+wildcardMatch p m = let f = replace "." "/" in f p ?== f m

--- a/tests/wildcard.test
+++ b/tests/wildcard.test
@@ -1,0 +1,7 @@
+---------------------------------------------------------------------
+RUN tests/wildcard.hs --hint=data/wildcard.yaml
+FILE tests/wildcard.hs
+module Spec where
+main = print $ (\ _ -> 'a') ()
+OUTPUT
+No hints

--- a/tests/wildcard.test
+++ b/tests/wildcard.test
@@ -1,7 +1,45 @@
 ---------------------------------------------------------------------
-RUN tests/wildcard.hs --hint=data/wildcard.yaml
-FILE tests/wildcard.hs
+RUN tests/wildcard-1.hs --hint=data/wildcard.yaml
+FILE tests/wildcard-1.hs
+module SpecNoMatch where
+main = print $ (\ _ -> 'a') ()
+OUTPUT
+tests/wildcard-1.hs:2:17-26: Suggestion: Use const
+Found:
+  \ _ -> 'a'
+Perhaps:
+  const 'a'
+
+1 hint
+
+---------------------------------------------------------------------
+RUN tests/wildcard-2.hs --hint=data/wildcard.yaml
+FILE tests/wildcard-2.hs
 module Spec where
+main = print $ (\ _ -> 'a') ()
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
+RUN tests/wildcard-3.hs --hint=data/wildcard.yaml
+FILE tests/wildcard-3.hs
+module PrefixedSpec where
+main = print $ (\ _ -> 'a') ()
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
+RUN tests/wildcard-4.hs --hint=data/wildcard.yaml
+FILE tests/wildcard-4.hs
+module Namespaced.Spec where
+main = print $ (\ _ -> 'a') ()
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
+RUN tests/wildcard-5.hs --hint=data/wildcard.yaml
+FILE tests/wildcard-5.hs
+module Deeply.Nested.Spec where
 main = print $ (\ _ -> 'a') ()
 OUTPUT
 No hints


### PR DESCRIPTION
Partly addresses some of #402.

I had never looked at the HLint codebase before this morning, so I can't say if these are good changes or not. That being said this turned out to be a relatively easy change. And I added a test case for it. 