### PR TITLE
Assume a name is from Prelude unless we know where it is from

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1281,6 +1281,17 @@
 # import Prelude((==)) \
 # import qualified Prelude as P \
 # main = P.length xs == 0 -- P.null xs
+# import Prelude () \
+# main = length xs == 0 -- null xs
+# import Prelude () \
+# import Foo \
+# main = length xs == 0 -- null xs
+# import Prelude () \
+# import Data.Text (length) \
+# main = length xs == 0
+# import Prelude () \
+# import qualified Data.Text (length) \
+# main = length xs == 0 -- null xs
 # main = hello .~ Just 12 -- hello ?~ 12
 # foo = liftIO $ window `on` deleteEvent $ do a; b
 # no = sort <$> f input `shouldBe` sort <$> x


### PR DESCRIPTION
This seems a reasonable short term improvement before we decide how to re-do scoping properly. Reason for doing this:

- Sometimes people disable Prelude by `import Prelude ()`, and re-export some of it in a custom Prelude. This would make many hints stop firing because they rely on Prelude to be in scope.
  - (The problem of re-exporting names is not specific to Prelude, but I'd imagine Prelude is much more often re-exported than say `Data.Map`)
- This also makes HLint behave the same way wrt `import Prelude ()` and `{-# LANGUAGE NoImplicitPrelude #-}`.

#1298 has some discussion.