### PR TITLE
quickcheck selection functions on singleton lists

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -981,8 +981,8 @@
     - package quickcheck
     rules:
     - warn: {lhs: Control.Monad.join (Test.QuickCheck.elements l), rhs: Test.QuickCheck.oneof l}
-    - warn: {lhs: "Test.QuickCheck.elements [x]", rhs: "return x", name: Evaluate}
-    - warn: {lhs: "Test.QuickCheck.growingElements [x]", rhs: "return x", name: Evaluate}
+    - warn: {lhs: "Test.QuickCheck.elements [x]", rhs: "return x"}
+    - warn: {lhs: "Test.QuickCheck.growingElements [x]", rhs: "return x"}
     - warn: {lhs: "Test.QuickCheck.oneof [x]", rhs: "x", name: Evaluate}
     - warn: {lhs: "Test.QuickCheck.frequency [(a,x)]", rhs: "x", name: Evaluate}
 

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -981,6 +981,10 @@
     - package quickcheck
     rules:
     - warn: {lhs: Control.Monad.join (Test.QuickCheck.elements l), rhs: Test.QuickCheck.oneof l}
+    - warn: {lhs: "Test.QuickCheck.elements [x]", rhs: "return x", name: Evaluate}
+    - warn: {lhs: "Test.QuickCheck.growingElements [x]", rhs: "return x", name: Evaluate}
+    - warn: {lhs: "Test.QuickCheck.oneof [x]", rhs: "x", name: Evaluate}
+    - warn: {lhs: "Test.QuickCheck.frequency [(a,x)]", rhs: "x", name: Evaluate}
 
 - group:
     name: generalise


### PR DESCRIPTION
The thing I actually encountered in code was of the form
```haskell
  x <- oneof [y]
```
(after some previous refactoring).

I guess the other hints, for `elements` etc., could also be encountered.