### PR TITLE
upgrade to ghc-9.4 parse tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,16 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # GHC 9.2.1 had a bug, so we treat it differently to 9.2.2
-        ghc: ['9.2', '9.2.1', '9.0', '8.10']
+        ghc: ['9.2', '9.2.1', '9.0']
         include:
         - os: windows-latest
           ghc: '9.2'
         - os: macOS-latest
-          ghc: '9.2'
+          # GHC 9.2.2 afflicted with a hadrian bug that results in
+          # 'ffitarget_XXX.h' file not found errors that manifest
+          # building ghc-lib-parser (see issue
+          # https://gitlab.haskell.org/ghc/ghc/-/issues/20592)
+          ghc: '9.2.3'
 
     steps:
     - run: git config --global core.autocrlf false

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ TAGS
 /.hpc/
 /.stack-work/
 /cc/.stack-work/
-stack.yaml.lock
+stack*.yaml.lock
 /issues/
 /Sample.hs
 /hlint.prof

--- a/hints.md
+++ b/hints.md
@@ -1420,13 +1420,13 @@ Example:
 </pre>
 Found:
 <pre>
-{-# LANGUAGE RebindableSyntax #-}
 {-# LANGUAGE EmptyCase, RebindableSyntax #-}
+{-# LANGUAGE RebindableSyntax #-}
 
 </pre>
 Suggestion:
 <code>
-{-# LANGUAGE RebindableSyntax, EmptyCase #-}
+{-# LANGUAGE EmptyCase, RebindableSyntax #-}
 </code>
 <br>
 </td>

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -53,7 +53,7 @@ flag gpl
     description: Use GPL libraries, specifically hscolour
 
 flag ghc-lib
-  default: False
+  default: True
   manual: True
   description: Force dependency on ghc-lib-parser even if GHC API in the ghc package is supported
 
@@ -81,16 +81,16 @@ library
         deriving-aeson >= 0.2,
         filepattern >= 0.1.1
 
-    if !flag(ghc-lib) && impl(ghc >= 9.2.2) && impl(ghc < 9.3.0)
+    if !flag(ghc-lib) && impl(ghc >= 9.4.1) && impl(ghc < 9.5.0)
       build-depends:
-        ghc == 9.2.*,
+        ghc == 9.4.*,
         ghc-boot-th,
         ghc-boot
     else
       build-depends:
-          ghc-lib-parser == 9.2.*
+          ghc-lib-parser == 9.4.*
     build-depends:
-        ghc-lib-parser-ex >= 9.2.0.3 && < 9.2.1
+        ghc-lib-parser-ex >= 9.4.0.0 && < 9.4.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/src/Config/Compute.hs
+++ b/src/Config/Compute.hs
@@ -63,7 +63,7 @@ findExp name vs (HsLam _ MG{mg_alts=L _ [L _ Match{m_pats, m_grhss=GRHSs{grhssGR
 findExp name vs HsLam{} = []
 findExp name vs HsVar{} = []
 findExp name vs (OpApp _ x dot y) | isDot dot = findExp name (vs++["_hlint"]) $
-    HsApp EpAnnNotUsed x $ noLocA $ HsPar EpAnnNotUsed $ noLocA $ HsApp EpAnnNotUsed y $ noLocA $ mkVar "_hlint"
+    HsApp EpAnnNotUsed x $ nlHsPar $ noLocA $ HsApp EpAnnNotUsed y $ noLocA $ mkVar "_hlint"
 
 findExp name vs bod = [SettingMatchExp $
         HintRule Warning defaultHintName []
@@ -74,7 +74,7 @@ findExp name vs bod = [SettingMatchExp $
 
         rep = zip vs $ map (mkVar . pure) ['a'..]
         f (HsVar _ x) | Just y <- lookup (rdrNameStr x) rep = y
-        f (OpApp _ x dol y) | isDol dol = HsApp EpAnnNotUsed x $ noLocA $ HsPar EpAnnNotUsed y
+        f (OpApp _ x dol y) | isDol dol = HsApp EpAnnNotUsed x $ nlHsPar y
         f x = x
 
 

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -23,6 +23,7 @@ import GHC.Hs.Lit
 import GHC.Data.FastString
 import GHC.Parser.Annotation
 import GHC.Utils.Outputable
+import qualified GHC.Data.Strict
 
 import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
 import Language.Haskell.GhclibParserEx.GHC.Types.Name.Reader
@@ -43,7 +44,7 @@ readPragma (HsAnnotation _ _ provenance expr) = f expr
                     Nothing -> errorOn expr "bad classify pragma"
                     Just severity -> Just $ Classify severity (trimStart b) "" name
             where (a,b) = break isSpace $ trimStart $ drop 6 s
-        f (L _ (HsPar _ x)) = f x
+        f (L _ (HsPar _ _ x _)) = f x
         f (L _ (ExprWithTySig _ x _)) = f x
         f _ = Nothing
 
@@ -83,6 +84,6 @@ errorOn (L pos val) msg = exitMessageImpure $
 errorOnComment :: LEpaComment -> String -> b
 errorOnComment c@(L s _) msg = exitMessageImpure $
     let isMultiline = isCommentMultiline c in
-    showSrcSpan (RealSrcSpan (anchor s) Nothing) ++
+    showSrcSpan (RealSrcSpan (anchor s) GHC.Data.Strict.Nothing) ++
     ": Error while reading hint file, " ++ msg ++ "\n" ++
     (if isMultiline then "{-" else "--") ++ commentText c ++ (if isMultiline then "-}" else "")

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -22,7 +22,9 @@ module Config.Yaml(
 #endif
 
 import GHC.Driver.Ppr
-import GHC.Parser.Errors.Ppr
+import GHC.Driver.Errors.Types
+import GHC.Types.Error hiding (Severity)
+
 import Config.Type
 import Data.Either.Extra
 import Data.Maybe
@@ -232,7 +234,7 @@ parseGHC parser v = do
     case parser defaultParseFlags{enabledExtensions=configExtensions, disabledExtensions=[]} x of
         POk _ x -> pure x
         PFailed ps ->
-          let errMsg = pprError . head . bagToList . snd $ getMessages ps
+          let errMsg = head . bagToList . getMessages $ GhcPsMessage <$> snd (getPsMessages ps)
               msg = showSDoc baseDynFlags $ pprLocMsgEnvelope errMsg
           in parseFail v $ "Failed to parse " ++ msg ++ ", when parsing:\n " ++ x
 

--- a/src/GHC/Util/ApiAnnotation.hs
+++ b/src/GHC/Util/ApiAnnotation.hs
@@ -8,6 +8,7 @@ module GHC.Util.ApiAnnotation (
 
 import GHC.LanguageExtensions.Type (Extension)
 import GHC.Parser.Annotation
+import GHC.Hs.DocString
 import GHC.Types.SrcLoc
 
 import Language.Haskell.GhclibParserEx.GHC.Driver.Session
@@ -33,14 +34,11 @@ trimCommentDelims = trimCommentEnd . trimCommentStart
 
 -- | A comment as a string.
 comment_ :: LEpaComment -> String
-comment_ (L _ (EpaComment (EpaBlockComment s ) _)) = s
-comment_ (L _ (EpaComment (EpaLineComment s) _)) = s
+comment_ (L _ (EpaComment (EpaDocComment ds ) _)) = renderHsDocString ds
 comment_ (L _ (EpaComment (EpaDocOptions s) _)) = s
-comment_ (L _ (EpaComment (EpaDocCommentNamed s) _)) = s
-comment_ (L _ (EpaComment (EpaDocCommentPrev s) _)) = s
-comment_ (L _ (EpaComment (EpaDocCommentNext s) _)) = s
-comment_ (L _ (EpaComment (EpaDocSection _ s) _)) = s
-comment_ (L _ (EpaComment  EpaEofComment _)) = ""
+comment_ (L _ (EpaComment (EpaLineComment s) _)) = s
+comment_ (L _ (EpaComment (EpaBlockComment s) _)) = s
+comment_ (L _ (EpaComment EpaEofComment _)) = ""
 
 -- | The comment string with delimiters removed.
 commentText :: LEpaComment -> String

--- a/src/GHC/Util/Brackets.hs
+++ b/src/GHC/Util/Brackets.hs
@@ -26,18 +26,18 @@ instance Brackets (LocatedA (HsExpr GhcPs)) where
   -- result in a "naked" section. Consequently, given an expression,
   -- when stripping brackets (c.f. 'Hint.Brackets), don't remove the
   -- paren's surrounding a section - they are required.
-  remParen (L _ (HsPar _ (L _ SectionL{}))) = Nothing
-  remParen (L _ (HsPar _ (L _ SectionR{}))) = Nothing
-  remParen (L _ (HsPar _ x)) = Just x
+  remParen (L _ (HsPar _ _ (L _ SectionL{}) _)) = Nothing
+  remParen (L _ (HsPar _ _ (L _ SectionR{}) _)) = Nothing
+  remParen (L _ (HsPar _ _ x _)) = Just x
   remParen _ = Nothing
 
-  addParen e = noLocA $ HsPar EpAnnNotUsed e
+  addParen = nlHsPar
 
   isAtom (L _ x) = case x of
       HsVar{} -> True
       HsUnboundVar{} -> True
       -- Technically atomic, but lots of people think it shouldn't be
-      HsRecFld{} -> False
+      HsRecSel{} -> False
       HsOverLabel{} -> True
       HsIPVar{} -> True
       -- Note that sections aren't atoms (but parenthesized sections are).
@@ -48,7 +48,8 @@ instance Brackets (LocatedA (HsExpr GhcPs)) where
       RecordCon{} -> True
       RecordUpd{} -> True
       ArithSeq{}-> True
-      HsBracket{} -> True
+      HsTypedBracket{} -> True
+      HsUntypedBracket{} -> True
       -- HsSplice might be $foo, where @($foo) would require brackets,
       -- but in that case the $foo is a type, so we can still mark Splice as atomic
       HsSpliceE{} -> True
@@ -104,9 +105,9 @@ isAtomOrApp (L _ (HsApp _ _ x)) = isAtomOrApp x
 isAtomOrApp _ = False
 
 instance Brackets (LocatedA (Pat GhcPs)) where
-  remParen (L _ (ParPat _ x)) = Just x
+  remParen (L _ (ParPat _ _ x _)) = Just x
   remParen _ = Nothing
-  addParen e = noLocA $ ParPat EpAnnNotUsed e
+  addParen = nlParPat
 
   isAtom (L _ x) = case x of
     ParPat{} -> True

--- a/src/GHC/Util/Scope.hs
+++ b/src/GHC/Util/Scope.hs
@@ -14,6 +14,7 @@ import GHC.Unit.Module
 import GHC.Data.FastString
 import GHC.Types.Name.Reader
 import GHC.Types.Name.Occurrence
+import GHC.Types.PkgQual
 
 import Language.Haskell.GhclibParserEx.GHC.Types.Name.Reader
 import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
@@ -34,7 +35,10 @@ scopeCreate xs = Scope $ [prelude | not $ any isPrelude res] ++ res
   where
     -- Package qualifier of an import declaration.
     pkg :: LImportDecl GhcPs -> Maybe StringLiteral
-    pkg (L _ x) = ideclPkgQual x
+    pkg (L _ x) =
+      case ideclPkgQual x of
+        RawPkgQual s -> Just s
+        NoRawPkgQual -> Nothing
 
     -- The import declaraions contained by the module 'xs'.
     res :: [LImportDecl GhcPs]

--- a/src/GHC/Util/SrcLoc.hs
+++ b/src/GHC/Util/SrcLoc.hs
@@ -10,6 +10,7 @@ import GHC.Parser.Annotation
 import GHC.Types.SrcLoc
 import GHC.Utils.Outputable
 import GHC.Data.FastString
+import qualified GHC.Data.Strict
 
 import Data.Default
 import Data.Data
@@ -18,7 +19,7 @@ import Data.Generics.Uniplate.DataOnly
 -- Get the 'SrcSpan' out of a value located by an 'Anchor' (e.g.
 -- comments).
 getAncLoc :: GenLocated Anchor a -> SrcSpan
-getAncLoc o = RealSrcSpan (anchor (getLoc o)) Nothing
+getAncLoc o = RealSrcSpan (anchor (getLoc o)) GHC.Data.Strict.Nothing
 
 -- 'stripLocs x' is 'x' with all contained source locs replaced by
 -- 'noSrcSpan'.
@@ -36,6 +37,12 @@ stripLocs =
 newtype SrcSpanD = SrcSpanD SrcSpan
   deriving (Outputable, Eq)
 instance Default SrcSpanD where def = SrcSpanD noSrcSpan
+
+newtype FastStringD = FastStringD FastString
+  deriving Eq
+compareFastStrings (FastStringD f) (FastStringD g) =
+  lexicalCompareFS f g
+instance Ord FastStringD where compare = compareFastStrings
 
 -- SrcSpan no longer provides 'Ord' so we are forced to roll our own.
 --

--- a/src/GHC/Util/Unify.hs
+++ b/src/GHC/Util/Unify.hs
@@ -128,7 +128,6 @@ unify' nm root x y
     | Just (x :: EpAnn EpAnnHsCase) <- cast x = Just mempty
     | Just (x :: EpAnn EpAnnUnboundVar) <- cast x = Just mempty
     | Just (x :: EpAnn AnnExplicitSum) <- cast x = Just mempty
-    | Just (x :: EpAnn AnnsLet) <- cast x = Just mempty
     | Just (x :: EpAnn AnnProjection) <- cast x = Just mempty
     | Just (x :: EpAnn Anchor) <- cast x = Just mempty
     | Just (x :: EpAnn EpaLocation) <- cast x = Just mempty
@@ -138,6 +137,8 @@ unify' nm root x y
     | Just (x :: EpAnn HsRuleAnn) <- cast x = Just mempty
     | Just (x :: EpAnn EpAnnImportDecl) <- cast x = Just mempty
     | Just (x :: EpAnn (AddEpAnn, AddEpAnn)) <- cast x = Just mempty
+    | Just (x :: EpAnn AnnsIf) <- cast x = Just mempty
+    | Just (x :: TokenLocation) <- cast y = Just mempty
     | Just (y :: SrcSpan) <- cast y = Just mempty
 
     | otherwise = unifyDef' nm x y
@@ -257,8 +258,8 @@ unifyExp' nm root x@(L _ (HsApp _ x1 x2)) y@(L _ (HsApp _ y1 y2)) =
 unifyExp' nm root x y@(L _ (OpApp _ lhs2 op2@(L _ (HsVar _ op2')) rhs2)) =
   noExtra $ unifyExp nm root x y
 
-unifyExp' nm root (L _ (HsBracket _ (VarBr _ b0 (occNameStr . unLoc -> v1))))
-                  (L _ (HsBracket _ (VarBr _ b1 (occNameStr . unLoc -> v2))))
+unifyExp' nm root (L _ (HsUntypedBracket _ (VarBr _ b0 (occNameStr . unLoc -> v1))))
+                  (L _ (HsUntypedBracket _ (VarBr _ b1 (occNameStr . unLoc -> v2))))
     | b0 == b1 && isUnifyVar v1 = Just (Subst [(v1, strToVar v2)])
 
 unifyExp' nm root x y | isOther x, isOther y = unifyDef' nm x y

--- a/src/GHC/Util/View.hs
+++ b/src/GHC/Util/View.hs
@@ -18,7 +18,7 @@ fromParen :: LocatedA (HsExpr GhcPs) -> LocatedA (HsExpr GhcPs)
 fromParen x = maybe x fromParen $ remParen x
 
 fromPParen :: LocatedA (Pat GhcPs) -> LocatedA (Pat GhcPs)
-fromPParen (L _ (ParPat _ x)) = fromPParen x
+fromPParen (L _ (ParPat _ _ x _ )) = fromPParen x
 fromPParen x = x
 
 class View a b where

--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -134,13 +134,13 @@ bracketHint _ _ x =
      -- Brackets the roots of annotations are fine, so we strip them.
      annotations :: AnnDecl GhcPs -> AnnDecl GhcPs
      annotations= descendBi $ \x -> case (x :: LHsExpr GhcPs) of
-       L _ (HsPar _ x) -> x
+       L _ (HsPar _ _ x _) -> x
        x -> x
 
      -- Brackets at the root of splices used to be required, but now they aren't
      splices :: HsDecl GhcPs -> HsDecl GhcPs
      splices (SpliceD a x) = SpliceD a $ flip descendBi x $ \x -> case (x :: LHsExpr GhcPs) of
-       L _ (HsPar _ x) -> x
+       L _ (HsPar _ _ x _) -> x
        x -> x
      splices x = x
 
@@ -151,8 +151,8 @@ bracketHint _ _ x =
 -- latter (in contrast to the HSE pretty printer). This patches things
 -- up.
 prettyExpr :: LHsExpr GhcPs -> String
-prettyExpr s@(L _ SectionL{}) = unsafePrettyPrint (noLocA (HsPar EpAnnNotUsed s) :: LHsExpr GhcPs)
-prettyExpr s@(L _ SectionR{}) = unsafePrettyPrint (noLocA (HsPar EpAnnNotUsed s) :: LHsExpr GhcPs)
+prettyExpr s@(L _ SectionL{}) = unsafePrettyPrint (nlHsPar s :: LHsExpr GhcPs)
+prettyExpr s@(L _ SectionR{}) = unsafePrettyPrint (nlHsPar s :: LHsExpr GhcPs)
 prettyExpr x = unsafePrettyPrint x
 
 -- 'Just _' if at least one set of parens were removed. 'Nothing' if
@@ -227,10 +227,9 @@ fieldDecl o@(L loc f@ConDeclField{cd_fld_type=v@(L l (HsParTy _ c))}) =
    where
      -- If we call 'unsafePrettyPrint' on a field decl, we won't like
      -- the output (e.g. "[foo, bar] :: T"). Here we use a custom
-     -- printer to work around (snarfed from
-     -- https://hackage.haskell.org/package/ghc-lib-parser-8.8.1/docs/src/HsTypes.html#pprConDeclFields).
+     -- printer to work around (snarfed from Hs.Types.pprConDeclFields)
      ppr_fld (L _ ConDeclField { cd_fld_names = ns, cd_fld_type = ty, cd_fld_doc = doc })
-       = ppr_names ns <+> dcolon <+> ppr ty <+> ppr_mbDoc doc
+       = pprMaybeWithDoc doc (ppr_names ns <+> dcolon <+> ppr ty)
      ppr_fld (L _ (XConDeclField x)) = ppr x
 
      ppr_names [n] = ppr n
@@ -250,20 +249,20 @@ dollar = concatMap f . universe
             , let r = Replace Expr (toSSA x) [("a", toSSA a), ("b", toSSA b)] "a b"]
           ++
           [ suggest "Move brackets to avoid $" (reLoc x) (reLoc (t y)) [r]
-            |(t, e@(L _ (HsPar _ (L _ (OpApp _ a1 op1 a2))))) <- splitInfix x
+            |(t, e@(L _ (HsPar _ _ (L _ (OpApp _ a1 op1 a2)) _))) <- splitInfix x
             , isDol op1
             , isVar a1 || isApp a1 || isPar a1, not $ isAtom a2
             , varToStr a1 /= "select" -- special case for esqueleto, see #224
-            , let y = noLocA $ HsApp EpAnnNotUsed a1 (noLocA (HsPar EpAnnNotUsed a2))
+            , let y = noLocA $ HsApp EpAnnNotUsed a1 (nlHsPar a2)
             , let r = Replace Expr (toSSA e) [("a", toSSA a1), ("b", toSSA a2)] "a (b)" ]
           ++  -- Special case of (v1 . v2) <$> v3
           [ (suggest "Redundant bracket" (reLoc x) (reLoc y) [r]){ideaSpan = locA locPar}
-          | L _ (OpApp _ (L locPar (HsPar _ o1@(L locNoPar (OpApp _ _ (isDot -> True) _)))) o2 v3) <- [x], varToStr o2 == "<$>"
+          | L _ (OpApp _ (L locPar (HsPar _ _ o1@(L locNoPar (OpApp _ _ (isDot -> True) _)) _)) o2 v3) <- [x], varToStr o2 == "<$>"
           , let y = noLocA (OpApp EpAnnNotUsed o1 o2 v3) :: LHsExpr GhcPs
           , let r = Replace Expr (toRefactSrcSpan (locA locPar)) [("a", toRefactSrcSpan (locA locNoPar))] "a"]
           ++
           [ suggest "Redundant section" (reLoc x) (reLoc y) [r]
-          | L _ (HsApp _ (L _ (HsPar _ (L _ (SectionL _ a b)))) c) <- [x]
+          | L _ (HsApp _ (L _ (HsPar _ _ (L _ (SectionL _ a b)) _)) c) <- [x]
           -- , error $ show (unsafePrettyPrint a, gshow b, unsafePrettyPrint c)
           , let y = noLocA $ OpApp EpAnnNotUsed a b c :: LHsExpr GhcPs
           , let r = Replace Expr (toSSA x) [("x", toSSA a), ("op", toSSA b), ("y", toSSA c)] "x op y"]

--- a/src/Hint/Comment.hs
+++ b/src/Hint/Comment.hs
@@ -21,6 +21,7 @@ import Refact.Types(Refactoring(ModifyComment))
 import GHC.Types.SrcLoc
 import GHC.Parser.Annotation
 import GHC.Util
+import qualified GHC.Data.Strict
 
 directives :: [String]
 directives = words $
@@ -44,7 +45,7 @@ commentHint _ m = concatMap chk (ghcComments m)
         grab :: String -> LEpaComment -> String -> Idea
         grab msg o@(L pos _) s2 =
           let s1 = commentText o
-              loc = RealSrcSpan (anchor pos) Nothing
+              loc = RealSrcSpan (anchor pos) GHC.Data.Strict.Nothing
           in
           rawIdea Suggestion msg loc (f s1) (Just $ f s2) [] (refact loc)
             where f s = if isCommentMultiline o then "{-" ++ s ++ "-}" else "--" ++ s

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -268,6 +268,8 @@ import GHC.Hs
 import GHC.Types.Basic
 import GHC.Types.Name.Reader
 import GHC.Types.ForeignCall
+import qualified GHC.Data.Strict
+import GHC.Types.PkgQual
 
 import GHC.Util
 import GHC.LanguageExtensions.Type
@@ -286,7 +288,7 @@ extensionsHint :: ModuHint
 extensionsHint _ x =
     [
         rawIdea Hint.Type.Warning "Unused LANGUAGE pragma"
-        (RealSrcSpan (anchor sl) Nothing)
+        (RealSrcSpan (anchor sl) GHC.Data.Strict.Nothing)
         (comment_ (mkLanguagePragmas sl exts))
         (Just newPragma)
         ( [RequiresExtension (show gone) | (_, Just x) <- before \\ after, gone <- Map.findWithDefault [] x disappear] ++
@@ -372,21 +374,9 @@ usedExt DeriveLift = hasDerive ["Lift"]
 usedExt DeriveAnyClass = not . null . derivesAnyclass . derives
 usedExt x = used x
 
--- The ghc-lib-parser-ex functions are getting fixed to have the new
--- signatures.
-isMDo' :: HsStmtContext GhcRn -> Bool
-isMDo' = \case MDoExpr _ -> True; _ -> False
-isStrictMatch' :: HsMatchContext GhcPs -> Bool
-isStrictMatch' = \case FunRhs{mc_strictness=SrcStrict} -> True; _ -> False
-
-isGetField :: LHsExpr GhcPs -> Bool
-isGetField = \case (L _ HsGetField{}) -> True; _ -> False
-isProjection :: LHsExpr GhcPs -> Bool
-isProjection = \case (L _ HsProjection{}) -> True; _ -> False
-
 used :: Extension -> Located HsModule -> Bool
 
-used RecursiveDo = hasS isMDo' ||^ hasS isRecStmt
+used RecursiveDo = hasS isMDo ||^ hasS isRecStmt
 used ParallelListComp = hasS isParComp
 used FunctionalDependencies = hasT (un :: FunDep GhcPs)
 used ImplicitParams = hasT (un :: HsIPName)
@@ -400,12 +390,12 @@ used EmptyCase = hasS f
   where
     f :: HsExpr GhcPs -> Bool
     f (HsCase _ _ (MG _ (L _ []) _)) = True
-    f (HsLamCase _ (MG _ (L _ []) _)) = True
+    f (HsLamCase _ _ (MG _ (L _ []) _)) = True
     f _ = False
 used KindSignatures = hasT (un :: HsKind GhcPs)
-used BangPatterns = hasS isPBangPat ||^ hasS isStrictMatch'
-used TemplateHaskell = hasS $ \case (HsQuasiQuote{} :: HsSplice GhcPs) -> False; _ -> True
-used TemplateHaskellQuotes = hasT (un :: HsBracket GhcPs)
+used BangPatterns = hasS isPBangPat ||^ hasS isStrictMatch
+used TemplateHaskell = hasS $ not . isQuasiQuoteSplice
+used TemplateHaskellQuotes = hasT (un :: HsQuote GhcPs)
 used ForeignFunctionInterface = hasT (un :: CCallConv)
 used PatternGuards = hasS f
   where
@@ -433,7 +423,7 @@ used TypeOperators = hasS tyOpInSig ||^ hasS tyOpInDecl
     isOp (L _ name) = isSymbolRdrName name
 
 used RecordWildCards = hasS hasFieldsDotDot ||^ hasS hasPFieldsDotDot
-used RecordPuns = hasS isPFieldPun ||^ hasS isFieldPun ||^ hasS isFieldPunUpdate
+used NamedFieldPuns = hasS isPFieldPun ||^ hasS isFieldPun ||^ hasS isFieldPunUpdate
 used UnboxedTuples = hasS isUnboxedTuple ||^ hasS (== Unboxed) ||^ hasS isDeriving
   where
       -- detect if there are deriving declarations or data ... deriving stuff
@@ -444,9 +434,9 @@ used UnboxedTuples = hasS isUnboxedTuple ||^ hasS (== Unboxed) ||^ hasS isDerivi
 used PackageImports = hasS f
   where
       f :: ImportDecl GhcPs -> Bool
-      f ImportDecl{ideclPkgQual=Just _} = True
+      f ImportDecl{ideclPkgQual=RawPkgQual _} = True
       f _ = False
-used QuasiQuotes = hasS isQuasiQuote ||^ hasS isTyQuasiQuote
+used QuasiQuotes = hasS isQuasiQuoteExpr ||^ hasS isTyQuasiQuote
 used ViewPatterns = hasS isPViewPat
 used InstanceSigs = hasS f
   where
@@ -483,11 +473,7 @@ used OverloadedLists = hasS isListExpr ||^ hasS isListPat
     isListPat ListPat{} = True
     isListPat _ = False
 
-used OverloadedLabels = hasS isLabel
-  where
-    isLabel :: HsExpr GhcPs -> Bool
-    isLabel HsOverLabel{} = True
-    isLabel _ = False
+used OverloadedLabels = hasS isOverLabel
 
 used Arrows = hasS isProc
 used TransformListComp = hasS isTransStmt
@@ -498,7 +484,7 @@ used MagicHash = hasS f ||^ hasS isPrimLiteral
 used PatternSynonyms = hasS isPatSynBind ||^ hasS isPatSynIE
 used ImportQualifiedPost = hasS (== QualifiedPost)
 used StandaloneKindSignatures = hasT (un :: StandaloneKindSig GhcPs)
-used OverloadedRecordDot = hasS isGetField ||^ hasS isProjection
+used OverloadedRecordDot = hasT (un :: DotFieldOcc GhcPs)
 
 used _= const True
 

--- a/src/Hint/Import.hs
+++ b/src/Hint/Import.hs
@@ -52,8 +52,15 @@ import GHC.Types.SourceText
 import GHC.Hs
 import GHC.Types.SrcLoc
 import GHC.Unit.Types -- for 'NotBoot'
+import GHC.Types.PkgQual
 
 import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
+
+rawPkgQualToMaybe :: RawPkgQual -> Maybe StringLiteral
+rawPkgQualToMaybe x =
+  case x of
+    NoRawPkgQual -> Nothing
+    RawPkgQual lit -> Just lit
 
 importHint :: ModuHint
 importHint _ ModuleEx {ghcModule=L _ HsModule{hsmodImports=ms}} =
@@ -63,7 +70,7 @@ importHint _ ModuleEx {ghcModule=L _ HsModule{hsmodImports=ms}} =
               , ideclSource (unLoc i) == NotBoot
               , let i' = unLoc i
               , let n = unLoc $ ideclName i'
-              , let pkg  = unpackFS . sl_fs <$> ideclPkgQual i']) ++
+              , let pkg  = unpackFS . sl_fs <$> rawPkgQualToMaybe (ideclPkgQual i')]) ++
   -- Ideas for removing redundant 'as' clauses.
   concatMap stripRedundantAlias ms
 

--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -120,7 +120,7 @@ import GHC.Hs
 import GHC.Types.Name.Occurrence
 import GHC.Types.Name.Reader
 import GHC.Types.SrcLoc
-import Language.Haskell.GhclibParserEx.GHC.Hs.Expr (isTypeApp, isOpApp, isLambda, isQuasiQuote, isVar, isDol, strToVar)
+import Language.Haskell.GhclibParserEx.GHC.Hs.Expr (isTypeApp, isOpApp, isLambda, isQuasiQuoteExpr, isVar, isDol, strToVar)
 import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
 import Language.Haskell.GhclibParserEx.GHC.Types.Name.Reader
 import GHC.Util.Brackets (isAtom)
@@ -169,7 +169,7 @@ lambdaBind
     where
           reform :: [LPat GhcPs] -> LHsExpr GhcPs -> Located (HsDecl GhcPs)
           reform ps b = L (combineSrcSpans (locA loc1) (locA loc2)) $ ValD noExtField $
-             origBind {fun_matches = MG noExtField (noLocA [noLocA $ Match EpAnnNotUsed ctxt ps $ GRHSs emptyComments [noLoc $ GRHS EpAnnNotUsed [] b] $ EmptyLocalBinds noExtField]) Generated}
+             origBind {fun_matches = MG noExtField (noLocA [noLocA $ Match EpAnnNotUsed ctxt ps $ GRHSs emptyComments [noLocA $ GRHS EpAnnNotUsed [] b] $ EmptyLocalBinds noExtField]) Generated}
 
           mkSubtsAndTpl newPats newBody = (sub, tpl)
             where
@@ -183,13 +183,13 @@ etaReduce :: [LPat GhcPs] -> LHsExpr GhcPs -> ([LPat GhcPs], LHsExpr GhcPs)
 etaReduce (unsnoc -> Just (ps, view -> PVar_ p)) (L _ (HsApp _ x (view -> Var_ y)))
     | p == y
     , y `notElem` vars x
-    , not $ any isQuasiQuote $ universe x
+    , not $ any isQuasiQuoteExpr $ universe x
     = etaReduce ps x
 etaReduce ps (L loc (OpApp _ x (isDol -> True) y)) = etaReduce ps (L loc (HsApp EpAnnNotUsed x y))
 etaReduce ps x = (ps, x)
 
 lambdaExp :: Maybe (LHsExpr GhcPs) -> LHsExpr GhcPs -> [Idea]
-lambdaExp _ o@(L _ (HsPar _ (L _ (HsApp _ oper@(L _ (HsVar _ origf@(L _ (rdrNameOcc -> f)))) y))))
+lambdaExp _ o@(L _ (HsPar _ _ (L _ (HsApp _ oper@(L _ (HsVar _ origf@(L _ (rdrNameOcc -> f)))) y)) _))
     | isSymOcc f -- is this an operator?
     , isAtom y
     , allowLeftSection $ occNameString f
@@ -197,15 +197,15 @@ lambdaExp _ o@(L _ (HsPar _ (L _ (HsApp _ oper@(L _ (HsVar _ origf@(L _ (rdrName
     = [suggest "Use section" (reLoc o) (reLoc to) [r]]
     where
         to :: LHsExpr GhcPs
-        to = noLocA $ HsPar EpAnnNotUsed $ noLocA $ SectionL EpAnnNotUsed y oper
+        to = nlHsPar $ noLocA $ SectionL EpAnnNotUsed y oper
         r = Replace Expr (toSSA o) [("x", toSSA y)] ("(x " ++ unsafePrettyPrint origf ++ ")")
 
-lambdaExp _ o@(L _ (HsPar _ (view -> App2 (view -> Var_ "flip") origf@(view -> RdrName_ f) y)))
+lambdaExp _ o@(L _ (HsPar _ _ (view -> App2 (view -> Var_ "flip") origf@(view -> RdrName_ f) y) _))
     | allowRightSection (rdrNameStr f), not $ "(" `isPrefixOf` rdrNameStr f
     = [suggest "Use section" (reLoc o) (reLoc to) [r]]
     where
         to :: LHsExpr GhcPs
-        to = noLocA $ HsPar EpAnnNotUsed $ noLocA $ SectionR EpAnnNotUsed origf y
+        to = nlHsPar $ noLocA $ SectionR EpAnnNotUsed origf y
         op = if isSymbolRdrName (unLoc f)
                then unsafePrettyPrint f
                else "`" ++ unsafePrettyPrint f ++ "`"
@@ -216,13 +216,13 @@ lambdaExp p o@(L _ HsLam{})
     | not $ any isOpApp p
     , (res, refact) <- niceLambdaR [] o
     , not $ isLambda res
-    , not $ any isQuasiQuote $ universe res
+    , not $ any isQuasiQuoteExpr $ universe res
     , not $ "runST" `Set.member` Set.map occNameString (freeVars o)
     , let name = "Avoid lambda" ++ (if countRightSections res > countRightSections o then " using `infix`" else "")
     -- If the lambda's parent is an HsPar, and the result is also an HsPar, the span should include the parentheses.
     , let from = case p of
               -- Avoid creating redundant bracket.
-              Just p@(L _ (HsPar _ (L _ HsLam{})))
+              Just p@(L _ (HsPar _ _ (L _ HsLam{}) _))
                 | L _ HsPar{} <- res -> p
                 | L _ (HsVar _ (L _ name)) <- res, not (isSymbolRdrName name) -> p
               _ -> o
@@ -294,7 +294,7 @@ lambdaExp _ o@(SimpleLambda [view -> PVar_ x] (L _ expr)) =
 
                  -- otherwise we should use @LambdaCase@
                  MG _ (L _ _) _ ->
-                     [(suggestN "Use lambda-case" (reLoc o) $ noLoc $ HsLamCase EpAnnNotUsed matchGroup)
+                     [(suggestN "Use lambda-case" (reLoc o) $ noLoc $ HsLamCase EpAnnNotUsed LamCase matchGroup)
                          {ideaNote=[RequiresExtension "LambdaCase"]}]
         _ -> []
     where

--- a/src/Hint/List.hs
+++ b/src/Hint/List.hs
@@ -54,7 +54,7 @@ import qualified Refact.Types as R
 
 import GHC.Hs
 import GHC.Types.SrcLoc
-import GHC.Types.Basic
+import GHC.Types.Basic hiding (Pattern)
 import GHC.Types.SourceText
 import GHC.Types.Name.Reader
 import GHC.Data.FastString
@@ -97,7 +97,7 @@ listComp o@(view -> App2 mp f (L _ (HsDo _ MonadComp (L _ stmts)))) =
   listCompCheckMap o mp f MonadComp stmts
 listComp _ = []
 
-listCompCheckGuards :: LHsExpr GhcPs -> HsStmtContext GhcRn -> [ExprLStmt GhcPs] -> [Idea]
+listCompCheckGuards :: LHsExpr GhcPs -> HsDoFlavour -> [ExprLStmt GhcPs] -> [Idea]
 listCompCheckGuards o ctx stmts =
   let revs = reverse stmts
       e@(L _ LastStmt{}) = head revs -- In a ListComp, this is always last.
@@ -120,7 +120,7 @@ listCompCheckGuards o ctx stmts =
         qualCon _ = Nothing
 
 listCompCheckMap ::
-  LHsExpr GhcPs -> LHsExpr GhcPs -> LHsExpr GhcPs -> HsStmtContext GhcRn -> [ExprLStmt GhcPs] -> [Idea]
+  LHsExpr GhcPs -> LHsExpr GhcPs -> LHsExpr GhcPs -> HsDoFlavour -> [ExprLStmt GhcPs] -> [Idea]
 listCompCheckMap o mp f ctx stmts  | varToStr mp == "map" =
     [suggest "Move map inside list comprehension" (reLoc o) (reLoc o2) (suggestExpr o o2)]
     where

--- a/src/Hint/ListRec.hs
+++ b/src/Hint/ListRec.hs
@@ -173,7 +173,7 @@ findCase x = do
 
   let ps12 = let (a, b) = splitAt p1 ps1 in map strToPat (a ++ xs : b) -- Function arguments.
       emptyLocalBinds = EmptyLocalBinds noExtField :: HsLocalBindsLR GhcPs GhcPs -- Empty where clause.
-      gRHS e = noLoc $ GRHS EpAnnNotUsed [] e :: LGRHS GhcPs (LHsExpr GhcPs) -- Guarded rhs.
+      gRHS e = noLocA $ GRHS EpAnnNotUsed [] e :: LGRHS GhcPs (LHsExpr GhcPs) -- Guarded rhs.
       gRHSSs e = GRHSs emptyComments [gRHS e] emptyLocalBinds -- Guarded rhs set.
       match e = Match{m_ext=EpAnnNotUsed,m_pats=ps12, m_grhss=gRHSSs e, ..} -- Match.
       matchGroup e = MG{mg_alts=noLocA [noLocA $ match e], mg_origin=Generated, ..} -- Match group.
@@ -225,7 +225,7 @@ findPat ps = do
 
 readPat :: LPat GhcPs -> Maybe (Either String BList)
 readPat (view -> PVar_ x) = Just $ Left x
-readPat (L _ (ParPat _ (L _ (ConPat _ (L _ n) (InfixCon (view -> PVar_ x) (view -> PVar_ xs))))))
+readPat (L _ (ParPat _ _ (L _ (ConPat _ (L _ n) (InfixCon (view -> PVar_ x) (view -> PVar_ xs)))) _))
  | n == consDataCon_RDR = Just $ Right $ BCons x xs
 readPat (L _ (ConPat _ (L _ n) (PrefixCon [] [])))
   | n == nameRdrName nilDataConName = Just $ Right BNil

--- a/src/Hint/NewType.hs
+++ b/src/Hint/NewType.hs
@@ -17,7 +17,7 @@ data Color a = Red a | Green a | Blue a
 data Pair a b = Pair a b
 data Foo = Bar
 data Foo a = Eq a => MkFoo a
-data Foo a = () => Foo a -- newtype Foo a = Foo a
+data Foo a = () => Foo a -- newtype Foo a = () => Foo a
 data X = Y {-# UNPACK #-} !Int -- newtype X = Y Int
 data A = A {b :: !C} -- newtype A = A {b :: C}
 data A = A Int#

--- a/src/Hint/NumLiteral.hs
+++ b/src/Hint/NumLiteral.hs
@@ -40,13 +40,13 @@ numLiteralHint _ modu =
      const []
 
 suggestUnderscore :: LHsExpr GhcPs -> [Idea]
-suggestUnderscore x@(L _ (HsOverLit _ ol@(OverLit _ (HsIntegral intLit@(IL (SourceText srcTxt) _ _)) _))) =
+suggestUnderscore x@(L _ (HsOverLit _ ol@(OverLit _ (HsIntegral intLit@(IL (SourceText srcTxt) _ _))))) =
   [ suggest "Use underscore" (reLoc x) (reLoc y) [r] | '_' `notElem` srcTxt, srcTxt /= underscoredSrcTxt ]
   where
     underscoredSrcTxt = addUnderscore srcTxt
     y = noLocA $ HsOverLit EpAnnNotUsed $ ol{ol_val = HsIntegral intLit{il_text = SourceText underscoredSrcTxt}}
     r = Replace Expr (toSSA x) [("a", toSSA y)] "a"
-suggestUnderscore x@(L _ (HsOverLit _ ol@(OverLit _ (HsFractional fracLit@(FL (SourceText srcTxt) _ _ _ _)) _))) =
+suggestUnderscore x@(L _ (HsOverLit _ ol@(OverLit _ (HsFractional fracLit@(FL (SourceText srcTxt) _ _ _ _))))) =
   [ suggest "Use underscore" (reLoc x) (reLoc y) [r] | '_' `notElem` srcTxt, srcTxt /= underscoredSrcTxt ]
   where
     underscoredSrcTxt = addUnderscore srcTxt

--- a/src/Hint/Pragma.hs
+++ b/src/Hint/Pragma.hs
@@ -25,7 +25,7 @@
 {-# LANGUAGE RebindableSyntax #-} \
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RebindableSyntax #-} \
-{-# LANGUAGE EmptyCase, RebindableSyntax #-} -- {-# LANGUAGE RebindableSyntax, EmptyCase #-}
+{-# LANGUAGE EmptyCase, RebindableSyntax #-} -- {-# LANGUAGE EmptyCase, RebindableSyntax #-}
 </TEST>
 -}
 

--- a/src/Hint/Unsafe.hs
+++ b/src/Hint/Unsafe.hs
@@ -63,10 +63,10 @@ unsafeHint _ (ModuleEx (L _ m)) = \ld@(L loc d) ->
     gen :: OccName -> LHsDecl GhcPs
     gen x = noLocA $
       SigD noExtField (InlineSig EpAnnNotUsed (noLocA (mkRdrUnqual x))
-                      (InlinePragma (SourceText "{-# NOINLINE") NoInline Nothing NeverActive FunLike))
+                      (InlinePragma (SourceText "{-# NOINLINE") (NoInline (SourceText "{-# NOINLINE")) Nothing NeverActive FunLike))
     noinline :: [OccName]
     noinline = [q | L _(SigD _ (InlineSig _ (L _ (Unqual q))
-                                                (InlinePragma _ NoInline Nothing NeverActive FunLike))
+                                                (InlinePragma _ (NoInline (SourceText "{-# NOINLINE")) Nothing NeverActive FunLike))
         ) <- hsmodDecls m]
 
 isUnsafeDecl :: HsDecl GhcPs -> Bool

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,8 @@ packages:
   - .
 
 extra-deps:
-  - ghc-lib-parser-9.2.3.20220709
-  - ghc-lib-parser-ex-9.2.0.4
+  - ghc-lib-parser-9.4.1.20220807
+  - ghc-lib-parser-ex-9.4.0.0
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex/ghc-lib-parser-ex-8.10.0.18.tar.gz

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -44,8 +44,7 @@ FILE tests/cpp-ext-enable.hs
 main = undefined
 EXIT 1
 OUTPUT
-tests/cpp-ext-enable.hs:1:1: Error: Parse error: Unsupported extension: Foo
-
+tests/cpp-ext-enable.hs:1:1: Error: Parse error: tests/cpp-ext-enable.hs:3:14: error: Unsupported extension: Foo
 Found:
   {-# LANGUAGE CPP #-}
 

--- a/tests/parse-error.test
+++ b/tests/parse-error.test
@@ -25,8 +25,8 @@ RUN tests/ignore-parse-error3.hs
 FILE tests/ignore-parse-error3.hs
 {-# LANGUAGE InvalidExtension #-}
 OUTPUT
-tests/ignore-parse-error3.hs:1:1: Error: Parse error: Unsupported extension: InvalidExtension
-
+tests/ignore-parse-error3.hs:1:1: Error: Parse error: tests/ignore-parse-error3.hs:1:14: error:
+    Unsupported extension: InvalidExtension
 Found:
   {-# LANGUAGE InvalidExtension #-}
 

--- a/tests/serialise.test
+++ b/tests/serialise.test
@@ -37,7 +37,8 @@ FILE tests/serialise-four.hs
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE CPP #-}
 OUTPUT
-[("tests/serialise-four.hs:1:1-20: Warning: Use fewer LANGUAGE pragmas\nFound:\n  {-# LANGUAGE CPP #-}\n  {-# LANGUAGE CPP #-}\nPerhaps:\n  {-# LANGUAGE CPP #-}\n",[ModifyComment {pos = SrcSpan {startLine = 1, startCol = 1, endLine = 1, endCol = 21}, newComment = "{-# LANGUAGE CPP #-}"},ModifyComment {pos = SrcSpan {startLine = 2, startCol = 1, endLine = 2, endCol = 21}, newComment = ""}])]
+[("tests/serialise-four.hs:2:1-20: Warning: Use fewer LANGUAGE pragmas\nFound:\n  {-# LANGUAGE CPP #-}\n  {-# LANGUAGE CPP #-}\nPerhaps:\n  {-# LANGUAGE CPP #-}\n",[ModifyComment {pos = SrcSpan {startLine = 2, startCol = 1, endLine = 2, endCol = 21}, newComment = "{-# LANGUAGE CPP #-}"},ModifyComment {pos = SrcSpan {startLine = 1, startCol = 1, endLine = 1, endCol = 21}, newComment = ""}])]
+
 
 
 ---------------------------------------------------------------------


### PR DESCRIPTION
- this pr migrates hlint to the ghc-9.4.1 parse tree
- the minimum ghc version for building hlint with this pr becomes ghc-9.0.1
  - accordingly i've removed 8.10 from `.github/workflws/ci.yml`
  - of course with 9.4.1 being now available, one hopes we can add `9.4` to that matrix in the near future
- regarding issue https://github.com/ndmitchell/hlint/pull/1385:
  - ghc-lib-parser-ex switched to always linking `ghc-lib-parser` by default in pr https://github.com/shayne-fletcher/ghc-lib-parser-ex/pull/123
  - the companion change to hlint in pr https://github.com/ndmitchell/hlint/pull/1385 has ~~yet to land~~ been abandoned in light of this PR being accepted
  - since the choice of defaults must be consistent between these two packages, replicate https://github.com/ndmitchell/hlint/pull/1385 in this pr accordingly
 