### PR TITLE
Match import wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,14 @@ This fragment requires that all imports of `Set` must be `qualified Data.Set as 
 
 You can customize the `Note:` for restricted modules, functions and extensions, by providing a `message` field (default: `may break the code`).
 
+You can use [glob](https://en.wikipedia.org/wiki/Glob_(programming))-style wildcards to match on module names.
+
+```yaml
+- modules:
+  - {name: [Data.Map, Data.Map.*], as: Map}
+  - {name: Test.Hspec, within: **.*Spec }
+```
+
 ## Hacking HLint
 
 Contributions to HLint are most welcome, following [my standard contribution guidelines](https://github.com/ndmitchell/neil/blob/master/README.md#contributions).

--- a/data/wildcard-import.yaml
+++ b/data/wildcard-import.yaml
@@ -1,0 +1,1 @@
+[ { modules: [ { name: Data.Map.*, as: Map } ] } ]

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -20,7 +20,7 @@ import GHC.Hs
 import Language.Haskell.GhclibParserEx.GHC.Hs
 import qualified Data.HashSet as Set
 import Prelude
-import Util (wildcardMatch)
+import Util
 
 
 -- | Apply hints to a single file, you may have the contents of the file.

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -20,7 +20,7 @@ import GHC.Hs
 import Language.Haskell.GhclibParserEx.GHC.Hs
 import qualified Data.HashSet as Set
 import Prelude
-import System.FilePattern (FilePattern, (?==))
+import Util (wildcardMatch)
 
 
 -- | Apply hints to a single file, you may have the contents of the file.
@@ -116,19 +116,3 @@ classify xs i = let s = foldl' (f i) (ideaSeverity i) xs in s `seq` i{ideaSeveri
                 | otherwise = r
         x ~= y = x == "" || any (wildcardMatch x) y
         x  ~~= y = x == "" || x == y || ((x ++ ":") `isPrefixOf` y)
-
--- | Returns true if the pattern matches the string. For example:
---
--- >>> let isSpec = wildcardMatch "**.*Spec"
--- >>> isSpec "Example"
--- False
--- >>> isSpec "ExampleSpec"
--- True
--- >>> isSpec "Namespaced.ExampleSpec"
--- True
--- >>> isSpec "Deeply.Nested.ExampleSpec"
--- True
---
--- See this issue for details: <https://github.com/ndmitchell/hlint/issues/402>.
-wildcardMatch :: FilePattern -> String -> Bool
-wildcardMatch p m = let f = replace "." "/" in f p ?== f m

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -23,6 +23,7 @@ foo = nub s
 
 import Hint.Type(ModuHint,ModuleEx(..),Idea(..),Severity(..),warn,rawIdea)
 import Config.Type
+import Util (wildcardMatch)
 
 import Data.Generics.Uniplate.DataOnly
 import qualified Data.List.NonEmpty as NonEmpty
@@ -141,7 +142,7 @@ checkImports modu imp (def, mp) =
            | not allowQual   -> warn "Avoid restricted qualification" i (noLoc $ (unLoc i){ ideclAs=noLoc . mkModuleName <$> listToMaybe riAs} :: Located (ImportDecl GhcPs)) []
            | otherwise       -> error "checkImports: unexpected case"
     | i@(L _ ImportDecl {..}) <- imp
-    , let RestrictItem{..} = Map.findWithDefault (RestrictItem [] [("","") | def] [] Nothing) (moduleNameString (unLoc ideclName)) mp
+    , let RestrictItem{..} = getRestrictItem def ideclName mp
     , let allowImport = within modu "" riWithin
     , let allowIdent = Set.disjoint
                        (Set.fromList riBadIdents)
@@ -149,6 +150,19 @@ checkImports modu imp (def, mp) =
     , let allowQual = maybe True (\x -> null riAs || moduleNameString (unLoc x) `elem` riAs) ideclAs
     , not allowImport || not allowQual || not allowIdent
     ]
+
+getRestrictItem :: Bool -> Located ModuleName -> Map.Map String RestrictItem -> RestrictItem
+getRestrictItem def ideclName = fromMaybe (RestrictItem [] [("","") | def] [] Nothing) . lookupRestrictItem ideclName
+
+lookupRestrictItem :: Located ModuleName -> Map.Map String RestrictItem -> Maybe RestrictItem
+lookupRestrictItem ideclName mp =
+    let moduleName = moduleNameString $ unLoc ideclName
+        exact = Map.lookup moduleName mp
+        wildcard = fmap snd
+            . find (flip wildcardMatch moduleName . fst)
+            . filter (elem '*' . fst)
+            $ Map.toList mp
+    in exact <|> wildcard
 
 importListToIdents :: IE GhcPs -> [String]
 importListToIdents =

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -23,7 +23,7 @@ foo = nub s
 
 import Hint.Type(ModuHint,ModuleEx(..),Idea(..),Severity(..),warn,rawIdea)
 import Config.Type
-import Util (wildcardMatch)
+import Util
 
 import Data.Generics.Uniplate.DataOnly
 import qualified Data.List.NonEmpty as NonEmpty

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -13,8 +13,8 @@ import System.IO.Unsafe
 import Unsafe.Coerce
 import Data.Data
 import Data.Generics.Uniplate.DataOnly
-import System.FilePattern (FilePattern, (?==))
-import Data.List.Extra (replace)
+import System.FilePattern
+import Data.List.Extra
 
 
 ---------------------------------------------------------------------

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -4,7 +4,7 @@ module Util(
     forceList,
     gzip, universeParentBi,
     exitMessage, exitMessageImpure,
-    getContentsUTF8
+    getContentsUTF8, wildcardMatch
     ) where
 
 import System.Exit
@@ -13,6 +13,8 @@ import System.IO.Unsafe
 import Unsafe.Coerce
 import Data.Data
 import Data.Generics.Uniplate.DataOnly
+import System.FilePattern (FilePattern, (?==))
+import Data.List.Extra (replace)
 
 
 ---------------------------------------------------------------------
@@ -64,3 +66,23 @@ universeParent x = (Nothing,x) : f x
 
 universeParentBi :: (Data a, Data b) => a -> [(Maybe b, b)]
 universeParentBi = concatMap universeParent . childrenBi
+
+
+---------------------------------------------------------------------
+-- SYSTEM.FILEPATTERN
+
+-- | Returns true if the pattern matches the string. For example:
+--
+-- >>> let isSpec = wildcardMatch "**.*Spec"
+-- >>> isSpec "Example"
+-- False
+-- >>> isSpec "ExampleSpec"
+-- True
+-- >>> isSpec "Namespaced.ExampleSpec"
+-- True
+-- >>> isSpec "Deeply.Nested.ExampleSpec"
+-- True
+--
+-- See this issue for details: <https://github.com/ndmitchell/hlint/issues/402>.
+wildcardMatch :: FilePattern -> String -> Bool
+wildcardMatch p m = let f = replace "." "/" in f p ?== f m

--- a/tests/wildcard-import.test
+++ b/tests/wildcard-import.test
@@ -1,0 +1,27 @@
+---------------------------------------------------------------------
+RUN tests/wildcard-import-1.hs --hint=data/wildcard-import.yaml
+FILE tests/wildcard-import-1.hs
+import Data.Map.Lazy as Foo
+OUTPUT
+tests/wildcard-import-1.hs:1:1-27: Warning: Avoid restricted qualification
+Found:
+  import Data.Map.Lazy as Foo
+Perhaps:
+  import Data.Map.Lazy as Map
+Note: may break the code
+
+1 hint
+
+---------------------------------------------------------------------
+RUN tests/wildcard-import-2.hs --hint=data/wildcard-import.yaml
+FILE tests/wildcard-import-2.hs
+import Data.Map.Strict as Foo
+OUTPUT
+tests/wildcard-import-2.hs:1:1-29: Warning: Avoid restricted qualification
+Found:
+  import Data.Map.Strict as Foo
+Perhaps:
+  import Data.Map.Strict as Map
+Note: may break the code
+
+1 hint


### PR DESCRIPTION
Continues #1149 and fixes #402. 

I'm not necessarily happy with this code. I was trying to find the smallest change that fixed the issue. I think I did that, but the performance of this approach is probably bad. To check against a module name it does a map lookup as before, then it tries matching every pattern against the module name until it finds a match. This works but it could no doubt be faster. 

That being said, I haven't tested the real world performance of this. Perhaps it's acceptable? At any rate I'd be happy to work on a faster approach. 