### PR TITLE
Install apply-refact in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
+    - run: cabal new-install apply-refact --install-method=copy
     - run: cabal v2-freeze --enable-tests
     - uses: actions/cache@v2
       with:

--- a/travis.hs
+++ b/travis.hs
@@ -5,7 +5,6 @@ import System.Process.Extra
 
 main :: IO ()
 main = do
-    system_ "cabal new-install apply-refact --install-method=copy"
     system_ "hlint --generate-summary"
     system_ "hlint --test +RTS -K512K"
     (time,_) <- duration $ system_ "hlint src --with-group=extra --with-group=future" -- "UNIPLATE_VERBOSE=-1 hlint src +RTS -K1K"


### PR DESCRIPTION
Fixes #1299 

It seems what happened is that `actions/cache` cached the `refactor` binary, so CI was using a binary built a while ago. The fix is to install `apply-refact` in `ci.yml` before `actions/cache`.