### PR TITLE
hint about 'null' on singleton list

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -735,6 +735,7 @@
     - warn: {lhs: "fst (x,y)", rhs: x, name: Evaluate}
     - warn: {lhs: "snd (x,y)", rhs: "y", name: Evaluate}
     - warn: {lhs: "init [x]", rhs: "[]", name: Evaluate}
+    - warn: {lhs: "null [x]", rhs: "False", name: Evaluate}
     - warn: {lhs: "null []", rhs: "True", name: Evaluate}
     - warn: {lhs: "length []", rhs: "0", name: Evaluate}
     - warn: {lhs: "foldl f z []", rhs: z, name: Evaluate}


### PR DESCRIPTION
Not sure anyone outside a teaching context would make this "mistake". That's why I put it into the `teaching` group. But in principle the hint could also go into the default group instead.