### PR TITLE
Add missing parentheses for Avoid Lambda

### DIFF
--- a/src/GHC/Util/HsExpr.hs
+++ b/src/GHC/Util/HsExpr.hs
@@ -228,6 +228,7 @@ niceLambdaR [x, y] (view -> App2 op (view -> Var_ y1) (view -> Var_ x1))
       )
   where
     gen = noLoc . HsApp noExtField (strToVar "flip")
+        . case op of L _ HsVar{} -> id; _ -> noLoc . HsPar noExtField
 
 -- We're done factoring, but have no variables left, so we shouldn't make a lambda.
 -- @\ -> e@ ==> @e@

--- a/src/GHC/Util/HsExpr.hs
+++ b/src/GHC/Util/HsExpr.hs
@@ -228,7 +228,7 @@ niceLambdaR [x, y] (view -> App2 op (view -> Var_ y1) (view -> Var_ x1))
       )
   where
     gen = noLoc . HsApp noExtField (strToVar "flip")
-        . case op of L _ HsVar{} -> id; _ -> noLoc . HsPar noExtField
+        . if isAtom op then id else addParen
 
 -- We're done factoring, but have no variables left, so we shouldn't make a lambda.
 -- @\ -> e@ ==> @e@

--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -63,6 +63,7 @@ f = bar (flip Foo.bar x) -- (`Foo.bar` x)
 f = a b (\x -> c x d)  -- (`c` d)
 yes = \x -> a x where -- a
 yes = \x y -> op y x where -- flip op
+yes = \x y -> op z y x where -- flip (op z)
 f = \y -> nub $ reverse y where -- nub . reverse
 f = \z -> foo $ bar $ baz z where -- foo . bar . baz
 f = \z -> foo $ bar x $ baz z where -- foo . bar x . baz


### PR DESCRIPTION
Reported originally by @poscat0x04 in https://github.com/mpickering/apply-refact/issues/102.

Minimum example: `x = f (\a b -> c d b a)`, should suggest `flip (c d)`, not `flip c d`.