### PR TITLE
evaluating all/any/allM/anyM on very simple lists

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -786,6 +786,10 @@
     - warn: {lhs: all (const True), rhs: const True, note: IncreasesLaziness, name: Evaluate}
     - warn: {lhs: "[] ++ x", rhs: x, name: Evaluate}
     - warn: {lhs: "x ++ []", rhs: x, name: Evaluate}
+    - warn: {lhs: "all f [a]", rhs: f a, name: Evaluate}
+    - warn: {lhs: "all f []", rhs: True, name: Evaluate}
+    - warn: {lhs: "any f [a]", rhs: f a, name: Evaluate}
+    - warn: {lhs: "any f []", rhs: False, name: Evaluate}
 
     # FOLDABLE + TUPLES
 
@@ -961,6 +965,10 @@
     - warn: {lhs: "ifM a b (return False)", rhs: "(&&^) a b"}
     - warn: {lhs: "anyM id", rhs: "orM"}
     - warn: {lhs: "allM id", rhs: "andM"}
+    - warn: {lhs: "allM f [a]", rhs: f a, name: Evaluate}
+    - warn: {lhs: "allM f []", rhs: return True, name: Evaluate}
+    - warn: {lhs: "anyM f [a]", rhs: f a, name: Evaluate}
+    - warn: {lhs: "anyM f []", rhs: return False, name: Evaluate}
     - warn: {lhs: "either id id", rhs: "fromEither"}
     - warn: {lhs: "either (const Nothing) Just", rhs: "eitherToMaybe"}
     - warn: {lhs: "either (Left . a) Right", rhs: "mapLeft a"}


### PR DESCRIPTION
The actual motivation for drawing those up was that I saw this in code:
```haskell
 if all null [unreachedState] then ...
```
Wasn't sure whether that was really what the student intended or there was some logical error.

Had they been prodded to rewrite this to:
```haskell
 if null unreachedState then ...
```
it would have probably been clearer already at their end (and possibly been changed in case of a logical error).

The other proposed rules are all similar, more or less just applying the same idea to similar functions.

I also thought about further special casing for two-element-lists, like
```yaml
    - warn: {lhs: "all f [a,b]", rhs: f a && f b, name: Evaluate}
```
but I guess this could be undesirable sometimes (such as when `f` is a long expression). So I didn't include those.