### PR TITLE
two hints about putStr -> putStrLn

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -66,6 +66,8 @@
     # I/O
 
     - warn: {lhs: putStrLn (show x), rhs: print x}
+    - warn: {lhs: putStr (x ++ "\n"), rhs: putStrLn x}
+    - warn: {lhs: putStr (x ++ y ++ "\n"), rhs: putStrLn (x ++ y)}
     - warn: {lhs: mapM_ putChar, rhs: putStr}
     - warn: {lhs: hGetChar stdin, rhs: getChar}
     - warn: {lhs: hGetLine stdin, rhs: getLine}


### PR DESCRIPTION
Typical occurrence (in student code) where the first hint applies is something like
```haskell
   putStr (show n ++ "\n")
```
which this will then suggest to replace by
```haskell
   putStrLn (show n)
```
after which an already existing hlint warning will say to replace it by
```haskell
   print n
```

Typical occurrence where the second hint from this commit applies is something like
```haskell
   putStr ("The result is: " ++ show n ++ "\n")
```
which this should then suggest to replace by
```haskell
   putStrLn ("The result is: " ++ show n)
```
