### PR TITLE
bump ghc-lib-parser-ex to 9.2.0.3

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ packages:
 
 extra-deps:
   - ghc-lib-parser-9.2.2.20220307
-  - ghc-lib-parser-ex-9.2.0.2
+  - ghc-lib-parser-ex-9.2.0.3
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex/ghc-lib-parser-ex-8.10.0.18.tar.gz


### PR DESCRIPTION
fixes https://github.com/ndmitchell/hlint/issues/1355 (modifications to stack.yaml seem to have been deleted from https://github.com/ndmitchell/hlint/pull/1356; it's a good catch - we definitely want this). fwiw, afaik,  stack.yaml doesn't affect CI and i'm the only user.