### PR TITLE
Flip ghc-lib default to True

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -53,7 +53,7 @@ flag gpl
     description: Use GPL libraries, specifically hscolour
 
 flag ghc-lib
-  default: False
+  default: True
   manual: True
   description: Force dependency on ghc-lib-parser even if GHC API in the ghc package is supported
 
@@ -90,7 +90,7 @@ library
       build-depends:
           ghc-lib-parser == 9.2.*
     build-depends:
-        ghc-lib-parser-ex >= 9.2.0.3 && < 9.2.1
+        ghc-lib-parser-ex >= 9.2.1.0 && < 9.2.2
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,19 +5,20 @@ packages:
 
 extra-deps:
   - ghc-lib-parser-9.2.3.20220709
-  - ghc-lib-parser-ex-9.2.0.4
+  - ghc-lib-parser-ex-9.2.1.0
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex/ghc-lib-parser-ex-8.10.0.18.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
 
-ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-local-binds -Werror=unused-top-binds -Werror=orphans}
-
-# Enabling this stanza forces both hlint and ghc-lib-parser-ex to
-# depend on ghc-lib-parser.
+# Enabling this stanza allows hlint and ghc-lib-parser-ex to link to
+# the native ghc compiler libs rather than ghc-lib-parser when the
+# compiler version is suitable.
 # flags:
-#   hlint:
-#     ghc-lib: true
-#   ghc-lib-parser-ex:
-#     auto: false
-#     no-ghc-lib: false
+#    hlint:
+#     ghc-lib: false
+#    ghc-lib-parser-ex:
+#      auto: true
+#      no-ghc-lib: false
+
+ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-local-binds -Werror=unused-top-binds -Werror=orphans}


### PR DESCRIPTION
Summary:

- Flip cabal flag `ghc-lib` default to `True` (i.e. disable 'auto' mode; unconditionally link `ghc-lib-parser`)
- Upgrade to `ghc-lib-parser-ex-9.2.1.0` (which has the same link behavior with respect to `ghc-lib-parser`)
- Fixes https://github.com/ndmitchell/hlint/issues/1376

Test plan:

(1) Execute `stack build --resolver nightly-2022-05-27 --cabal-verbose` (i.e. ghc-9.2.2). Observe,
```
depends:
  ...
  ghc-lib-parser-9.2.3.20220527-Apb5ZlADTS72sl2ZpNOJTy
  ghc-lib-parser-ex-9.2.1.0-13IoJhA5FNUCTxsgEW3SsR
  ...
```
This shows that `ghc-lib-parser` is linked and not ghc libs despite the compiler version being >=9.2.2 && <9.3.

(2) Enable in `stack.yaml` the stanza 
```yaml
flags:
   hlint:
     ghc-lib: false
   ghc-lib-parser-ex:
     auto: true
     no-ghc-lib: false
```
and execute`stack build --resolver nightly-2022-05-27 --cabal-verbose`. Observe now,
```
depends:
  ...
  ghc-9.2.2
  ghc-boot-9.2.2
  ghc-boot-th-9.2.2
  ...
```
This shows that with the default flags overridden we can recover the "old" behavior of linking the the native ghc libs rather than `ghc-lib-parser` when the compiler version is >= 9.2.2 && < 9.3