### PR TITLE
Set -Wextra (fixes CI job)

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,3 +1,4 @@
+:set -W
 :set -Wincomplete-patterns
 :set -Wunused-binds -Wunused-imports -Worphans
 :set -isrc


### PR DESCRIPTION
`Cabal.hs` in [@ndmitchell/neil](https://github.com/ndmitchell/neil) checks that either `-W` is set or a couple `-fwarn-*`
flags are. Simplest fix is to just set `-W` (synonym for `-Wextra`)