### PR TITLE
Generalize hints which were with '&' form

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -821,9 +821,9 @@
     - warn: {lhs: "(a ^. b) ^. c", rhs: "a ^. (b . c)"}
     - warn: {lhs: "fromJust (a ^? b)", rhs: "a ^?! b"}
     - warn: {lhs: "a .~ Just b", rhs: "a ?~ b"}
-    - warn: {lhs: "a & (mapped %~ b)", rhs: "a <&> b"}
-    - warn: {lhs: "a & ((mapped . b) %~ c)", rhs: "a <&> b %~ c"}
-    - warn: {lhs: "a & (mapped .~ b)", rhs: "b <$ a"}
+    - warn: {lhs: "(mapped %~ b) a", rhs: "a <&> b"}
+    - warn: {lhs: "((mapped . b) %~ c) a", rhs: "a <&> b %~ c"}
+    - warn: {lhs: "(mapped .~ b) a", rhs: "b <$ a"}
     - warn: {lhs: "ask <&> (^. a)", rhs: "view a"}
     - warn: {lhs: "view a <&> (^. b)", rhs: "view (a . b)"}
 
@@ -1107,6 +1107,7 @@
 # yes = foo (elem x y) -- x `elem` y
 # no  = x `elem` y
 # no  = elem 1 [] : []
+# yes = a & (mapped . b) %~ c -- a <&> b %~ c
 # test a = foo (\x -> True) -- const True
 # test a = foo (\_ -> True) -- const True
 # test a = foo (\x -> x) -- id


### PR DESCRIPTION
Without the '&' the hints apply in more cases,
and since 3.2.7 hlint can see through '&' so it isn't needed in the hints