### PR TITLE
Override NoCpp if neccessary

### DIFF
--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -207,13 +207,12 @@ cmdExtensions = getExtensions . cmdLanguage
 cmdCpp :: Cmd -> CppFlags
 cmdCpp cmd
     | cmdCppSimple cmd = CppSimple
-    | Cpp `elem` (fst . snd) (cmdExtensions cmd) = Cpphs defaultCpphsOptions
+    | otherwise = Cpphs defaultCpphsOptions
         {boolopts=defaultBoolOptions{hashline=False, stripC89=True, ansi=cmdCppAnsi cmd}
         ,includes = cmdCppInclude cmd
         ,preInclude = cmdCppFile cmd
         ,defines = ("__HLINT__","1") : [(a,drop1 b) | x <- cmdCppDefine cmd, let (a,b) = break (== '=') x]
         }
-    | otherwise = NoCpp
 
 
 -- | Determines whether to use colour or not.

--- a/src/GHC/All.hs
+++ b/src/GHC/All.hs
@@ -39,8 +39,7 @@ import GHC.Util
 
 -- | What C pre processor should be used.
 data CppFlags
-    = NoCpp -- ^ No pre processing is done.
-    | CppSimple -- ^ Lines prefixed with @#@ are stripped.
+    = CppSimple -- ^ Lines prefixed with @#@ are stripped.
     | Cpphs CpphsOptions -- ^ The @cpphs@ library is used.
 
 -- | Created with 'defaultParseFlags', used by 'parseModuleEx'.
@@ -54,7 +53,7 @@ data ParseFlags = ParseFlags
 
 -- | Default value for 'ParseFlags'.
 defaultParseFlags :: ParseFlags
-defaultParseFlags = ParseFlags NoCpp Nothing defaultExtensions [] defaultFixities
+defaultParseFlags = ParseFlags CppSimple Nothing defaultExtensions [] defaultFixities
 
 -- | Given some fixities, add them to the existing fixities in 'ParseFlags'.
 parseFlagsAddFixities :: [FixityInfo] -> ParseFlags -> ParseFlags
@@ -65,7 +64,6 @@ parseFlagsSetLanguage (l, (es, ds)) x = x{baseLanguage = l, enabledExtensions = 
 
 
 runCpp :: CppFlags -> FilePath -> String -> IO String
-runCpp NoCpp _ x = pure x
 runCpp CppSimple _ x = pure $ unlines [if "#" `isPrefixOf` trimStart x then "" else x | x <- lines x]
 runCpp (Cpphs o) file x = dropLine <$> runCpphs o file x
     where


### PR DESCRIPTION
If `CPP` is not a default enabled extension (because e.g. `-XHaskell2010` was provided and so hlint itself doesn't decide what the default extensions in effect are) and if further, `-XCPP` is not provided on the command line, then, the logic of `CmdLine.cmdCpp`  writes `NoCpp` into the prevailing `ParseFlags`.

In this scenario when later we determine `CPP` is in effect for a module because we read so from its pragmas, then we `runCpp` on it in`parseModuleEx` but the `NoCpp` means doing so has no effect! So, here, don't call `runCpp` with `cppFlags flags` but rather with `Cpphs defaultCpphsOptions`. Perhaps this will do?

Fixes https://github.com/ndmitchell/hlint/issues/1360.
