### PR TITLE
upgrade to ghc-lib-parser-9.2.2

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -80,7 +80,7 @@ library
         aeson >= 1.1.2.0,
         filepattern >= 0.1.1
 
-    if !flag(ghc-lib) && impl(ghc >= 9.2.0) && impl(ghc < 9.3.0)
+    if !flag(ghc-lib) && impl(ghc >= 9.2.2) && impl(ghc < 9.3.0)
       build-depends:
         ghc == 9.2.*,
         ghc-boot-th,
@@ -89,7 +89,7 @@ library
       build-depends:
           ghc-lib-parser == 9.2.*
     build-depends:
-        ghc-lib-parser-ex >= 9.2.0.1 && < 9.2.1
+        ghc-lib-parser-ex >= 9.2.0.2 && < 9.2.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -274,7 +274,7 @@ import GHC.LanguageExtensions.Type
 
 import Language.Haskell.GhclibParserEx.GHC.Hs.Pat
 import Language.Haskell.GhclibParserEx.GHC.Hs.Expr
-import Language.Haskell.GhclibParserEx.GHC.Hs.Types
+import Language.Haskell.GhclibParserEx.GHC.Hs.Type
 import Language.Haskell.GhclibParserEx.GHC.Hs.Decls
 import Language.Haskell.GhclibParserEx.GHC.Hs.Binds
 import Language.Haskell.GhclibParserEx.GHC.Hs.ImpExp
@@ -379,9 +379,6 @@ isMDo' = \case MDoExpr _ -> True; _ -> False
 isStrictMatch' :: HsMatchContext GhcPs -> Bool
 isStrictMatch' = \case FunRhs{mc_strictness=SrcStrict} -> True; _ -> False
 
--- TODO(SF, 2012-12-22): Replace with ghc-lib-parser-ex.
-isKindTyApp :: LHsType GhcPs -> Bool
-isKindTyApp = \case (L _ HsAppKindTy{}) -> True; _ -> False
 isGetField :: LHsExpr GhcPs -> Bool
 isGetField = \case (L _ HsGetField{}) -> True; _ -> False
 isProjection :: LHsExpr GhcPs -> Bool

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,8 @@ packages:
   - .
 
 extra-deps:
-  - ghc-lib-parser-9.2.1.20211101
-  - ghc-lib-parser-ex-9.2.0.1
+  - ghc-lib-parser-9.2.2.20220307
+  - ghc-lib-parser-ex-9.2.0.2
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex/ghc-lib-parser-ex-8.10.0.18.tar.gz


### PR DESCRIPTION
- confirmed no more panics on input `infixr ++++`