### PR TITLE
Suggest NumericUnderscores

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -160,6 +160,7 @@ library
         Hint.Smell
         Hint.Type
         Hint.Unsafe
+        Hint.NumLiteral
         Test.All
         Test.Annotations
         Test.InputOutput

--- a/src/GHC/Util/ApiAnnotation.hs
+++ b/src/GHC/Util/ApiAnnotation.hs
@@ -3,13 +3,19 @@ module GHC.Util.ApiAnnotation (
     comment, commentText, isCommentMultiline
   , pragmas, flags, languagePragmas
   , mkFlags, mkLanguagePragmas
+  , extensions
 ) where
 
+import GHC.LanguageExtensions.Type (Extension)
 import GHC.Parser.Annotation
 import GHC.Types.SrcLoc
 
+import Language.Haskell.GhclibParserEx.GHC.Driver.Session
+
 import Control.Applicative
 import Data.List.Extra
+import Data.Maybe (mapMaybe)
+import qualified Data.Set as Set
 
 trimCommentStart :: String -> String
 trimCommentStart s
@@ -63,6 +69,11 @@ pragmas anns =
    where
      realToLoc :: RealLocated a -> Located a
      realToLoc (L r x) = L (RealSrcSpan r Nothing) x
+
+-- All the extensions defined to be used.
+extensions :: ApiAnns -> Set.Set Extension
+extensions = Set.fromList . mapMaybe readExtension .
+    concatMap snd . languagePragmas . pragmas
 
 -- Utility for a case insensitive prefix strip.
 stripPrefixCI :: String -> String -> Maybe String

--- a/src/GHC/Util/ApiAnnotation.hs
+++ b/src/GHC/Util/ApiAnnotation.hs
@@ -14,7 +14,7 @@ import Language.Haskell.GhclibParserEx.GHC.Driver.Session
 
 import Control.Applicative
 import Data.List.Extra
-import Data.Maybe (mapMaybe)
+import Data.Maybe
 import qualified Data.Set as Set
 
 trimCommentStart :: String -> String

--- a/src/Hint/All.hs
+++ b/src/Hint/All.hs
@@ -32,6 +32,7 @@ import Hint.Comment
 import Hint.Unsafe
 import Hint.NewType
 import Hint.Smell
+import Hint.NumLiteral
 
 -- | A list of the builtin hints wired into HLint.
 --   This list is likely to grow over time.
@@ -39,7 +40,7 @@ data HintBuiltin =
     HintList | HintListRec | HintMonad | HintLambda | HintFixities |
     HintBracket | HintNaming | HintPattern | HintImport | HintExport |
     HintPragma | HintExtensions | HintUnsafe | HintDuplicate | HintRestrict |
-    HintComment | HintNewType | HintSmell
+    HintComment | HintNewType | HintSmell | HintNumLiteral
     deriving (Show,Eq,Ord,Bounded,Enum)
 
 -- See https://github.com/ndmitchell/hlint/issues/1150 - Duplicate is too slow
@@ -67,6 +68,7 @@ builtin x = case x of
     HintPattern    -> decl patternHint
     HintMonad      -> decl monadHint
     HintExtensions -> modu extensionsHint
+    HintNumLiteral -> decl numLiteralHint
     where
         wrap = timed "Hint" (drop 4 $ show x) . forceList
         decl f = mempty{hintDecl=const $ \a b c -> wrap $ f a b c}

--- a/src/Hint/NumLiteral.hs
+++ b/src/Hint/NumLiteral.hs
@@ -1,0 +1,106 @@
+{-
+    Suggest the usage of underscore when NumericUnderscores is enabled.
+
+<TEST>
+123456
+{-# LANGUAGE NumericUnderscores #-} \
+12345 -- @Suggestion 12_345
+{-# LANGUAGE NumericUnderscores #-} \
+123456789.0441234e-123456 -- @Suggestion 123_456_789.044_123_4e-123_456
+{-# LANGUAGE NumericUnderscores #-} \
+0x12abc.523defp+172345 -- @Suggestion 0x1_2abc.523d_efp+172_345
+{-# LANGUAGE NumericUnderscores #-} \
+3.14159265359 -- @Suggestion 3.141_592_653_59
+{-# LANGUAGE NumericUnderscores #-} \
+12_33574_56
+</TEST>
+
+-}
+
+module Hint.NumLiteral (numLiteralHint) where
+
+import GHC.Hs
+import GHC.LanguageExtensions.Type (Extension (..))
+import GHC.Types.SrcLoc
+import GHC.Types.Basic (SourceText (..), IntegralLit (..), FractionalLit (..))
+import GHC.Util.ApiAnnotation (extensions)
+import Data.Char (isDigit, isOctDigit, isHexDigit)
+import Data.List (intercalate)
+import Data.Generics.Uniplate.DataOnly (universeBi)
+import Refact.Types
+
+import Hint.Type (DeclHint, toSS, ghcAnnotations)
+import Idea (Idea, suggest)
+
+numLiteralHint :: DeclHint
+numLiteralHint _ modu decl =
+  if NumericUnderscores `elem` extensions (ghcAnnotations modu) then
+     concatMap suggestUnderscore $ universeBi decl
+  else
+     []
+
+suggestUnderscore :: LHsExpr GhcPs -> [Idea]
+suggestUnderscore x@(L _ (HsOverLit _ ol@(OverLit _ (HsIntegral intLit@(IL (SourceText srcTxt) _ _)) _))) =
+  [ suggest "Use underscore" x y [r] | '_' `notElem` srcTxt, srcTxt /= underscoredSrcTxt ]
+  where
+    underscoredSrcTxt = addUnderscore srcTxt
+    y = noLoc $ HsOverLit noExtField $ ol{ol_val = HsIntegral intLit{il_text = SourceText underscoredSrcTxt}}
+    r = Replace Expr (toSS x) [("a", toSS y)] "a"
+suggestUnderscore x@(L _ (HsOverLit _ ol@(OverLit _ (HsFractional fracLit@(FL (SourceText srcTxt) _ _)) _))) =
+  [ suggest "Use underscore" x y [r] | '_' `notElem` srcTxt, srcTxt /= underscoredSrcTxt ]
+  where
+    underscoredSrcTxt = addUnderscore srcTxt
+    y = noLoc $ HsOverLit noExtField $ ol{ol_val = HsFractional fracLit{fl_text = SourceText underscoredSrcTxt}}
+    r = Replace Expr (toSS x) [("a", toSS y)] "a"
+suggestUnderscore _ = mempty
+
+addUnderscore :: String -> String
+addUnderscore intStr = numLitToStr underscoredNumLit
+ where
+   numLit = toNumLiteral intStr
+   underscoredNumLit = numLit{ nl_intPart = underscoreFromRight chunkSize $ nl_intPart numLit
+                             , nl_fracPart = underscore chunkSize $ nl_fracPart numLit
+                             , nl_exp = underscoreFromRight 3 $ nl_exp numLit -- Exponential part is always decimal
+                             }
+   chunkSize = if null (nl_prefix numLit) then 3 else 4
+
+   underscore chunkSize = intercalate "_" . chunk chunkSize
+   underscoreFromRight chunkSize = reverse . underscore chunkSize . reverse
+   chunk chunkSize [] = []
+   chunk chunkSize xs = a:chunk chunkSize b where (a, b) = splitAt chunkSize xs
+
+data NumLiteral = NumLiteral
+  { nl_prefix :: String
+  , nl_intPart :: String
+  , nl_decSep :: String -- decimal separator
+  , nl_fracPart :: String
+  , nl_expSep :: String -- e, e+, e-, p, p+, p-
+  , nl_exp :: String
+  } deriving (Show, Eq)
+
+toNumLiteral :: String -> NumLiteral
+toNumLiteral str = case str of
+  '0':'b':digits -> (afterPrefix isBinDigit digits){nl_prefix = "0b"}
+  '0':'B':digits -> (afterPrefix isBinDigit digits){nl_prefix = "0B"}
+  '0':'o':digits -> (afterPrefix isOctDigit digits){nl_prefix = "0o"}
+  '0':'O':digits -> (afterPrefix isOctDigit digits){nl_prefix = "0O"}
+  '0':'x':digits -> (afterPrefix isHexDigit digits){nl_prefix = "0x"}
+  '0':'X':digits -> (afterPrefix isHexDigit digits){nl_prefix = "0X"}
+  _              -> afterPrefix isDigit str
+  where
+    isBinDigit x = x == '0' || x == '1'
+
+    afterPrefix isDigit str = (afterIntPart isDigit suffix){nl_intPart = intPart}
+      where (intPart, suffix) = span isDigit str
+
+    afterIntPart isDigit ('.':suffix) = (afterDecSep isDigit suffix){nl_decSep = "."}
+    afterIntPart isDigit str = afterFracPart str
+
+    afterDecSep isDigit str = (afterFracPart suffix){nl_fracPart = fracPart}
+      where (fracPart, suffix) = span isDigit str
+
+    afterFracPart str = NumLiteral "" "" "" "" expSep exp
+      where (expSep, exp) = break isDigit str
+
+numLitToStr :: NumLiteral -> String
+numLitToStr (NumLiteral p ip ds fp es e) = p ++ ip ++ ds ++ fp ++ es ++ e

--- a/src/Hint/NumLiteral.hs
+++ b/src/Hint/NumLiteral.hs
@@ -33,11 +33,11 @@ import Hint.Type (DeclHint, toSS, ghcAnnotations)
 import Idea (Idea, suggest)
 
 numLiteralHint :: DeclHint
-numLiteralHint _ modu decl =
+numLiteralHint _ modu =
   if NumericUnderscores `elem` extensions (ghcAnnotations modu) then
-     concatMap suggestUnderscore $ universeBi decl
+     concatMap suggestUnderscore . universeBi
   else
-     []
+     const []
 
 suggestUnderscore :: LHsExpr GhcPs -> [Idea]
 suggestUnderscore x@(L _ (HsOverLit _ ol@(OverLit _ (HsIntegral intLit@(IL (SourceText srcTxt) _ _)) _))) =

--- a/src/Hint/NumLiteral.hs
+++ b/src/Hint/NumLiteral.hs
@@ -4,13 +4,13 @@
 <TEST>
 123456
 {-# LANGUAGE NumericUnderscores #-} \
-12345 -- @Suggestion 12_345
+12345 -- @Suggestion 12_345 @NoRefactor
 {-# LANGUAGE NumericUnderscores #-} \
-123456789.0441234e-123456 -- @Suggestion 123_456_789.044_123_4e-123_456
+123456789.0441234e-123456 -- @Suggestion 123_456_789.044_123_4e-123_456 @NoRefactor
 {-# LANGUAGE NumericUnderscores #-} \
-0x12abc.523defp+172345 -- @Suggestion 0x1_2abc.523d_efp+172_345
+0x12abc.523defp+172345 -- @Suggestion 0x1_2abc.523d_efp+172_345 @NoRefactor
 {-# LANGUAGE NumericUnderscores #-} \
-3.14159265359 -- @Suggestion 3.141_592_653_59
+3.14159265359 -- @Suggestion 3.141_592_653_59 @NoRefactor
 {-# LANGUAGE NumericUnderscores #-} \
 12_33574_56
 </TEST>


### PR DESCRIPTION
Addressing #578.

Here, we suggest underscore with chunk size of 3 for decimal literals and 4 for non-decimal literals. We only suggest if `NumericUnderscores` is enabled in the file.

Example:
```
Suggestion: Use underscore
Found:
  123456789.0441234e-123456
Perhaps:
  123_456_789.044_123_4e-123_456

Suggestion: Use underscore
Found:
  0x12abc.523defp+172345
Perhaps:
  0x1_2abc.523d_efp+172_345

Suggestion: Use underscore
Found:
  3.14159265359
Perhaps:
  3.141_592_653_59
```