### PR TITLE
Upgrade to ghc-lib-parser-ex-9.0.0.4

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -85,7 +85,7 @@ library
       build-depends:
           ghc-lib-parser == 9.0.*
     build-depends:
-        ghc-lib-parser-ex >= 9.0.0.3 && < 9.0.1
+        ghc-lib-parser-ex >= 9.0.0.4 && < 9.0.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/src/Hint/Fixities.hs
+++ b/src/Hint/Fixities.hs
@@ -38,7 +38,7 @@ fixitiesHint settings _ _ x =
   concatMap (infixBracket fixities) (childrenBi x :: [LHsExpr GhcPs])
    where
      fixities = foldMap getFixity settings `mappend` fromList (toFixity <$> defaultFixities)
-     getFixity (Infix x) = uncurry singleton (toFixity x)
+     getFixity (Infix x) = uncurry Data.Map.singleton (toFixity x)
      getFixity _ = mempty
 
 infixBracket :: Map String Fixity -> LHsExpr GhcPs -> [Idea]

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
   - .
 extra-deps:
   - ghc-lib-parser-9.0.1.20210207
-  - ghc-lib-parser-ex-9.0.0.3
+  - ghc-lib-parser-ex-9.0.0.4
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex.git/ghc-lib-parser-ex-8.10.0.18.tar.gz


### PR DESCRIPTION
- Fixes issue with`ghc-lib-parser-ex-9.0.0.3` affecting ghc-9.0.1 non-`ghc-lib-parser` builds;
- When testing this I had to qualify the use of `singleton` in `Fixity.hs` - I don't know why but anyway fixed;
- Stack continues to be broken for ghc-9.0.1:
  - Tested with:
     ```bash
      cabal new-build --constraint "hlint -ghc-lib" --constraint "ghc-lib-parser-ex -auto +no-ghc-lib"
      ``` 