### PR TITLE
Refactor findFunction

### DIFF
--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -191,10 +191,7 @@ findFunction
     -> Located RdrName
     -> [ModuleName]
     -> Maybe ([(String, String)], Maybe String)
-findFunction restrictMap (rdrNameStr -> x) (map moduleNameString -> possMods) =
-    case Map.lookup x restrictMap of
-        Just (RestrictFun mp) -> do
-            n <- NonEmpty.nonEmpty . Map.elems $ Map.filterWithKey (const . maybe True (`elem` possMods)) mp
-            pure (sconcat n)
-        Nothing ->
-            Nothing
+findFunction restrictMap (rdrNameStr -> x) (map moduleNameString -> possMods) = do
+    (RestrictFun mp) <- Map.lookup x restrictMap
+    n <- NonEmpty.nonEmpty . Map.elems $ Map.filterWithKey (const . maybe True (`elem` possMods)) mp
+    pure (sconcat n)


### PR DESCRIPTION
While doing some initial experimenting for https://github.com/ndmitchell/hlint/issues/769 I ended up refactoring this function, I thought the end result was worth submitting, as it makes use of `do` notation for handling the `Maybe`, and gets rid of a duplicate name that was a bit confusing when initially reading the function.