### PR TITLE
Bump ghc-lib-parser-ex version

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,3 +1,4 @@
+:set -W
 :set -Wincomplete-patterns
 :set -Wunused-binds -Wunused-imports -Worphans
 :set -isrc


### PR DESCRIPTION
Forgotten in b34a949
Closes: #1355