### PR TITLE
Add CI step to generate hints.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,10 @@ Getting started on problems in HLint often means wanting to inspect a GHC parse 
 
 When you have an [`HsSyn`](https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/compiler/hs-syn-type) term in your program, it's quite common to want to print it (e.g. via `Debug.Trace.trace`). Types in `HsSyn` aren't in [`Show`](https://hoogle.haskell.org/?hoogle=Show). Not all types in `HsSyn` are [`Outputable`](https://hoogle.haskell.org/?hoogle=Outputable) but when they are you can call `ppr` to get `SDoc`s. This idiom is common enough that there exists [`unsafePrettyPrint`](https://hackage.haskell.org/package/ghc-lib-parser-ex-8.10.0.16/docs/Language-Haskell-GhclibParserEx-GHC-Utils-Outputable.html#v:unsafePrettyPrint). The function [`showAstData`](https://hoogle.haskell.org/?hoogle=showAstData) can be called on any `HsSyn` term to get output like with the `dump-parsed-ast` flag. The `showAstData` approach is preferable to `ppr` when both choices exist in that two ASTs that differ only in fixity arrangements will render differently with the former.
 
+### Generating the hints summary
+
+The hints summary is an auto-generated list of hlint's builtin hints. This can be generated with `hlint --generate-summary`, which will output the summary to `hints.md`.
+
 ### Acknowledgements
 
 Many improvements to this program have been made by [Niklas Broberg](http://www.nbroberg.se) in response to feature requests. Additionally, many people have provided help and patches, including Lennart Augustsson, Malcolm Wallace, Henk-Jan van Tuyl, Gwern Branwen, Alex Ott, Andy Stewart, Roman Leshchinskiy, Johannes Lippmann, Iustin Pop, Steve Purcell, Mitchell Rosen and others.

--- a/hints.md
+++ b/hints.md
@@ -4934,6 +4934,22 @@ f
 <td>Warning</td>
 </tr>
 <tr>
+<td>Redundant uncurry</td>
+<td>
+LHS:
+<code>
+uncurry f (a, b)
+</code>
+<br>
+RHS:
+<code>
+f a b
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
 <td>Redundant $</td>
 <td>
 LHS:
@@ -11522,6 +11538,22 @@ Data.Map.Strict.empty
 <td>Warning</td>
 </tr>
 <tr>
+<td>Use TH quotation brackets</td>
+<td>
+LHS:
+<code>
+TH.varE 'a
+</code>
+<br>
+RHS:
+<code>
+[| a |]
+</code>
+<br>
+</td>
+<td>Suggestion</td>
+</tr>
+<tr>
 <td>Redundant ^.</td>
 <td>
 LHS:
@@ -11574,7 +11606,7 @@ a ?~ b
 <td>
 LHS:
 <code>
-a & (mapped %~ b)
+(mapped %~ b) a
 </code>
 <br>
 RHS:
@@ -11590,7 +11622,7 @@ a <&> b
 <td>
 LHS:
 <code>
-a & ((mapped . b) %~ c)
+((mapped . b) %~ c) a
 </code>
 <br>
 RHS:
@@ -11606,7 +11638,7 @@ a <&> b %~ c
 <td>
 LHS:
 <code>
-a & (mapped .~ b)
+(mapped .~ b) a
 </code>
 <br>
 RHS:

--- a/travis.hs
+++ b/travis.hs
@@ -6,6 +6,7 @@ import System.Process.Extra
 main :: IO ()
 main = do
     system_ "cabal new-install apply-refact --install-method=copy"
+    system_ "hlint --generate-summary"
     system_ "hlint --test +RTS -K512K"
     (time,_) <- duration $ system_ "hlint src --with-group=extra --with-group=future" -- "UNIPLATE_VERBOSE=-1 hlint src +RTS -K1K"
     putStrLn $ "Running HLint on self took " ++ showDuration time


### PR DESCRIPTION
As part of the CI steps, hlint new executes `--generate-summary`, which
means the CI will fail if any changes to `hints.md` are written. This
aims to keep the hints summary list up to date.

This commit also refreshes the `hints.md` document.

This should address #1237