### PR TITLE
Update to ghc-8.10.7

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2021-02-06 # ghc-8.10.3
+resolver: lts-18.14
 packages:
   - .
 extra-deps:


### PR DESCRIPTION
Latest minor version bump. Testsuite runs correctly.

Motivation is just not wanting to have to have old GHCs installed, can just ship
this patch in my packaging if not merged. Will do so for now regardless.