### PR TITLE
replace map by mapMaybe in context of filter isJust

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -652,10 +652,10 @@
     - warn: {lhs: if isJust x then f (fromJust x) else y, rhs: maybe y f x}
     - warn: {lhs: maybe Nothing (Just . f), rhs: fmap f}
     - hint: {lhs: map fromJust (filter isJust x), rhs:  Data.Maybe.catMaybes x}
-    - hint: {lhs: filter isJust (map f x), rhs: map Just (mapMaybe f x)}
-    - hint: {lhs: filter isJust (f <*> x), rhs: map Just (mapMaybe f x)}
-    - hint: {lhs: filter isJust (x <&> f), rhs: map Just (mapMaybe f x)}
-    - hint: {lhs: filter isJust (fmap f x), rhs: map Just (mapMaybe f x)}
+    - hint: {lhs: filter isJust (map f x), rhs: map Just (mapMaybe f x), name: Use mapMaybe}
+    - hint: {lhs: filter isJust (f <*> x), rhs: map Just (mapMaybe f x), name: Use mapMaybe}
+    - hint: {lhs: filter isJust (x <&> f), rhs: map Just (mapMaybe f x), name: Use mapMaybe}
+    - hint: {lhs: filter isJust (fmap f x), rhs: map Just (mapMaybe f x), name: Use mapMaybe}
     - warn: {lhs: x == Nothing , rhs:  isNothing x}
     - warn: {lhs: Nothing == x , rhs:  isNothing x}
     - warn: {lhs: x /= Nothing , rhs:  Data.Maybe.isJust x}

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -652,6 +652,10 @@
     - warn: {lhs: if isJust x then f (fromJust x) else y, rhs: maybe y f x}
     - warn: {lhs: maybe Nothing (Just . f), rhs: fmap f}
     - hint: {lhs: map fromJust (filter isJust x), rhs:  Data.Maybe.catMaybes x}
+    - hint: {lhs: filter isJust (map f x), rhs: map Just (mapMaybe f x)}
+    - hint: {lhs: filter isJust (f <*> x), rhs: map Just (mapMaybe f x)}
+    - hint: {lhs: filter isJust (x <&> f), rhs: map Just (mapMaybe f x)}
+    - hint: {lhs: filter isJust (fmap f x), rhs: map Just (mapMaybe f x)}
     - warn: {lhs: x == Nothing , rhs:  isNothing x}
     - warn: {lhs: Nothing == x , rhs:  isNothing x}
     - warn: {lhs: x /= Nothing , rhs:  Data.Maybe.isJust x}


### PR DESCRIPTION
Not sure you consider these hints always worthwhile, but thought I would at least propose them.

A meaningful rule name would also still be needed.

The reason I consider this rewrite worthwhile when the opportunity arises is that through the `map Just` it is then more explicit "for the compiler" that the output list contains only `Just` values, potentially enabling more fusion etc.