### PR TITLE
Update macos ghc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         - os: windows-latest
           ghc: '9.2'
         - os: macOS-latest
-          ghc: '9.2'
+          ghc: '9.2.3'
 
     steps:
     - run: git config --global core.autocrlf false

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -53,7 +53,7 @@ flag gpl
     description: Use GPL libraries, specifically hscolour
 
 flag ghc-lib
-  default: False
+  default: True
   manual: True
   description: Force dependency on ghc-lib-parser even if GHC API in the ghc package is supported
 
@@ -89,7 +89,7 @@ library
       build-depends:
           ghc-lib-parser == 9.2.*
     build-depends:
-        ghc-lib-parser-ex >= 9.2.0.3 && < 9.2.1
+        ghc-lib-parser-ex >= 9.2.1.0 && < 9.2.2
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,20 +4,21 @@ packages:
   - .
 
 extra-deps:
-  - ghc-lib-parser-9.2.3.20220507
-  - ghc-lib-parser-ex-9.2.0.4
+  - ghc-lib-parser-9.2.3.20220527
+  - ghc-lib-parser-ex-9.2.1.0
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex/ghc-lib-parser-ex-8.10.0.18.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
 
-ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-local-binds -Werror=unused-top-binds -Werror=orphans}
-
-# Enabling this stanza forces both hlint and ghc-lib-parser-ex to
-# depend on ghc-lib-parser.
+# Enabling this stanza allows hlint and ghc-lib-parser-ex to link to
+# the native ghc compiler libs rather than ghc-lib-parser when the
+# compiler version is suitable.
 # flags:
-#   hlint:
-#     ghc-lib: true
-#   ghc-lib-parser-ex:
-#     auto: false
-#     no-ghc-lib: false
+#    hlint:
+#     ghc-lib: false
+#    ghc-lib-parser-ex:
+#      auto: true
+#      no-ghc-lib: false
+
+ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-local-binds -Werror=unused-top-binds -Werror=orphans}


### PR DESCRIPTION
let's see what the effect is of fixing the `macOS-latest`  build compiler to ghc-9.2.3