### PR TITLE
Bypass camelCase hint for new tasty_... custom test prefix

### DIFF
--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -122,7 +122,7 @@ isSym _ = False
 suggestName :: String -> Maybe String
 suggestName original
     | isSym original || good || not (any isLower original) || any isDigit original ||
-        any (`isPrefixOf` original) ["prop_","case_","unit_","test_","spec_","scprop_","hprop_"] = Nothing
+        any (`isPrefixOf` original) ["prop_","case_","unit_","test_","spec_","scprop_","hprop_","tasty_"] = Nothing
     | otherwise = Just $ f original
     where
         good = all isAlphaNum $ drp '_' $ drp '#' $ reverse $ filter (/= '\'') $ drp '_' original


### PR DESCRIPTION
In tasty-discover 4.2.4 support was added for "custom test cases" with a
prefix of 'tasty_'. We bypass the camelCase naming hint for these,
matching the current behaviour for the other tasty-discover prefixes.

(See https://github.com/haskell-works/tasty-discover#write-tests for the list of supported identifiers.)