### PR TITLE
introducing nubSort

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1117,6 +1117,8 @@
     - warn: {lhs: "notNull [x]", rhs: "True", name: Evaluate}
     - warn: {lhs: "notNull []", rhs: "False", name: Evaluate}
     - hint: {lhs: "\\(x,y) -> (f x, f y)", rhs: both f}
+    - hint: {lhs: nub (sort x), rhs: nubSort x}
+    - warn: {lhs: sort (nub x), rhs: nubSort x}
 
 # hints that will be enabled in future
 - group:


### PR DESCRIPTION
The first of these is a "defining property" stated in the documentation of `nubSort`.

The second one, `sort (nub x)`, is something I spotted in student code and seems to be even more deserving of a rewrite, I think, since the inner `nub` is doing excess work if we later want to sort anyway.

Is there need for some kind of warning here that the `Ord`/`Eq` instances are assumed to be defined sensibly?