### PR TITLE
Qualifies use of (!?) in order to build against extra 1.7.10

### DIFF
--- a/src/Hint/Fixities.hs
+++ b/src/Hint/Fixities.hs
@@ -62,7 +62,7 @@ redundantInfixBracket fixities i parent child
             | i == 0 = (c, p)
             | otherwise = (p, c)
     in
-    case compareFixity <$> (fixities !? occNameString lop) <*> (fixities !? occNameString rop) of
+    case compareFixity <$> (fixities Data.Map.!? occNameString lop) <*> (fixities Data.Map.!? occNameString rop) of
     Just (False, r)
         | i == 0 -> not (needParenAsChild cr || r)
         | otherwise -> r


### PR DESCRIPTION
Running `cabal build` against `master` fails with 

```
src/Hint/Fixities.hs:65:38: error:
    Ambiguous occurrence ‘!?’
    It could refer to
       either ‘Data.List.Extra.!?’,
              imported from ‘Data.List.Extra’ at src/Hint/Fixities.hs:22:1-22
           or ‘Data.Map.!?’,
              imported from ‘Data.Map’ at src/Hint/Fixities.hs:23:1-15
              (and originally defined in ‘Data.Map.Internal’)
   |
65 |     case compareFixity <$> (fixities !? occNameString lop) <*> (fixities !? occNameString rop) of
   |                                      ^^

src/Hint/Fixities.hs:65:74: error:
    Ambiguous occurrence ‘!?’
    It could refer to
       either ‘Data.List.Extra.!?’,
              imported from ‘Data.List.Extra’ at src/Hint/Fixities.hs:22:1-22
           or ‘Data.Map.!?’,
              imported from ‘Data.Map’ at src/Hint/Fixities.hs:23:1-15
              (and originally defined in ‘Data.Map.Internal’)
   |
65 |     case compareFixity <$> (fixities !? occNameString lop) <*> (fixities !? occNameString rop) of
   |                                                                          ^^
```

since `Data.Map` and `Data.List.Extra` are both open imports.  This patch simply qualifies the uses of `(!?)`.  With this patch, the build succeeds.