### PR TITLE
Require apply-refact 0.9.0.0

### DIFF
--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -42,6 +42,7 @@ issue909 = let ((x:: y) -> z) = q in q
 issue909 = do {((x :: y) -> z) <- e; return 1}
 issue970 = (f x +) (g x) -- f x + (g x)
 issue969 = (Just \x -> x || x) *> Just True
+issue1179 = do(this is a test) -- do this is a test
 
 -- type bracket reduction
 foo :: (Int -> Int) -> Int

--- a/src/Refact.hs
+++ b/src/Refact.hs
@@ -51,7 +51,9 @@ refactorPath rpath = do
             ver <- readVersion . tail <$> readProcess exc ["--version"] ""
             pure $ if ver >= minRefactorVersion
                        then Right exc
-                       else Left $ "Your version of refactor is too old, please upgrade to " ++ showVersion minRefactorVersion ++ " or later"
+                       else Left $ "Your version of refactor is too old, please install apply-refact "
+                                ++ showVersion minRefactorVersion
+                                ++ " or later. Apply-refact can be installed from Cabal or Stack."
         Nothing -> pure $ Left $ unlines
                        [ "Could not find 'refactor' executable"
                        , "Tried to find '" ++ excPath ++ "' on the PATH"
@@ -72,4 +74,4 @@ runRefactoring rpath fin hints enabled disabled opts =  do
     waitForProcess phand
 
 minRefactorVersion :: Version
-minRefactorVersion = makeVersion [0,8,2,0]
+minRefactorVersion = makeVersion [0,9,0,0]


### PR DESCRIPTION
Also mention that apply-refact can be installed from Cabal or Stack, which hopefully makes the message clearer.

Fixes #1179.