### PR TITLE
Allow configuration to forbid all imports from a module, with exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,12 +361,14 @@ This declares that the `nub` function can't be used in any modules, and thus is 
   - {name: [Data.Set, Data.HashSet], as: Set}
   - {name: Control.Arrow, within: []}
   - {name: Control.Monad.State, badidents: [modify, get, put], message: "Use Control.Monad.State.Class instead"}
+  - {name: Control.Exception, only: [Exception], message: "Use UnliftIO.Exception instead"}
 ```
 
 This fragment adds the following hints:
 * Requires that all imports of `Set` must be `qualified Data.Set as Set`, enforcing consistency
 * Ensures the module `Control.Arrow` can't be used anywhere
 * Prevents explicit imports of the given identifiers from `Control.Monad.State` (e.g. to prevent people from importing reexported identifiers).
+* Prevents all imports from `Control.Exception`, except `Exception`
 
 You can customize the `Note:` for restricted modules, functions and extensions, by providing a `message` field (default: `may break the code`).
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,10 @@ This declares that the `nub` function can't be used in any modules, and thus is 
   - {name: Control.Monad.State, badidents: [modify, get, put], message: "Use Control.Monad.State.Class instead"}
 ```
 
-This fragment requires that all imports of `Set` must be `qualified Data.Set as Set`, enforcing consistency. It also ensures the module `Control.Arrow` can't be used anywhere. It also prevents explicit imports of the `modify` identifier from `Control.Monad.State` (this is meant to allow you to prevent people from importing reexported identifiers).
+This fragment adds the following hints:
+* Requires that all imports of `Set` must be `qualified Data.Set as Set`, enforcing consistency
+* Ensures the module `Control.Arrow` can't be used anywhere
+* Prevents explicit imports of the given identifiers from `Control.Monad.State` (e.g. to prevent people from importing reexported identifiers).
 
 You can customize the `Note:` for restricted modules, functions and extensions, by providing a `message` field (default: `may break the code`).
 

--- a/data/test-restrict.yaml
+++ b/data/test-restrict.yaml
@@ -1,6 +1,8 @@
 - modules:
   - {name: Restricted.Module, within: []}
   - {name: Restricted.Module.Message, within: [], message: "Custom message"}
+  - {name: Restricted.Module.BadIdents, badidents: ['bad']}
+  - {name: Restricted.Module.OnlyIdents, only: ['good']}
 
 - functions:
   - {name: restricted, within: []}

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -1,7 +1,7 @@
 
 module Config.Type(
     Severity(..), Classify(..), HintRule(..), Note(..), Setting(..),
-    Restrict(..), RestrictType(..), SmellType(..),
+    Restrict(..), RestrictType(..), RestrictIdents(..), SmellType(..),
     defaultHintName, isUnifyVar, showNotes, getSeverity, getRestrictType, getSmellType
     ) where
 
@@ -106,13 +106,23 @@ data HintRule = HintRule
 
 data RestrictType = RestrictModule | RestrictExtension | RestrictFlag | RestrictFunction deriving (Show,Eq,Ord)
 
+data RestrictIdents
+    = NoRestrictIdents -- No restrictions on module imports
+    | ForbidIdents [String] -- Forbid importing the given identifiers from this module
+    deriving Show
+
+instance Semigroup RestrictIdents where
+    NoRestrictIdents <> ri = ri
+    ri <> NoRestrictIdents = ri
+    ForbidIdents x1 <> ForbidIdents y1 = ForbidIdents $ x1 <> y1
+
 data Restrict = Restrict
     {restrictType :: RestrictType
     ,restrictDefault :: Bool
     ,restrictName :: [String]
     ,restrictAs :: [String] -- for RestrictModule only, what module names you can import it as
     ,restrictWithin :: [(String, String)]
-    ,restrictBadIdents :: [String]
+    ,restrictIdents :: RestrictIdents -- for RestrictModule only, what identifiers can be imported from it
     ,restrictMessage :: Maybe String
     } deriving Show
 

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -109,12 +109,15 @@ data RestrictType = RestrictModule | RestrictExtension | RestrictFlag | Restrict
 data RestrictIdents
     = NoRestrictIdents -- No restrictions on module imports
     | ForbidIdents [String] -- Forbid importing the given identifiers from this module
+    | OnlyIdents [String] -- Forbid importing all identifiers from this module, except the given identifiers
     deriving Show
 
 instance Semigroup RestrictIdents where
     NoRestrictIdents <> ri = ri
     ri <> NoRestrictIdents = ri
     ForbidIdents x1 <> ForbidIdents y1 = ForbidIdents $ x1 <> y1
+    OnlyIdents x1 <> OnlyIdents x2 = OnlyIdents $ x1 <> x2
+    ri1 <> ri2 = error $ "Incompatible restrictions: " ++ show (ri1, ri2)
 
 data Restrict = Restrict
     {restrictType :: RestrictType

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -292,12 +292,18 @@ parseRestrict restrictType v = do
         Just def -> do
             b <- parseBool def
             allowFields v ["default"]
-            pure $ Restrict restrictType b [] [] [] [] Nothing
+            pure $ Restrict restrictType b [] [] [] NoRestrictIdents Nothing
         Nothing -> do
             restrictName <- parseFieldOpt "name" v >>= maybe (pure []) parseArrayString
             restrictWithin <- parseFieldOpt "within" v >>= maybe (pure [("","")]) (parseArray >=> concatMapM parseWithin)
             restrictAs <- parseFieldOpt "as" v >>= maybe (pure []) parseArrayString
-            restrictBadIdents <- parseFieldOpt "badidents" v >>= maybe (pure []) parseArrayString
+
+            restrictBadIdents <- parseFieldOpt "badidents" v
+            restrictIdents <-
+                case restrictBadIdents of
+                    Just badIdents -> ForbidIdents <$> parseArrayString badIdents
+                    Nothing -> return NoRestrictIdents
+
             restrictMessage <- parseFieldOpt "message" v >>= maybeParse parseString
             allowFields v $ concat
                 [ ["name", "within", "message"]

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -299,7 +299,12 @@ parseRestrict restrictType v = do
             restrictAs <- parseFieldOpt "as" v >>= maybe (pure []) parseArrayString
             restrictBadIdents <- parseFieldOpt "badidents" v >>= maybe (pure []) parseArrayString
             restrictMessage <- parseFieldOpt "message" v >>= maybeParse parseString
-            allowFields v $ ["as" | restrictType == RestrictModule] ++ ["badidents", "name", "within", "message"]
+            allowFields v $ concat
+                [ ["name", "within", "message"]
+                , if restrictType == RestrictModule
+                    then ["as", "badidents"]
+                    else []
+                ]
             pure Restrict{restrictDefault=True,..}
 
 parseWithin :: Val -> Parser [(String, String)] -- (module, decl)

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -150,6 +150,7 @@ checkImports modu lImportDecls (def, mp) = mapMaybe getImportHint lImportDecls
             invalidIdents = case riRestrictIdents of
               NoRestrictIdents -> Set.empty
               ForbidIdents badIdents -> importedIdents `Set.intersection` Set.fromList badIdents
+              OnlyIdents onlyIdents -> importedIdents `Set.difference` Set.fromList onlyIdents
         unless (Set.null invalidIdents) $
           Left $ ideaNoTo $ warn "Avoid restricted identifiers" i i []
 

--- a/tests/hint.test
+++ b/tests/hint.test
@@ -100,6 +100,82 @@ Note: Custom message
 1 hint
 
 ---------------------------------------------------------------------
+RUN tests/restricted-badidents-bad.lhs --hint=data/test-restrict.yaml
+FILE tests/restricted-badidents-bad.lhs
+> import Restricted.Module.BadIdents (bad)
+OUTPUT
+tests/restricted-badidents-bad.lhs:1:3-42: Warning: Avoid restricted identifiers
+Found:
+  import Restricted.Module.BadIdents ( bad )
+Note: may break the code
+
+1 hint
+
+---------------------------------------------------------------------
+RUN tests/restricted-badidents-multibad.lhs --hint=data/test-restrict.yaml
+FILE tests/restricted-badidents-multibad.lhs
+> import Restricted.Module.BadIdents (bad, good)
+OUTPUT
+tests/restricted-badidents-multibad.lhs:1:3-48: Warning: Avoid restricted identifiers
+Found:
+  import Restricted.Module.BadIdents ( bad, good )
+Note: may break the code
+
+1 hint
+
+---------------------------------------------------------------------
+RUN tests/restricted-badidents-valid.lhs --hint=data/test-restrict.yaml
+FILE tests/restricted-badidents-valid.lhs
+> import Restricted.Module.BadIdents (good)
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
+RUN tests/restricted-badidents-universal.lhs --hint=data/test-restrict.yaml
+FILE tests/restricted-badidents-universal.lhs
+> import Restricted.Module.BadIdents
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
+RUN tests/restricted-onlyidents-bad.lhs --hint=data/test-restrict.yaml
+FILE tests/restricted-onlyidents-bad.lhs
+> import Restricted.Module.OnlyIdents (bad)
+OUTPUT
+tests/restricted-onlyidents-bad.lhs:1:3-43: Warning: Avoid restricted identifiers
+Found:
+  import Restricted.Module.OnlyIdents ( bad )
+Note: may break the code
+
+1 hint
+
+---------------------------------------------------------------------
+RUN tests/restricted-onlyidents-multibad.lhs --hint=data/test-restrict.yaml
+FILE tests/restricted-onlyidents-multibad.lhs
+> import Restricted.Module.OnlyIdents (bad, good)
+OUTPUT
+tests/restricted-onlyidents-multibad.lhs:1:3-49: Warning: Avoid restricted identifiers
+Found:
+  import Restricted.Module.OnlyIdents ( bad, good )
+Note: may break the code
+
+1 hint
+
+---------------------------------------------------------------------
+RUN tests/restricted-onlyidents-valid.lhs --hint=data/test-restrict.yaml
+FILE tests/restricted-onlyidents-valid.lhs
+> import Restricted.Module.OnlyIdents (good)
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
+RUN tests/restricted-onlyidents-universal.lhs --hint=data/test-restrict.yaml
+FILE tests/restricted-onlyidents-universal.lhs
+> import Restricted.Module.OnlyIdents
+OUTPUT
+No hints
+
+---------------------------------------------------------------------
 RUN tests/restricted-function.lhs --hint=data/test-restrict.yaml
 FILE tests/restricted-function.lhs
 > main = restricted ()


### PR DESCRIPTION
Resolves #1244 

This PR includes the following changes:
* Previously, `badidents` was not disallowed when used on a `function:` block, but from what I can tell, it only makes sense in a `module:` block. Updated the `allowFields` call to only allow `badidents` for a `module:` block
* Change README paragraph to a bulleted list, which makes it much easier to correspond the hint in the config to the explanation for the hint
* Some refactoring in the `checkImports` function. Not strictly necessary, but IMO _much_ easier to read and understand. If reviewers disagree, happy to revert.
* Add a `RestrictIdents` data type and the `only` option to solve the ticket. This makes it a configuration error to provide both `badidents` and `only`. I'm not sure how they should interact if these options are not mutually exclusive.
* Add tests for both `badidents` and `only`