### PR TITLE
point out interplay between list comprehension and singleton list

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -588,6 +588,7 @@
     - hint: {lhs: "if b then [x] else []", rhs: "[x | b]", name: Use list comprehension}
     - hint: {lhs: "if b then [] else [x]", rhs: "[x | not b]", name: Use list comprehension}
     - hint: {lhs: "[x | x <- y]", rhs: "y", side: isVar x, name: Redundant list comprehension}
+    - hint: {lhs: "[ f x | x <- [y] ]", rhs: "[f y]", side: isVar x, name: Redundant list comprehension}
 
     # SEQ
 
@@ -1133,7 +1134,6 @@
     - hint: {lhs: "[] /= x", rhs: not (null x), name: Use null}
     - hint: {lhs: "not (x || y)", rhs: "not x && not y", name: Apply De Morgan law}
     - hint: {lhs: "not (x && y)", rhs: "not x || not y", name: Apply De Morgan law}
-    - hint: {lhs: "[ f x | x <- [y] ]", rhs: "[f y]", name: Redundant list comprehension}
     - hint: {lhs: "[ f x | x <- l ]", rhs: map f l}
     - hint: {lhs: "[ x | x <- l, p x ]", rhs: filter p l}
     - warn: {lhs: foldr f c (reverse x), rhs: foldl (flip f) c x, name: Use left fold instead of right fold}

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1133,6 +1133,7 @@
     - hint: {lhs: "[] /= x", rhs: not (null x), name: Use null}
     - hint: {lhs: "not (x || y)", rhs: "not x && not y", name: Apply De Morgan law}
     - hint: {lhs: "not (x && y)", rhs: "not x || not y", name: Apply De Morgan law}
+    - hint: {lhs: "[ f x | x <- [y] ]", rhs: "[f y]", name: Redundant list comprehension}
     - hint: {lhs: "[ f x | x <- l ]", rhs: map f l}
     - hint: {lhs: "[ x | x <- l, p x ]", rhs: filter p l}
     - warn: {lhs: foldr f c (reverse x), rhs: foldl (flip f) c x, name: Use left fold instead of right fold}


### PR DESCRIPTION
Students sometimes write
```haskell
[ f x | x <- [y] ]
```
when they really mean
```haskell
[ f x | x <- y ]
```
It's as if they think that by putting the `y` in brackets they are "declaring" that it is a list. (As if that were not already given by the *type* of `y`. Interestingly, I see the same behavior in Prolog code, which doesn't really have a type system. Some students put Prolog variables in `[...]` when they are lists. Leading to code with `[Y]` when `Ys` would be the "sample solution" - signifying the list type at least via variable name convention.)

Putting that aside aside, a few comments on this pull request:

1. Ideally I would want to automatically tell students that they probably didn't mean `[ f x | x <- [y] ]` in the first place. But that's not really a job `hlint` is made for. But by pointing students to the fact that what they wrote is equivalent to `[f y]`, they maybe realize that they actually meant `[ f x | x <- y ]` originally.
2. I put the new rule into the `teaching` group, but arguably it could also belong here in the `default` group: https://github.com/ndmitchell/hlint/blob/c9bfda7de8c2872d0d207212b123345756084e98/data/hlint.yaml#L586-L590

3. There is overlap of the rule from this pull request with this one (also in the `teaching` group): https://github.com/ndmitchell/hlint/blob/c9bfda7de8c2872d0d207212b123345756084e98/data/hlint.yaml#L1136 But I would still propose to keep both. For one thing, hint selection via rule names can be used (and is used at our end) to disable hints about higher-order functions when these are still unknown. So, in fact, in the first exercise sessions students already know about list comprehensions, but not about `map`, so we will not show them the `Use map` hint. But the new hint from this pull request could already be shown to them. Moreover, if the new rule would be added to `default` instead of `teaching`, the point about rule overlap would be moot, since the other hint is still in `teaching` only.
4. I was a bit concerned whether I need an `isVar` side condition, because this rule has one: https://github.com/ndmitchell/hlint/blob/c9bfda7de8c2872d0d207212b123345756084e98/data/hlint.yaml#L590 But actually, some local experiments seem to indicate that `isVar` is not needed. (?) Actually, that one line is the only occurrence of `isVar` in the whole of `hlint.yaml`. Is it an obsolete left-over?