### PR TITLE
dual versions of existing min/max hints (from if-comparison-else)

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -120,9 +120,13 @@
     - hint: {lhs: flip (g `on` h), rhs: flip g `on` h, name: Move flip}
     - hint: {lhs: (f `on` g) `on` h, rhs: f `on` (g . h), name: Fuse on/on}
     - warn: {lhs: if a >= b then a else b, rhs: max a b}
+    - warn: {lhs: if a >= b then b else a, rhs: min a b}
     - warn: {lhs: if a > b then a else b, rhs: max a b}
+    - warn: {lhs: if a > b then b else a, rhs: min a b}
     - warn: {lhs: if a <= b then a else b, rhs: min a b}
+    - warn: {lhs: if a <= b then b else a, rhs: max a b}
     - warn: {lhs: if a < b then a else b, rhs: min a b}
+    - warn: {lhs: if a < b then b else a, rhs: max a b}
     - warn: {lhs: "maximum [a, b]", rhs: max a b}
     - warn: {lhs: "minimum [a, b]", rhs: min a b}
 


### PR DESCRIPTION
These would be superfluous if hlint somehow "saw through comparisons", matching
```haskell
if a >= b then b else a
```
against
```haskell
if b <= a then b else a
```
But I guess it doesn't.