### PR TITLE
Allow matching for TemplateHaskellQuotes #1194 and add some TH rules

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -36,6 +36,7 @@
     - import Maybe as Data.Maybe
     - import Monad as Control.Monad
     - import Char as Data.Char
+    - import Language.Haskell.TH as TH
 
 - package:
     name: lens
@@ -811,6 +812,10 @@
     - warn: {lhs: "Data.Map.Lazy.fromList []", rhs: Data.Map.Lazy.empty}
     - warn: {lhs: "Data.Map.Strict.fromList []", rhs: Data.Map.Strict.empty}
 
+    # TEMPLATE HASKELL
+
+    - hint: {lhs: "TH.varE 'a", rhs: "[|a|]", name: Use TH quotation brackets}
+
 - group:
     name: lens
     enabled: true
@@ -1217,6 +1222,8 @@
 # issue1183 = (a >= 'a') && a <= 'z' -- isAsciiLower a
 # issue1183 = (a >= 'a') && (a <= 'z') -- isAsciiLower a
 
+# import Language.Haskell.TH\
+# yes = varE 'foo -- [|foo|]
 # import Prelude \
 # yes = flip mapM -- Control.Monad.forM
 # import Control.Monad \

--- a/src/GHC/Util/FreeVars.hs
+++ b/src/GHC/Util/FreeVars.hs
@@ -106,6 +106,8 @@ instance FreeVars (LHsExpr GhcPs) where
   freeVars (L _ (RecordCon _ _ (HsRecFields flds _))) = Set.unions $ map freeVars flds -- Record construction.
   freeVars (L _ (RecordUpd _ e flds)) = Set.unions $ freeVars e : map freeVars flds -- Record update.
   freeVars (L _ (HsMultiIf _ grhss)) = free (allVars grhss) -- Multi-way if.
+  freeVars (L _ (HsBracket _ (ExpBr _ e))) = freeVars e
+  freeVars (L _ (HsBracket _ (VarBr _ _ v))) = Set.fromList [occName v]
 
   freeVars (L _ HsConLikeOut{}) = mempty -- After typechecker.
   freeVars (L _ HsRecFld{}) = mempty -- Variable pointing to a record selector.

--- a/src/GHC/Util/Unify.hs
+++ b/src/GHC/Util/Unify.hs
@@ -224,6 +224,10 @@ unifyExp' nm root x@(L _ (HsApp _ x1 x2)) y@(L _ (HsApp _ y1 y2)) =
 unifyExp' nm root x y@(L _ (OpApp _ lhs2 op2@(L _ (HsVar _ op2')) rhs2)) =
   noExtra $ unifyExp nm root x y
 
+unifyExp' nm root (L _ (HsBracket _ (VarBr _ b0 (occNameStr -> v1))))
+                  (L _ (HsBracket _ (VarBr _ b1 (occNameStr -> v2))))
+    | b0 == b1 && isUnifyVar v1 = Just (Subst [(v1, strToVar v2)])
+
 unifyExp' nm root x y | isOther x, isOther y = unifyDef' nm x y
     where
         -- Types that are not already handled in unify.


### PR DESCRIPTION
The `'var` and `''TypeCon` syntaxes are now supported for rule left-hand-sides.

This covers some basic needs of TH rules.

More complete support (more rules) would also need:

* Also support matching on `[|code|]` syntax on LHS
* Support parsing `[|$var|]` syntax on RHS
* Bonus: support `'var` syntax also on RHS
