### PR TITLE
Remove >= from cabal-vesion

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -1,4 +1,4 @@
-cabal-version:      >= 1.18
+cabal-version:      1.18
 build-type:         Simple
 name:               hlint
 version:            3.3.1


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: hlint.cabal:1:28: Packages with 'cabal-version: 1.12' or later should
specify a specific version of the Cabal spec of the form 'cabal-version: x.y'.
Use 'cabal-version: 1.18'.
```