### PR TITLE
Fix freeVars computation for do-blocks

### DIFF
--- a/data/do-block.yaml
+++ b/data/do-block.yaml
@@ -1,0 +1,2 @@
+- ignore: { }
+- warn: {lhs: "case m of Just x -> y; Nothing -> Nothing", rhs: "do x <- m; y"}

--- a/tests/do-block.test
+++ b/tests/do-block.test
@@ -1,0 +1,17 @@
+---------------------------------------------------------------------
+RUN tests/do-block.hs --hint=data/do-block.yaml
+FILE tests/do-block.hs
+h x = case f x of
+  Just n -> g n
+  Nothing -> Nothing
+OUTPUT
+tests/do-block.hs:(1,7)-(3,20): Warning: Redundant Nothing
+Found:
+  case f x of
+    Just n -> g n
+    Nothing -> Nothing
+Perhaps:
+  do n <- f x
+     g n
+
+1 hint


### PR DESCRIPTION
Fixes #1425.

`freeVars` for do-blocks computes free variables for each statement separately, and unions them. This means in `do a <- f x; g a`, `a` is considered a free variable. This PR fixes it.