### PR TITLE
make lefts/rights hints apply more often

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -680,8 +680,8 @@
 
     # EITHER
 
-    - warn: {lhs: "[a | Left a <- a]", rhs: lefts a}
-    - warn: {lhs: "[a | Right a <- a]", rhs: rights a}
+    - warn: {lhs: "[a | Left a <- b]", rhs: lefts b}
+    - warn: {lhs: "[a | Right a <- b]", rhs: rights b}
     - warn: {lhs: either Left (Right . f), rhs: fmap f}
     - warn: {lhs: either f g (fmap h x), rhs: either f (g . h) x, name: Redundant fmap}
     - warn: {lhs: isLeft (fmap f x), rhs: isLeft x}


### PR DESCRIPTION
It seems `hlint` isn't realizing that the `a`s in the current hints have different scopes. They seem to be matched literally, so that the hints do match less often than they could.