### PR TITLE
Time to default to ghc-9.0.2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.14 # ghc-8.10.7
+resolver: lts-19.8 # ghc-9.0.2
 
 packages:
   - .


### PR DESCRIPTION
changes the default resolver in stack.yaml to a ghc-9.0.2 compiler. this matters because 94.1 is coming (july) and a 9.0 series compiler will be a minimum version requirement.