### PR TITLE
Do not refactor "Redundant lambda" if the body is HsCase

### DIFF
--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -144,6 +144,7 @@ lambdaDecl
           gen :: [LPat GhcPs] -> LHsExpr GhcPs -> LHsDecl GhcPs
           gen ps = uncurry reform . fromLambda . lambda ps
           refacts = case newBody of
+              -- https://github.com/alanz/ghc-exactprint/issues/97
               L _ HsCase{} -> []
               _ -> [Replace Decl (toSS o) sub tpl]
        in [warn "Redundant lambda" o (gen pats origBody) refacts]

--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -143,7 +143,10 @@ lambdaDecl
           (sub, tpl) = mkSubtsAndTpl newPats newBody
           gen :: [LPat GhcPs] -> LHsExpr GhcPs -> LHsDecl GhcPs
           gen ps = uncurry reform . fromLambda . lambda ps
-       in [warn "Redundant lambda" o (gen pats origBody) [Replace Decl (toSS o) sub tpl]]
+          refacts = case newBody of
+              L _ HsCase{} -> []
+              _ -> [Replace Decl (toSS o) sub tpl]
+       in [warn "Redundant lambda" o (gen pats origBody) refacts]
 
     | let (newPats, newBody) = etaReduce pats origBody
     , length newPats < length pats, pvars (drop (length newPats) pats) `disjoint` varss bind


### PR DESCRIPTION
There are some difficulties, described in https://github.com/alanz/ghc-exactprint/issues/97, in refactoring redundant lambda hints where the body of the lambda is an `HsCase` and the "case" is in the same line as the lambda, for example
```haskell
f = \x -> case scrut of
  pat -> body
```
This may be fixable from ghc-exactprint, but I'm not familiar enough with ghc-exactprint to say how easy it is. So the best thing to do for now seems to be disabling the refactoring if the body is `HsCase`.