### PR TITLE
Bump to ghc-lib-parser-ex-9.0.0.3

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -85,7 +85,7 @@ library
       build-depends:
           ghc-lib-parser == 9.0.*
     build-depends:
-        ghc-lib-parser-ex >= 9.0.0.1 && < 9.0.1
+        ghc-lib-parser-ex >= 9.0.0.3 && < 9.0.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-9.0.1.20210207
-  - ghc-lib-parser-ex-9.0.0.1
+  - ghc-lib-parser-ex-9.0.0.3
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.18.tar.gz


### PR DESCRIPTION
This updates `hlint.cabal` and `stack.yaml` to require `ghc-lib-parser-ex-9.0.0.3`. This version of `ghc-lib-parser-ex` fixes some Cabal config mistakes present in older versions. Thank-you for your patience and sorry about this.