### PR TITLE
Add brackets on refactoring templates when needed

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1245,6 +1245,8 @@
 # foo = last (sortBy (compare `on` fst) xs) -- maximumBy (compare `on` fst) xs
 # g = \ f -> parseFile f >>= (\ cu -> return (f, cu))
 # foo = bar $ \(x,y) -> x x y
+# f = const [] . (>>= const Nothing) . const Nothing -- (const Nothing Control.Monad.<=< const Nothing)
+# f = g . either Left h x -- (h =<< x)
 # foo = (\x -> f x >>= g) -- f Control.Monad.>=> g
 # foo = (\f -> h f >>= g) -- h Control.Monad.>=> g
 # foo = (\f -> h f >>= f)

--- a/src/Hint/Match.hs
+++ b/src/Hint/Match.hs
@@ -162,7 +162,7 @@ matchIdea sb declName HintRule{..} parent x = do
   guard $ checkDefine declName parent rhs
 
   (u, tpl) <- pure $ if any ((== noSrcSpan) . locA . getLoc . snd) (fromSubst u) then (mempty, res) else (u, tpl)
-  tpl <- pure $ unqualify sa sb (performSpecial tpl)
+  tpl <- pure $ unqualify sa sb (addBracket parent $ performSpecial tpl)
 
   pure ( res, tpl, hintRuleNotes,
          [ (s, toSSA pos') | (s, pos) <- fromSubst u, locA (getLoc pos) /= noSrcSpan


### PR DESCRIPTION
Fixes #1364, fixes https://github.com/mpickering/apply-refact/issues/124

We call `addBracket` on the RHS to add brackets when needed. It appears the same should be done to `tpl` so that the refactoring output also includes the brackets.