### PR TITLE
update lower bound on ghc-lib-parser-ex

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -89,7 +89,7 @@ library
       build-depends:
           ghc-lib-parser == 9.2.*
     build-depends:
-        ghc-lib-parser-ex >= 9.2.0.2 && < 9.2.1
+        ghc-lib-parser-ex >= 9.2.0.3 && < 9.2.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21


### PR DESCRIPTION
use ghc-lib-parser-ex-9.2.0.3 as lower bound (fixes https://github.com/ndmitchell/hlint/issues/1314#issuecomment-1063382753)