### PR TITLE
Make `HintRule` imply `Classify` in the hint file

### DIFF
--- a/data/hintrule-implies-classify.yaml
+++ b/data/hintrule-implies-classify.yaml
@@ -1,0 +1,2 @@
+- ignore: { }
+- warn: {lhs: mapM, rhs: traverse}

--- a/src/Test/Annotations.hs
+++ b/src/Test/Annotations.hs
@@ -123,7 +123,10 @@ parseTestFile file =
         open line
           |  "<TEST>" `isPrefixOf` line =
              let suffix = dropPrefix "<TEST>" line
-                 config = decodeEither'  $ BS.pack suffix
+                 config =
+                   if isBuiltinYaml file
+                     then mapRight getConfigYamlBuiltin $ decodeEither' $ BS.pack suffix
+                     else mapRight getConfigYamlUser $ decodeEither' $ BS.pack suffix
              in case config of
                   Left err -> Just []
                   Right config -> Just $ settingsFromConfigYaml [config]

--- a/tests/hintrule-implies-classify.test
+++ b/tests/hintrule-implies-classify.test
@@ -1,0 +1,12 @@
+---------------------------------------------------------------------
+RUN tests/hintrule-implies-classify.hs --hint=data/hintrule-implies-classify.yaml
+FILE tests/hintrule-implies-classify.hs
+x = mapM print [1, 2, 3]
+OUTPUT
+tests/hintrule-implies-classify.hs:1:5-8: Warning: Use traverse
+Found:
+  mapM
+Perhaps:
+  traverse
+
+1 hint


### PR DESCRIPTION
This change makes it so that a `Classify` is automatically added for each rule in the hint file. For example, `- error: {lhs: mapM, rhs: traverse}` now implies `- error: {name: Use traverse}`. See #1319 for motivation.

This only applies to the user hint file, and not `data/hlint.yaml`, for the following reasons:
- Efficiency. There's no need to generate a ton of `Classify`s for the rules in `data/hlint.yaml`.
- There are multiple rules with the same name, e.g., there's a builtin "Use join" which is a suggestion, and a few other "Use join" rules in `data/hlint.yaml` which are warnings. Applying the change to `data/hlint.yaml` would cause "Use join" to always be warnings.

Also, currently `Classify`s are only generated for rules. Other types of configs, such as
```
- modules:
  - {name: Control.Arrow, within: []}
```
does not generate a `- warn: {name: Avoid restricted module}`. This still needs to be added explicitly if needed, but at least the number is bounded.