### PR TITLE
Remove/empty haddock empty comment

### DIFF
--- a/src/Hint/Comment.hs
+++ b/src/Hint/Comment.hs
@@ -11,6 +11,7 @@
 </TEST>
 -}
 
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Hint.Comment(commentHint) where
@@ -19,6 +20,7 @@ import Hint.Type
 import Data.Char
 import Data.List.Extra
 import Refact.Types(Refactoring(ModifyComment))
+import qualified Refact.Types as R (SrcSpan)
 import GHC.Types.SrcLoc
 import GHC.Parser.Annotation
 import GHC.Util
@@ -29,13 +31,50 @@ directives = words $
     "LANGUAGE OPTIONS_GHC INCLUDE WARNING DEPRECATED MINIMAL INLINE NOINLINE INLINABLE " ++
     "CONLIKE LINE SPECIALIZE SPECIALISE UNPACK NOUNPACK SOURCE"
 
-commentHint :: ModuHint
-commentHint _ m = concatMap chk (ghcComments m)
 
-chk :: LEpaComment -> [Idea]
-chk comm@(L{})
-  | isHaddockWhitespace comm = [(if isMultiline then emptyHaddockMulti else emptyHaddockSingle) comm]
-  | isCommentWhitespace comm = if isMultiline then [emptyCommentMulti comm] else []
+commentHint :: ModuHint
+commentHint _ m = concatMap (chk singleLines singleSomeLines) comments
+  where
+    comments = ghcComments m
+
+    singleLines :: [Int]
+    singleLines = sort $ commentLine <$> filter isSingle comments
+
+    singleSomeLines :: [Int]
+    singleSomeLines = sort $ commentLine <$> filter isSingleSome comments
+
+isSingle :: LEpaComment -> Bool
+isSingle comm@(L (anchor -> span) _) =
+  isOneLineRealSpan span
+  && not (isPointRealSpan span)
+  && not (isCommentMultiline comm || isHaddock comm)
+
+isSingleSome :: LEpaComment -> Bool
+isSingleSome comm@(L (anchor -> span) _) =
+  isOneLineRealSpan span
+  && not (isPointRealSpan span)
+  && not (isCommentMultiline comm || isHaddock comm || isCommentWhitespace comm)
+
+commentLine :: LEpaComment -> Int
+commentLine (L (anchor -> span) _) = srcLocLine $ realSrcSpanStart span
+
+nextLineIsComment :: Int -> [Int] -> [Int] -> Bool
+nextLineIsComment x singles somes =
+  x + 1 `elem` singles
+  && (Just True == do
+    next <- find (x <) somes
+    pure $ [x + 1 .. next] `isInfixOf` singles)
+
+chk :: [Int] -> [Int] -> LEpaComment -> [Idea]
+chk singles somes comm@(L{})
+  | isHaddockWhitespace comm =
+      if | isMultiline -> [emptyHaddockMulti comm]
+         | nextLineIsComment (commentLine comm) singles somes -> []
+         | otherwise -> [emptyHaddockSingle comm]
+  | isCommentWhitespace comm =
+      if | isMultiline -> [emptyCommentMulti comm]
+         | not $ nextLineIsComment (commentLine comm) singles somes -> [emptyCommentSingle comm]
+         | otherwise -> []
   | isMultiline, null (commentText comm) = [emptyCommentMulti comm]
   | isMultiline, "#" `isSuffixOf` s && not ("#" `isPrefixOf` s) = [grab "Fix pragma markup" comm $ '#':s]
   | isMultiline, name `elem` directives = [grab "Use pragma syntax" comm $ "# " ++ trim s ++ " #"]
@@ -43,8 +82,7 @@ chk comm@(L{})
       isMultiline = isCommentMultiline comm
       s = commentText comm
       name = takeWhile (\x -> isAlphaNum x || x == '_') $ trimStart s
-
-chk _ = []
+chk _ _ _ = []
 
 isHaddockWhitespace :: LEpaComment -> Bool
 isHaddockWhitespace comm = isHaddock comm && isStringWhitespace (drop 2 $ commentText comm)
@@ -59,29 +97,29 @@ isCommentWhitespace :: LEpaComment -> Bool
 isCommentWhitespace comm@(L (anchor -> span) _ ) =
   not (isPointRealSpan span) && isStringWhitespace (commentText comm)
 
-emptyHaddockSingle  :: LEpaComment -> Idea
+emptyCommentSingle, emptyHaddockSingle  :: LEpaComment -> Idea
+emptyCommentSingle = emptyComment ("--" ++) "Empty single-line comment"
 emptyHaddockSingle = emptyComment ("--" ++) "Empty single-line haddock"
 
 emptyCommentMulti, emptyHaddockMulti :: LEpaComment -> Idea
 emptyCommentMulti = emptyComment (\s -> "{-" ++ s ++ "-}") "Empty multi-line comment"
 emptyHaddockMulti = emptyComment (\s -> "{-" ++ s ++ "-}") "Empty multi-line haddock"
 
+refact :: SrcSpan -> String -> [Refactoring R.SrcSpan]
+refact loc s = [ModifyComment (toRefactSrcSpan loc) s]
+
 emptyComment :: (String -> String) -> String -> LEpaComment -> Idea
 emptyComment f msg o@(L pos _) =
   let s1 = commentText o
       loc = RealSrcSpan (anchor pos) GHC.Data.Strict.Nothing
-  in
-  ideaRemove Suggestion msg loc (f s1) (refact loc)
-    where refact loc = [ModifyComment (toRefactSrcSpan loc) ""]
+  in ideaRemove Suggestion msg loc (f s1) (refact loc "")
 
 grab :: String -> LEpaComment -> String -> Idea
 grab msg o@(L pos _) s2 =
   let s1 = commentText o
       loc = RealSrcSpan (anchor pos) GHC.Data.Strict.Nothing
-  in
-  rawIdea Suggestion msg loc (f s1) (Just $ f s2) [] (refact loc)
-    where f s = if isCommentMultiline o then "{-" ++ s ++ "-}" else "--" ++ s
-          refact loc = [ModifyComment (toRefactSrcSpan loc) (f s2)]
+      f s = if isCommentMultiline o then "{-" ++ s ++ "-}" else "--" ++ s
+  in rawIdea Suggestion msg loc (f s1) (Just $ f s2) [] (refact loc $ f s2)
 
 -- | 'True' if the span is known to straddle only one line.
 -- SEE: https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Types/SrcLoc.hs#L480-483

--- a/src/Hint/Comment.hs
+++ b/src/Hint/Comment.hs
@@ -11,6 +11,7 @@
 </TEST>
 -}
 
+{-# LANGUAGE ViewPatterns #-}
 
 module Hint.Comment(commentHint) where
 
@@ -28,25 +29,70 @@ directives = words $
     "LANGUAGE OPTIONS_GHC INCLUDE WARNING DEPRECATED MINIMAL INLINE NOINLINE INLINABLE " ++
     "CONLIKE LINE SPECIALIZE SPECIALISE UNPACK NOUNPACK SOURCE"
 
-
 commentHint :: ModuHint
 commentHint _ m = concatMap chk (ghcComments m)
-    where
-        chk :: LEpaComment -> [Idea]
-        chk comm
-          | isMultiline, "#" `isSuffixOf` s && not ("#" `isPrefixOf` s) = [grab "Fix pragma markup" comm $ '#':s]
-          | isMultiline, name `elem` directives = [grab "Use pragma syntax" comm $ "# " ++ trim s ++ " #"]
-               where
-                 isMultiline = isCommentMultiline comm
-                 s = commentText comm
-                 name = takeWhile (\x -> isAlphaNum x || x == '_') $ trimStart s
-        chk _ = []
 
-        grab :: String -> LEpaComment -> String -> Idea
-        grab msg o@(L pos _) s2 =
-          let s1 = commentText o
-              loc = RealSrcSpan (anchor pos) GHC.Data.Strict.Nothing
-          in
-          rawIdea Suggestion msg loc (f s1) (Just $ f s2) [] (refact loc)
-            where f s = if isCommentMultiline o then "{-" ++ s ++ "-}" else "--" ++ s
-                  refact loc = [ModifyComment (toRefactSrcSpan loc) (f s2)]
+chk :: LEpaComment -> [Idea]
+chk comm@(L{})
+  | isHaddockWhitespace comm = [(if isMultiline then emptyHaddockMulti else emptyHaddockSingle) comm]
+  | isCommentWhitespace comm = if isMultiline then [emptyCommentMulti comm] else []
+  | isMultiline, null (commentText comm) = [emptyCommentMulti comm]
+  | isMultiline, "#" `isSuffixOf` s && not ("#" `isPrefixOf` s) = [grab "Fix pragma markup" comm $ '#':s]
+  | isMultiline, name `elem` directives = [grab "Use pragma syntax" comm $ "# " ++ trim s ++ " #"]
+    where
+      isMultiline = isCommentMultiline comm
+      s = commentText comm
+      name = takeWhile (\x -> isAlphaNum x || x == '_') $ trimStart s
+
+chk _ = []
+
+isHaddockWhitespace :: LEpaComment -> Bool
+isHaddockWhitespace comm = isHaddock comm && isStringWhitespace (drop 2 $ commentText comm)
+
+isHaddock :: LEpaComment -> Bool
+isHaddock (take 2 . commentText -> s) = " |" == s || " ^" == s
+
+isStringWhitespace :: String -> Bool
+isStringWhitespace = not . any (`notElem` " \r\n")
+
+isCommentWhitespace :: LEpaComment -> Bool
+isCommentWhitespace comm@(L (anchor -> span) _ ) =
+  not (isPointRealSpan span) && isStringWhitespace (commentText comm)
+
+emptyHaddockSingle  :: LEpaComment -> Idea
+emptyHaddockSingle = emptyComment ("--" ++) "Empty single-line haddock"
+
+emptyCommentMulti, emptyHaddockMulti :: LEpaComment -> Idea
+emptyCommentMulti = emptyComment (\s -> "{-" ++ s ++ "-}") "Empty multi-line comment"
+emptyHaddockMulti = emptyComment (\s -> "{-" ++ s ++ "-}") "Empty multi-line haddock"
+
+emptyComment :: (String -> String) -> String -> LEpaComment -> Idea
+emptyComment f msg o@(L pos _) =
+  let s1 = commentText o
+      loc = RealSrcSpan (anchor pos) GHC.Data.Strict.Nothing
+  in
+  ideaRemove Suggestion msg loc (f s1) (refact loc)
+    where refact loc = [ModifyComment (toRefactSrcSpan loc) ""]
+
+grab :: String -> LEpaComment -> String -> Idea
+grab msg o@(L pos _) s2 =
+  let s1 = commentText o
+      loc = RealSrcSpan (anchor pos) GHC.Data.Strict.Nothing
+  in
+  rawIdea Suggestion msg loc (f s1) (Just $ f s2) [] (refact loc)
+    where f s = if isCommentMultiline o then "{-" ++ s ++ "-}" else "--" ++ s
+          refact loc = [ModifyComment (toRefactSrcSpan loc) (f s2)]
+
+-- | 'True' if the span is known to straddle only one line.
+-- SEE: https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Types/SrcLoc.hs#L480-483
+isOneLineRealSpan :: RealSrcSpan -> Bool
+isOneLineRealSpan span = line1 == line2 where
+  line1 = srcLocLine $ realSrcSpanStart span
+  line2 = srcLocLine $ realSrcSpanEnd span
+
+-- | 'True' if the span is a single point.
+-- SEE: https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Types/SrcLoc.hs#L485-488
+isPointRealSpan :: RealSrcSpan -> Bool
+isPointRealSpan span = isOneLineRealSpan span && col1 == col2 where
+  col1 = srcLocCol $ realSrcSpanStart span
+  col2 = srcLocCol $ realSrcSpanEnd span

--- a/tests/empty-comment-test.hs
+++ b/tests/empty-comment-test.hs
@@ -1,0 +1,74 @@
+-- |
+haddockAboveSingle = 1
+
+haddockBelowSingle = 1
+-- ^
+
+-- |
+--
+haddockAboveSingles = 1
+
+-- |
+-- >>>
+haddockAboveDoctest = 1
+
+-- |
+--
+--
+-- foo
+haddockAboveIntoNonEmpty = 1
+
+haddockBelowIntoNonEmpty = 1
+-- ^
+--
+--
+-- foo
+
+{--}
+commentMultiEmpty = 1
+
+{- -}
+commentMultiEmptySpace = 1
+
+{-
+
+    -}
+commentMultiEmptyLines = 1
+
+{- |-}
+haddockAboveMultiEmpty = 1
+
+{- | -}
+haddockAboveMultiEmptySpace = 1
+
+{- |
+
+    -}
+haddockAboveMultiEmptyLines = 1
+
+haddockBelowMultiEmpty = 1
+{- ^-}
+
+haddockBelowMultiEmptySpace = 1
+{- ^-}
+
+haddockBelowMultiEmptyLines = 1
+{- ^
+
+    -}
+
+data HaddockSingle = HaddockSingle
+  { haddockFieldEmptyBelow :: Int
+  -- ^
+  -- |
+  , haddockFieldAboveEmpty :: Int
+  , haddockFieldEmptyAfter :: Int -- ^
+  }
+
+data HaddockMulti = HaddockMulti
+  { haddockFieldEmptyBelow :: Int
+  {- ^-}
+  {- |-}
+  , haddockFieldAboveEmpty :: Int
+  , haddockFieldEmptyAfter :: Int {- ^-}
+  }


### PR DESCRIPTION
Can we suggest removing empty comments and removing empty haddocks? I've seen examples of these littering code, like the following:

```haskell
-- |
foo = 1
```

I had a crack at doing this.

- If I run `cabal run hlint -- --refactor tests/empty-comment-test.hs` the comments are removed but single line comments are replaced by an empty line. I'd really like to remove the whole line. Is there a way to do that? I tried `advanceSrcLoc (realSrcSpanEnd realSpan) '\n'` for the refactor span but this didn't work as I'd hoped.
- I'm not quite sure what is the best way to convert `tests/empty-comment-test.hs` into tests.

```
$ cabal run hlint -- --refactor --refactor-options=inplace tests/empty-comment-test.hs
$ git diff
```

```diff

diff --git a/tests/empty-comment-test.hs b/tests/empty-comment-test.hs
index 33b38157..84811b24 100644
--- a/tests/empty-comment-test.hs
+++ b/tests/empty-comment-test.hs
@@ -1,11 +1,11 @@
--- |
+
 haddockAboveSingle = 1
 
 haddockBelowSingle = 1
--- ^
 
--- |
---
+
+
+
 haddockAboveSingles = 1
 
 -- |
@@ -24,51 +24,45 @@ haddockBelowIntoNonEmpty = 1
 --
 -- foo
 
-{--}
+
 commentMultiEmpty = 1
 
-{- -}
+
 commentMultiEmptySpace = 1
 
-{-
 
-    -}
 commentMultiEmptyLines = 1
 
-{- |-}
+
 haddockAboveMultiEmpty = 1
 
-{- | -}
+
 haddockAboveMultiEmptySpace = 1
 
-{- |
 
-    -}
 haddockAboveMultiEmptyLines = 1
 
 haddockBelowMultiEmpty = 1
-{- ^-}
+
 
 haddockBelowMultiEmptySpace = 1
-{- ^-}
+
 
 haddockBelowMultiEmptyLines = 1
-{- ^
 
-    -}
 
 data HaddockSingle = HaddockSingle
   { haddockFieldEmptyBelow :: Int
-  -- ^
-  -- |
+  
+  
   , haddockFieldAboveEmpty :: Int
-  , haddockFieldEmptyAfter :: Int -- ^
+  , haddockFieldEmptyAfter :: Int 
   }
 
 data HaddockMulti = HaddockMulti
   { haddockFieldEmptyBelow :: Int
-  {- ^-}
-  {- |-}
+  
+  
   , haddockFieldAboveEmpty :: Int
-  , haddockFieldEmptyAfter :: Int {- ^-}
-  }
\ No newline at end of file
+  , haddockFieldEmptyAfter :: Int 
+  }
```
