### PR TITLE
Add some warnings to the cabal file

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -165,6 +165,7 @@ library
         Test.Annotations
         Test.InputOutput
         Test.Util
+    ghc-options: -Wunused-binds -Wunused-imports -Worphans
 
 
 executable hlint


### PR DESCRIPTION
I've forgot to check for unused imports before opening a PR multiple times. Adding the warnings that are checked in CI to the cabal file would be helpful.
