### PR TITLE
Require apply-refact 0.9.1.0

### DIFF
--- a/src/Refact.hs
+++ b/src/Refact.hs
@@ -74,4 +74,4 @@ runRefactoring rpath fin hints enabled disabled opts =  do
     waitForProcess phand
 
 minRefactorVersion :: Version
-minRefactorVersion = makeVersion [0,9,0,0]
+minRefactorVersion = makeVersion [0,9,1,0]


### PR DESCRIPTION
0.9.1.0 includes a fix that uses the correct DynFlags to parse refactoring templates (https://github.com/mpickering/apply-refact/commit/7ec5a82096f1b59467c990a0cb105e7fffea056c), which should fix the refactoring error in #1215.