### PR TITLE
Replace the ghc-lib flag with a subcomponent

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -1,8 +1,8 @@
-cabal-version:      1.18
+cabal-version:      3.0
 build-type:         Simple
 name:               hlint
 version:            3.4
-license:            BSD3
+license:            BSD-3-Clause
 license-file:       LICENSE
 category:           Development
 author:             Neil Mitchell <ndmitchell@gmail.com>
@@ -55,14 +55,14 @@ flag gpl
 flag ghc-lib
   default: False
   manual: True
-  description: Force dependency on ghc-lib-parser even if GHC API in the ghc package is supported
+  description: This flag does nothing. Instead, use the hlint:ghclib library
 
 flag hsyaml
   default: False
   manual: True
   description: Use HsYAML instead of yaml
 
-library
+common library
     default-language:   Haskell2010
     build-depends:
         base == 4.*, process, filepath, directory, containers,
@@ -78,17 +78,7 @@ library
         extra >= 1.7.3,
         refact >= 0.3,
         aeson >= 1.1.2.0,
-        filepattern >= 0.1.1
-
-    if !flag(ghc-lib) && impl(ghc >= 9.2.2) && impl(ghc < 9.3.0)
-      build-depends:
-        ghc == 9.2.*,
-        ghc-boot-th,
-        ghc-boot
-    else
-      build-depends:
-          ghc-lib-parser == 9.2.*
-    build-depends:
+        filepattern >= 0.1.1,
         ghc-lib-parser-ex >= 9.2.0.3 && < 9.2.1
 
     if flag(gpl)
@@ -105,8 +95,6 @@ library
         build-depends: yaml >= 0.5.0
 
     hs-source-dirs:     src
-    exposed-modules:
-        Language.Haskell.HLint
     other-modules:
         Paths_hlint
         Apply
@@ -170,6 +158,24 @@ library
         Test.InputOutput
         Test.Util
     ghc-options: -Wunused-binds -Wunused-imports -Worphans
+
+library
+  import: library
+  visibility:public
+  build-depends:
+      ghc == 9.2.*,
+      ghc-boot-th,
+      ghc-boot
+  exposed-modules:
+      Language.Haskell.HLint
+
+library ghclib
+  import: library
+  visibility:public
+  build-depends:
+        ghc-lib-parser == 9.2.*
+  exposed-modules:
+      Language.Haskell.HLint
 
 
 executable hlint


### PR DESCRIPTION
Addresses #1376 by creating a subcomponent `hlint:ghclib` that replaces the `ghc-lib` flag. This enables other packages upstream to declaratively select which "version" of `hlint` they need, e.g. HLS: https://github.com/pepeiborra/ide/commit/637aa0ba169b40dbcd73b54afb3e2834e1608b4e

A priori, there is no downside to introducing the `ghclib` component:

1. Building the `hlint` binary doesn't pull the `ghclib` component
2. No additional Hackage upload required

But there might be some hidden costs. Most tooling struggles with Cabal subcomponents. I don't know if `stack` can handle them, for instance.
