### PR TITLE
Try to build with a later lts

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.20 # ghc-8.6.5
+resolver: lts-16.20 # ghc-8.8.4
 packages:
   - .
 extra-deps:


### PR DESCRIPTION
Check if we build with a later lts on windows. If we do, this would be a fix for #1155 by just making a release with the newer lts (tested it locally)