### PR TITLE
Warn that .hlint.yml is not a substitute for .hlint.yaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,7 @@ Each hint says which file/line the hint relates to, how serious an issue it is, 
 
 The first hint is marked as an warning, because using `concatMap` in preference to the two separate functions is always desirable. In contrast, the removal of brackets is probably a good idea, but not always. Reasons that a hint might be a suggestion include requiring an additional import, something not everyone agrees on, and functions only available in more recent versions of the base library.
 
-Any configuration can be done via [.hlint.yaml](./README.md#customizing-the-hints) file[^config-file-names].
-
-[^config-file-names]: Any other file name such as `.hlint.yml` can only be used explicitly with the `--hint=FILE` option.
+Any configuration can be done via [.hlint.yaml](./README.md#customizing-the-hints) file. Any other file name, such as `.hlint.yml`, can only be used explicitly with the `--hint=FILE` option.
 
 **Bug reports:** The suggested replacement should be equivalent - please report all incorrect suggestions not mentioned as known limitations.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Each hint says which file/line the hint relates to, how serious an issue it is, 
 
 The first hint is marked as an warning, because using `concatMap` in preference to the two separate functions is always desirable. In contrast, the removal of brackets is probably a good idea, but not always. Reasons that a hint might be a suggestion include requiring an additional import, something not everyone agrees on, and functions only available in more recent versions of the base library.
 
-Any configuration can be done via [.hlint.yaml](./README.md#customizing-the-hints) file.
+Any configuration can be done via [.hlint.yaml](./README.md#customizing-the-hints) file[^config-file-names].
+
+[^config-file-names]: Any other file name such as `.hlint.yml` can only be used explicitly with the `--hint=FILE` option.
 
 **Bug reports:** The suggested replacement should be equivalent - please report all incorrect suggestions not mentioned as known limitations.
 


### PR DESCRIPTION
Adds a footnote that configuration in `.hlint.yml` won't be picked up by default.
