### PR TITLE
update stack.yaml to ghc-lib-parser-9.2.3.20220507

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,8 @@ packages:
   - .
 
 extra-deps:
-  - ghc-lib-parser-9.2.2.20220307
-  - ghc-lib-parser-ex-9.2.0.3
+  - ghc-lib-parser-9.2.3.20220507
+  - ghc-lib-parser-ex-9.2.0.4
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex/ghc-lib-parser-ex-8.10.0.18.tar.gz


### PR DESCRIPTION
- update `stack.yaml` use:
  -  `ghc-lib-parser-9.2.3.20220507`
  - `ghc-lib-parser-ex-9.2.0.4`
- this change results from the release of ghc-9.2.3 (it is not related to https://github.com/ndmitchell/hlint/issues/1376#issuecomment-1139557187)
- it does not affect `hlint.cabal` & does not require a release (the new packages will be picked up automatically)