### PR TITLE
Improve module restrict hints

### DIFF
--- a/data/import_style.yaml
+++ b/data/import_style.yaml
@@ -1,0 +1,6 @@
+- modules:
+  - {name: HypotheticalModule1, as: HM1, asRequired: true}
+  - {name: HypotheticalModule2, importStyle: explicitOrQualified}
+  - {name: HypotheticalModule3, importStyle: qualified}
+  - {name: 'HypotheticalModule3.*', importStyle: unqualified}
+  - {name: 'HypotheticalModule3.OtherSubModule', importStyle: unrestricted, qualifiedStyle: post}

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -2,11 +2,13 @@
 module Config.Type(
     Severity(..), Classify(..), HintRule(..), Note(..), Setting(..),
     Restrict(..), RestrictType(..), RestrictIdents(..), SmellType(..),
+    RestrictImportStyle(..), QualifiedStyle(..),
     defaultHintName, isUnifyVar, showNotes, getSeverity, getRestrictType, getSmellType
     ) where
 
 import Data.Char
 import Data.List.Extra
+import Data.Monoid
 import Prelude
 
 
@@ -119,11 +121,28 @@ instance Semigroup RestrictIdents where
     OnlyIdents x1 <> OnlyIdents x2 = OnlyIdents $ x1 <> x2
     ri1 <> ri2 = error $ "Incompatible restrictions: " ++ show (ri1, ri2)
 
+data RestrictImportStyle
+  = ImportStyleQualified
+  | ImportStyleUnqualified
+  | ImportStyleExplicit
+  | ImportStyleExplicitOrQualified
+  | ImportStyleUnrestricted
+  deriving Show
+
+data QualifiedStyle
+  = QualifiedStylePre
+  | QualifiedStylePost
+  | QualifiedStyleUnrestricted
+  deriving Show
+
 data Restrict = Restrict
     {restrictType :: RestrictType
     ,restrictDefault :: Bool
     ,restrictName :: [String]
     ,restrictAs :: [String] -- for RestrictModule only, what module names you can import it as
+    ,restrictAsRequired :: Alt Maybe Bool -- for RestrictModule only
+    ,restrictImportStyle :: Alt Maybe RestrictImportStyle -- for RestrictModule only
+    ,restrictQualifiedStyle :: Alt Maybe QualifiedStyle -- for RestrictModule only
     ,restrictWithin :: [(String, String)]
     ,restrictIdents :: RestrictIdents -- for RestrictModule only, what identifiers can be imported from it
     ,restrictMessage :: Maybe String

--- a/tests/import_style.test
+++ b/tests/import_style.test
@@ -1,0 +1,68 @@
+---------------------------------------------------------------------
+RUN tests/importStyle-1.hs --hint=data/import_style.yaml
+FILE tests/importStyle-1.hs
+import HypotheticalModule1
+import HypotheticalModule2
+import HypotheticalModule3
+import qualified HypotheticalModule3.SomeModule
+import HypotheticalModule3.SomeModule qualified
+import qualified HypotheticalModule3.OtherSubModule
+OUTPUT
+tests/importStyle-1.hs:1:1-26: Warning: Avoid restricted alias
+Found:
+  import HypotheticalModule1
+Perhaps:
+  import HypotheticalModule1 as HM1
+Note: may break the code
+
+tests/importStyle-1.hs:2:1-26: Warning: HypotheticalModule2 should be imported qualified or with an explicit import list
+Found:
+  import HypotheticalModule2
+Perhaps:
+  import qualified HypotheticalModule2
+Note: may break the code
+
+tests/importStyle-1.hs:3:1-26: Warning: HypotheticalModule3 should be imported qualified
+Found:
+  import HypotheticalModule3
+Perhaps:
+  import qualified HypotheticalModule3
+Note: may break the code
+
+tests/importStyle-1.hs:4:1-47: Warning: HypotheticalModule3.SomeModule should be imported unqualified
+Found:
+  import qualified HypotheticalModule3.SomeModule
+Perhaps:
+  import HypotheticalModule3.SomeModule
+Note: may break the code
+
+tests/importStyle-1.hs:5:1-47: Warning: HypotheticalModule3.SomeModule should be imported unqualified
+Found:
+  import HypotheticalModule3.SomeModule qualified
+Perhaps:
+  import HypotheticalModule3.SomeModule
+Note: may break the code
+
+tests/importStyle-1.hs:6:1-51: Warning: HypotheticalModule3.OtherSubModule should be imported post-qualified or unqualified
+Found:
+  import qualified HypotheticalModule3.OtherSubModule
+Perhaps:
+  import HypotheticalModule3.OtherSubModule qualified
+Note: may break the code
+
+6 hints
+
+---------------------------------------------------------------------
+RUN tests/importStyle-2.hs --hint=data/import_style.yaml
+FILE tests/importStyle-2.hs
+import HypotheticalModule1 as HM1
+import qualified HypotheticalModule2
+import HypotheticalModule2 (a, b, c, d)
+import qualified HypotheticalModule3
+import HypotheticalModule3.SomeModule
+import HypotheticalModule3.OtherSubModule qualified
+import HypotheticalModule3.OtherSubModule
+OUTPUT
+No hints
+
+---------------------------------------------------------------------

--- a/tests/wildcards.test
+++ b/tests/wildcards.test
@@ -3,7 +3,7 @@ RUN tests/wildcards-a.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-a.hs
 import A as Z
 OUTPUT
-tests/wildcards-a.hs:1:1-13: Warning: Avoid restricted qualification
+tests/wildcards-a.hs:1:1-13: Warning: Avoid restricted alias
 Found:
   import A as Z
 Perhaps:
@@ -38,7 +38,7 @@ RUN tests/wildcards-b.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-b.hs
 import B as Z
 OUTPUT
-tests/wildcards-b.hs:1:1-13: Warning: Avoid restricted qualification
+tests/wildcards-b.hs:1:1-13: Warning: Avoid restricted alias
 Found:
   import B as Z
 Perhaps:
@@ -52,7 +52,7 @@ RUN tests/wildcards-xb.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-xb.hs
 import XB as Z
 OUTPUT
-tests/wildcards-xb.hs:1:1-14: Warning: Avoid restricted qualification
+tests/wildcards-xb.hs:1:1-14: Warning: Avoid restricted alias
 Found:
   import XB as Z
 Perhaps:
@@ -80,7 +80,7 @@ RUN tests/wildcards-c.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-c.hs
 import C as Z
 OUTPUT
-tests/wildcards-c.hs:1:1-13: Warning: Avoid restricted qualification
+tests/wildcards-c.hs:1:1-13: Warning: Avoid restricted alias
 Found:
   import C as Z
 Perhaps:
@@ -101,7 +101,7 @@ RUN tests/wildcards-x-c.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-x-c.hs
 import X.C as Z
 OUTPUT
-tests/wildcards-x-c.hs:1:1-15: Warning: Avoid restricted qualification
+tests/wildcards-x-c.hs:1:1-15: Warning: Avoid restricted alias
 Found:
   import X.C as Z
 Perhaps:
@@ -115,7 +115,7 @@ RUN tests/wildcards-x-y-c.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-x-y-c.hs
 import X.Y.C as Z
 OUTPUT
-tests/wildcards-x-y-c.hs:1:1-17: Warning: Avoid restricted qualification
+tests/wildcards-x-y-c.hs:1:1-17: Warning: Avoid restricted alias
 Found:
   import X.Y.C as Z
 Perhaps:
@@ -129,7 +129,7 @@ RUN tests/wildcards-d.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-d.hs
 import D as Z
 OUTPUT
-tests/wildcards-d.hs:1:1-13: Warning: Avoid restricted qualification
+tests/wildcards-d.hs:1:1-13: Warning: Avoid restricted alias
 Found:
   import D as Z
 Perhaps:
@@ -143,7 +143,7 @@ RUN tests/wildcards-xd.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-xd.hs
 import XD as Z
 OUTPUT
-tests/wildcards-xd.hs:1:1-14: Warning: Avoid restricted qualification
+tests/wildcards-xd.hs:1:1-14: Warning: Avoid restricted alias
 Found:
   import XD as Z
 Perhaps:
@@ -157,7 +157,7 @@ RUN tests/wildcards-x-d.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-x-d.hs
 import X.D as Z
 OUTPUT
-tests/wildcards-x-d.hs:1:1-15: Warning: Avoid restricted qualification
+tests/wildcards-x-d.hs:1:1-15: Warning: Avoid restricted alias
 Found:
   import X.D as Z
 Perhaps:
@@ -171,7 +171,7 @@ RUN tests/wildcards-x-y-d.hs --hint=data/wildcards.yaml
 FILE tests/wildcards-x-y-d.hs
 import X.Y.D as Z
 OUTPUT
-tests/wildcards-x-y-d.hs:1:1-17: Warning: Avoid restricted qualification
+tests/wildcards-x-y-d.hs:1:1-17: Warning: Avoid restricted alias
 Found:
   import X.Y.D as Z
 Perhaps:


### PR DESCRIPTION
I'm not updating the readme for now, since I want some general feedback before doing any more work.

- Add new fields to module restrict config:
    - asRequired: Bool; if true, `as` alias is required. Ignored if `as`
      is empty.
    - ~~qualified: either 'always', 'never', 'exhaustive' or 'ignore';
      should the module be qualified? 'exhaustive' only requires
      qualification if there's no explicit import list, e.g.
      `import Foo (a, b, c)` is fine, but `import Bar hiding (d)` and
      `import Baz` will generate a hint.~~
    - importStyle: one of qualified, unqualified, explicit, explicitOrQualified, ignore.
      The preferred import style. `explicitOrQualified` accepts both `import Foo (a,b,c)`
      and `import qualified Foo`, but not `import Foo` or `import Foo hiding (x)`.
      `explicit` is basically the same, but doesn't accept `import qualified`
      (I'm not sure if it's very useful tbh). `qualified` and `unqualified` do not care
      about the import list at all.
    - qualifiedStyle: either 'pre', 'post' or 'ignore'; how should the
      module be qualified?

- Wildcard match handling is extended, such that restrictions are
  unified between wildcard and specific matches. With the new
  fields, the more specific option takes precedence. The list fields are
  merged. With multiple wildcard matches, the precedence between them is
  not guaranteed (but in practice, names are sorted in the
  reverse lexicograpicall order, and the first one wins -- which
  hopefully means the more specific one more often than not)

  This hopefully explains the reason for 'ignore' option: we can
  override the wildcard match with it.

  The primary motivation for this is to be able to specify the default
  pre/post style with something like

  ```
  - {name: ['**'], qualifiedStyle: post}
  ```

  But it does also add a fair bit of flexibility for writing rules (at the cost of some complexity).

  If there's a better way to do this, let me know.

If the same module is specified multiple times, for the new fields, only
the first definition will take effect.

If you're wondering why `asRequired` is a `Bool`, and not `always/never/ignore`, that's because `false` is `ignore` here, and there's no `never` option. One can already effectively forbid aliasing by specifying something like `name: Data.Map, as: Data.Map`.