### PR TITLE
remove two of three identical lines

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -499,8 +499,6 @@
     - warn: {lhs: unless (not x), rhs: when x}
     - warn: {lhs: x >>= id, rhs: Control.Monad.join x}
     - warn: {lhs: id =<< x, rhs: Control.Monad.join x}
-    - warn: {lhs: id =<< x, rhs: Control.Monad.join x}
-    - warn: {lhs: id =<< x, rhs: Control.Monad.join x}
     - hint: {lhs: join (f <$> x), rhs: f =<< x}
     - hint: {lhs: join (fmap f x), rhs: f =<< x}
     - hint: {lhs: a >> pure (), rhs: Control.Monad.void a, side: isAtom a || isApp a}


### PR DESCRIPTION
Seems to be the only (verbatim) case of such duplication, according to
```
sort -m hlint.yaml | uniq -d
```