### PR TITLE
Add the yaml files used by EmbedData to extra-source-files

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -29,6 +29,10 @@ extra-source-files:
     data/*.hs
     data/*.yaml
     tests/*.test
+    -- These are needed because of haskell/cabal#7862
+    data/default.yaml
+    data/hlint.yaml
+    data/report_template.yaml
 extra-doc-files:
     README.md
     CHANGES.txt


### PR DESCRIPTION
Otherwise, modifying `hlint.yaml` does not trigger Cabal to rebuild `EmbedData.hs`, and one problem this leads to is failing to generate an up-to-date summary. See https://github.com/haskell/cabal/issues/7862.

Fixes #1316.