### PR TITLE
upgrade to ghc-9.6.1

### DIFF
--- a/hints.md
+++ b/hints.md
@@ -239,12 +239,12 @@ Does not support refactoring.
 <td>
 Example: 
 <pre>
-{-# LANGUAGE OverloadedRecordDot #-} 
-f = (. foo)
+{-# LANGUAGE TypeData #-} 
+data T = MkT
 </pre>
 Found:
 <code>
-{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE TypeData #-}
 </code>
 <br>
 Suggestion:

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -72,7 +72,7 @@ library
         utf8-string,
         data-default >= 0.3,
         cpphs >= 1.20.1,
-        cmdargs >= 0.10,
+        cmdargs >= 0.10.22,
         uniplate >= 1.5,
         ansi-terminal >= 0.8.1,
         extra >= 1.7.3,
@@ -81,16 +81,16 @@ library
         deriving-aeson >= 0.2,
         filepattern >= 0.1.1
 
-    if !flag(ghc-lib) && impl(ghc >= 9.4.1) && impl(ghc < 9.5.0)
+    if !flag(ghc-lib) && impl(ghc >= 9.6.1) && impl(ghc < 9.7.0)
       build-depends:
-        ghc == 9.4.*,
+        ghc == 9.6.*,
         ghc-boot-th,
         ghc-boot
     else
       build-depends:
-          ghc-lib-parser == 9.4.*
+          ghc-lib-parser == 9.6.*
     build-depends:
-        ghc-lib-parser-ex >= 9.4.0.0 && < 9.4.1
+        ghc-lib-parser-ex >= 9.6.0.0 && < 9.6.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -73,7 +73,7 @@ applyHintsReal settings hints_ ms = concat $
 removeRequiresExtensionNotes :: ModuleEx -> Idea -> Idea
 removeRequiresExtensionNotes m = \x -> x{ideaNote = filter keep $ ideaNote x}
     where
-        exts = Set.fromList $ concatMap snd $ languagePragmas $ pragmas (comments (hsmodAnn (unLoc . ghcModule $ m)))
+        exts = Set.fromList $ concatMap snd $ languagePragmas $ pragmas (comments (hsmodAnn (hsmodExt . unLoc . ghcModule $ m)))
         keep (RequiresExtension x) = not $ x `Set.member` exts
         keep _ = True
 

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -31,7 +31,7 @@ import Language.Haskell.GhclibParserEx.GHC.Types.Name.Reader
 -- | Read an {-# ANN #-} pragma and determine if it is intended for HLint.
 --   Return Nothing if it is not an HLint pragma, otherwise what it means.
 readPragma :: AnnDecl GhcPs -> Maybe Classify
-readPragma (HsAnnotation _ _ provenance expr) = f expr
+readPragma (HsAnnotation _ provenance expr) = f expr
     where
         name = case provenance of
             ValueAnnProvenance (L _ x) -> occNameStr x

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -235,7 +235,7 @@ parseGHC parser v = do
         POk _ x -> pure x
         PFailed ps ->
           let errMsg = head . bagToList . getMessages $ GhcPsMessage <$> snd (getPsMessages ps)
-              msg = showSDoc baseDynFlags $ pprLocMsgEnvelope errMsg
+              msg = showSDoc baseDynFlags $ pprLocMsgEnvelopeDefault errMsg
           in parseFail v $ "Failed to parse " ++ msg ++ ", when parsing:\n " ++ x
 
 ---------------------------------------------------------------------
@@ -440,7 +440,7 @@ settingsFromConfigYaml (mconcat -> ConfigYaml configs) = settings ++ concatMap f
               scope'= asScope' packageMap' (map (fmap unextendInstances) groupImports)
 
 asScope' :: Map.HashMap String [LocatedA (ImportDecl GhcPs)] -> [Either String (LocatedA (ImportDecl GhcPs))] -> Scope
-asScope' packages xs = scopeCreate (HsModule EpAnnNotUsed NoLayoutInfo Nothing Nothing (concatMap f xs) [] Nothing Nothing)
+asScope' packages xs = scopeCreate (HsModule (XModulePs EpAnnNotUsed NoLayoutInfo Nothing Nothing) Nothing Nothing (concatMap f xs) [])
     where
         f (Right x) = [x]
         f (Left x) | Just pkg <- Map.lookup x packages = pkg

--- a/src/GHC/Util.hs
+++ b/src/GHC/Util.hs
@@ -41,7 +41,7 @@ import GHC.Data.FastString
 import System.FilePath
 import Language.Preprocessor.Unlit
 
-fileToModule :: FilePath -> String -> DynFlags -> ParseResult (Located HsModule)
+fileToModule :: FilePath -> String -> DynFlags -> ParseResult (Located (HsModule GhcPs))
 fileToModule filename str flags =
   parseFile filename flags
     (if takeExtension filename /= ".lhs" then str else unlit filename str)

--- a/src/GHC/Util/ApiAnnotation.hs
+++ b/src/GHC/Util/ApiAnnotation.hs
@@ -87,7 +87,7 @@ flags ps =
 
 -- Language pragmas. The first element of the
 -- pair is the (located) annotation comment that enables the
--- pragmas enumerated by he second element of the pair.
+-- pragmas enumerated by the second element of the pair.
 languagePragmas :: [(LEpaComment, String)] -> [(LEpaComment, [String])]
 languagePragmas ps =
   [(c, exts) | (c, s) <- ps

--- a/src/GHC/Util/Brackets.hs
+++ b/src/GHC/Util/Brackets.hs
@@ -54,7 +54,8 @@ instance Brackets (LocatedA (HsExpr GhcPs)) where
       HsUntypedBracket{} -> True
       -- HsSplice might be $foo, where @($foo) would require brackets,
       -- but in that case the $foo is a type, so we can still mark Splice as atomic
-      HsSpliceE{} -> True
+      HsTypedSplice{} -> True
+      HsUntypedSplice{} -> True
       HsOverLit _ x | not $ isNegativeOverLit x -> True
       HsLit _ x     | not $ isNegativeLit x     -> True
       _  -> False
@@ -109,6 +110,7 @@ isAtomOrApp _ = False
 instance Brackets (LocatedA (Pat GhcPs)) where
   remParen (L _ (ParPat _ _ x _)) = Just x
   remParen _ = Nothing
+
   addParen = nlParPat
 
   isAtom (L _ x) = case x of

--- a/src/GHC/Util/DynFlags.hs
+++ b/src/GHC/Util/DynFlags.hs
@@ -8,7 +8,7 @@ import Language.Haskell.GhclibParserEx.GHC.Settings.Config
 -- 'parsePragmasIntoDynFlags' based solely on the parse flags
 -- (and source level annotations).
 baseDynFlags :: DynFlags
-baseDynFlags = defaultDynFlags fakeSettings fakeLlvmConfig
+baseDynFlags = defaultDynFlags fakeSettings
 
 initGlobalDynFlags :: IO ()
 initGlobalDynFlags = setUnsafeGlobalDynFlags baseDynFlags

--- a/src/GHC/Util/Scope.hs
+++ b/src/GHC/Util/Scope.hs
@@ -10,7 +10,6 @@ module GHC.Util.Scope (
 import GHC.Hs
 import GHC.Types.SrcLoc
 import GHC.Types.SourceText
-import GHC.Unit.Module
 import GHC.Data.FastString
 import GHC.Types.Name.Reader
 import GHC.Types.Name.Occurrence
@@ -21,6 +20,7 @@ import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
 
 import Data.List.Extra
 import Data.Maybe
+import Data.Bifunctor
 
 -- A scope is a list of import declarations.
 newtype Scope = Scope [LImportDecl GhcPs]
@@ -30,7 +30,7 @@ instance Show Scope where
     show (Scope x) = unsafePrettyPrint x
 
 -- Create a 'Scope from a module's import declarations.
-scopeCreate :: HsModule -> Scope
+scopeCreate :: HsModule GhcPs -> Scope
 scopeCreate xs = Scope $ [prelude | not $ any isPrelude res] ++ res
   where
     -- Package qualifier of an import declaration.
@@ -116,7 +116,7 @@ possImport (L _ i) (L _ (Qual mod x)) =
   where ms = map unLoc $ ideclName i : maybeToList (ideclAs i)
 possImport (L _ i) (L _ (Unqual x)) =
   if ideclQualified i == NotQualified
-    then maybe PossiblyImported f (ideclHiding i)
+    then maybe PossiblyImported (f . first (== EverythingBut)) (ideclImportList i)
     else NotImported
   where
     f :: (Bool, LocatedL [LIE GhcPs]) -> IsImported
@@ -137,6 +137,6 @@ possImport (L _ i) (L _ (Unqual x)) =
     g (L _ (IEThingWith _ y _wildcard ys)) = Just $ tag `elem` unwrapName y : map unwrapName ys
     g _ = Just False
 
-    unwrapName :: LIEWrappedName RdrName -> String
+    unwrapName :: LIEWrappedName GhcPs -> String
     unwrapName x = occNameString (rdrNameOcc $ ieWrappedName (unLoc x))
 possImport _ _ = NotImported

--- a/src/GHC/Util/Unify.hs
+++ b/src/GHC/Util/Unify.hs
@@ -95,7 +95,7 @@ substitute (Subst bind) = transformBracketOld exp . transformBi pat . transformB
     typ :: LHsType GhcPs -> LHsType GhcPs
     -- Type variables.
     typ (L _ (HsTyVar _ _ x))
-      | Just (L _ (HsAppType _ _ (HsWC _ y))) <- lookup (rdrNameStr x) bind = y
+      | Just (L _ (HsAppType _ _ _ (HsWC _ y))) <- lookup (rdrNameStr x) bind = y
     typ x = x :: LHsType GhcPs
 
 
@@ -288,7 +288,7 @@ unifyPat' nm x y =
 unifyType' :: NameMatch -> LHsType GhcPs -> LHsType GhcPs -> Maybe (Subst (LHsExpr GhcPs))
 unifyType' nm (L loc (HsTyVar _ _ x)) y =
   let wc = HsWC noExtField y :: LHsWcType (NoGhcTc GhcPs)
-      unused = strToVar "__unused__" :: LHsExpr GhcPs
-      appType = L loc (HsAppType noSrcSpan unused wc) :: LHsExpr GhcPs
+      unused = strToVar "__unused__"
+      appType = L loc (HsAppType noExtField unused noHsTok wc)
  in Just $ Subst [(rdrNameStr x, appType)]
 unifyType' nm x y = unifyDef' nm x y

--- a/src/GHC/Util/View.hs
+++ b/src/GHC/Util/View.hs
@@ -32,8 +32,8 @@ data App2  = NoApp2  | App2 (LocatedA (HsExpr GhcPs)) (LocatedA (HsExpr GhcPs)) 
 data LamConst1 = NoLamConst1 | LamConst1 (LocatedA (HsExpr GhcPs))
 
 instance View (LocatedA (HsExpr GhcPs)) LamConst1 where
-  view (fromParen -> (L _ (HsLam _ (MG _ (L _ [L _ (Match _ LambdaExpr [L _ WildPat {}]
-    (GRHSs _ [L _ (GRHS _ [] x)] ((EmptyLocalBinds _))))]) FromSource)))) = LamConst1 x
+  view (fromParen -> (L _ (HsLam _ (MG FromSource (L _ [L _ (Match _ LambdaExpr [L _ WildPat {}]
+    (GRHSs _ [L _ (GRHS _ [] x)] ((EmptyLocalBinds _))))]))))) = LamConst1 x
   view _ = NoLamConst1
 
 instance View (LocatedA (HsExpr GhcPs)) RdrName_ where
@@ -62,4 +62,4 @@ instance View (LocatedA (Pat GhcPs)) PApp_ where
 
 -- A lambda with no guards and no where clauses
 pattern SimpleLambda :: [LocatedA (Pat GhcPs)] -> LocatedA (HsExpr GhcPs) -> LocatedA (HsExpr GhcPs)
-pattern SimpleLambda vs body <- L _ (HsLam _ (MG _ (L _ [L _ (Match _ _ vs (GRHSs _ [L _ (GRHS _ [] body)] ((EmptyLocalBinds _))))]) _))
+pattern SimpleLambda vs body <- L _ (HsLam _ (MG _ (L _ [L _ (Match _ _ vs (GRHSs _ [L _ (GRHS _ [] body)] ((EmptyLocalBinds _))))])))

--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -169,12 +169,15 @@ remParens' = fmap go . remParen
   where
     go e = maybe e go (remParen e)
 
+-- note(sf, 2022-06-02): i've completely bluffed my way through this.
+-- see
+-- https://gitlab.haskell.org/ghc/ghc/-/commit/7975202ba9010c581918413808ee06fbab9ac85f
+-- for where splice expressions were refactored.
 isPartialAtom :: Maybe (LHsExpr GhcPs) -> LHsExpr GhcPs -> Bool
 -- Might be '$x', which was really '$ x', but TH enabled misparsed it.
-isPartialAtom _ (L _ (HsSpliceE _ (HsTypedSplice _ DollarSplice _ _) )) = True
-isPartialAtom _ (L _ (HsSpliceE _ (HsUntypedSplice _ DollarSplice _ _) )) = True
+isPartialAtom _ (L _ (HsUntypedSplice _ HsUntypedSpliceExpr{})) = True
 -- Might be '$(x)' where the brackets are required in GHC 8.10 and below
-isPartialAtom (Just (L _ HsSpliceE{})) _ = True
+isPartialAtom (Just (L _ HsUntypedSplice{})) _ = True
 isPartialAtom _ x = isRecConstr x || isRecUpdate x
 
 bracket :: forall a . (Data a, Outputable a, Brackets (LocatedA a)) => (LocatedA a -> String) -> (Maybe (LocatedA a) -> LocatedA a -> Bool) -> Bool -> LocatedA a -> [Idea]

--- a/src/Hint/Export.hs
+++ b/src/Hint/Export.hs
@@ -16,7 +16,6 @@ module Hint.Export(exportHint) where
 import Hint.Type(ModuHint, ModuleEx(..),ideaNote,ignore,Note(..))
 
 import GHC.Hs
-import GHC.Unit.Module
 import GHC.Types.SrcLoc
 import GHC.Types.Name.Occurrence
 import GHC.Types.Name.Reader
@@ -33,11 +32,11 @@ exportHint _ (ModuleEx (L s m@HsModule {hsmodName = Just name, hsmodExports = ex
   , exports' <- [x | x <- xs, not (matchesModName modName x)]
   , modName `elem` names =
       let dots = mkRdrUnqual (mkVarOcc " ... ")
-          r = o{ hsmodExports = Just (noLocA (noLocA (IEVar noExtField (noLocA (IEName (noLocA dots)))) : exports') )}
+          r = o{ hsmodExports = Just (noLocA (noLocA (IEVar noExtField (noLocA (IEName noExtField (noLocA dots)))) : exports') )}
       in
         [ignore "Use explicit module export list" (L s o) (noLoc r) []]
       where
-          o = m{hsmodImports=[], hsmodDecls=[], hsmodDeprecMessage=Nothing, hsmodHaddockModHeader=Nothing }
+          o = m{hsmodImports=[], hsmodDecls=[] }
           isMod (L _ (IEModuleContents _ _)) = True
           isMod _ = False
 

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -98,7 +98,7 @@ deriving instance Show Bar -- {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveGeneric, GeneralizedNewtypeDeriving #-} \
 newtype Micro = Micro Int deriving Generic -- {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveGeneric, TypeFamilies #-} \
-data family Bar a; data instance Bar Foo = Foo deriving (Generic)
+data family Bar a; data instance Bar Foo = Foo deriving Generic
 {-# LANGUAGE GeneralizedNewtypeDeriving #-} \
 instance Class Int where {newtype MyIO a = MyIO a deriving NewClass}
 {-# LANGUAGE UnboxedTuples #-} \
@@ -248,13 +248,18 @@ f = (. foo) -- @NoRefactor: refactor requires GHC >= 9.2.1
 foo = [|| x ||]
 {-# LANGUAGE TemplateHaskell #-} \
 foo = $bar
+{-# LANGUAGE TypeData # -} \
+type data Nat = Zero | Succ Nat  -- @NoRefactor: refactor requires GHC >= 9.6.1
+{-# LANGUAGE TypeData #-} \
+data T = MkT -- @NoRefactor: refactor requires GHC >= 9.6.1
 </TEST>
 -}
 
 
+
 module Hint.Extensions(extensionsHint) where
 
-import Hint.Type(ModuHint,rawIdea,Severity(Warning),Note(..),toSSAnc,ghcModule,modComments)
+import Hint.Type(ModuHint,rawIdea,Severity(Warning),Note(..),toSSAnc,ghcModule,modComments,firstDeclComments)
 import Extension
 
 import Data.Generics.Uniplate.DataOnly
@@ -299,7 +304,13 @@ extensionsHint _ x =
             [ Note $ "Extension " ++ s ++ " is " ++ reason x
             | (s, Just x) <- explainedRemovals])
         [ModifyComment (toSSAnc (mkLanguagePragmas sl exts)) newPragma]
-    | (L sl _,  exts) <- languagePragmas $ pragmas (modComments x)
+    | (L sl _,  exts) <-
+      -- Comments appearing without an empty line before the first
+      -- declaration in a module are now associated with the
+      -- declaration not the module so to be safe, look also at
+      -- `firstDeclComments x`
+      -- (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9517).
+      languagePragmas $ pragmas (modComments x) ++ pragmas (firstDeclComments x)
     , let before = [(x, readExtension x) | x <- exts]
     , let after = filter (maybe True (`Set.member` keep) . snd) before
     , before /= after
@@ -320,7 +331,12 @@ extensionsHint _ x =
     -- All the extensions defined to be used.
     extensions :: Set.Set Extension
     extensions = Set.fromList $ mapMaybe readExtension $
-        concatMap snd $ languagePragmas (pragmas (modComments x))
+      -- Comments appearing without an empty line before the first
+      -- declaration in a module are now associated with the
+      -- declaration not the module so to be safe, look also at
+      -- `firstDeclComments x`
+      -- (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9517).
+        concatMap snd $ languagePragmas (pragmas (modComments x) ++ pragmas (firstDeclComments x))
 
     -- Those extensions we detect to be useful.
     useful :: Set.Set Extension
@@ -370,7 +386,7 @@ noDeriveNewtype =
 deriveStock :: [String]
 deriveStock = deriveHaskell ++ deriveGenerics ++ deriveCategory
 
-usedExt :: Extension -> Located HsModule -> Bool
+usedExt :: Extension -> Located (HsModule GhcPs) -> Bool
 usedExt NumDecimals = hasS isWholeFrac
   -- Only whole number fractions are permitted by NumDecimals
   -- extension.  Anything not-whole raises an error.
@@ -378,23 +394,30 @@ usedExt DeriveLift = hasDerive ["Lift"]
 usedExt DeriveAnyClass = not . null . derivesAnyclass . derives
 usedExt x = used x
 
-used :: Extension -> Located HsModule -> Bool
+used :: Extension -> Located (HsModule GhcPs) -> Bool
 
 used RecursiveDo = hasS isMDo ||^ hasS isRecStmt
 used ParallelListComp = hasS isParComp
 used FunctionalDependencies = hasT (un :: FunDep GhcPs)
 used ImplicitParams = hasT (un :: HsIPName)
+
 used TypeApplications = hasS isTypeApp ||^ hasS isKindTyApp
+
 used EmptyDataDecls = hasS f
   where
     f :: HsDataDefn GhcPs -> Bool
-    f (HsDataDefn _ _ _ _ _ [] _) = True
+    f (HsDataDefn _ _ _ _ (DataTypeCons _ []) _) = True
+    f _ = False
+used TypeData  = hasS f
+  where
+    f :: HsDataDefn GhcPs -> Bool
+    f (HsDataDefn _ _ _ _ (DataTypeCons True _) _) = True
     f _ = False
 used EmptyCase = hasS f
   where
     f :: HsExpr GhcPs -> Bool
-    f (HsCase _ _ (MG _ (L _ []) _)) = True
-    f (HsLamCase _ _ (MG _ (L _ []) _)) = True
+    f (HsCase _ _ (MG _ (L _ []))) = True
+    f (HsLamCase _ _ (MG _ (L _ []))) = True
     f _ = False
 used KindSignatures = hasT (un :: HsKind GhcPs)
 used BangPatterns = hasS isPBangPat ||^ hasS isStrictMatch
@@ -497,7 +520,7 @@ used OverloadedRecordDot = hasT (un :: DotFieldOcc GhcPs)
 
 used _= const True
 
-hasDerive :: [String] -> Located HsModule -> Bool
+hasDerive :: [String] -> Located (HsModule GhcPs) -> Bool
 hasDerive want = any (`elem` want) . derivesStock' . derives
 
 -- Derivations can be implemented using any one of 3 strategies, so for each derivation
@@ -526,14 +549,14 @@ addDerives nt _ xs = mempty
     ,derivesNewtype' = if maybe True isNewType nt then filter (`notElem` noDeriveNewtype) xs else []}
     where (stock, other) = partition (`elem` deriveStock) xs
 
-derives :: Located HsModule -> Derives
+derives :: Located (HsModule GhcPs) -> Derives
 derives (L _ m) =  mconcat $ map decl (childrenBi m) ++ map idecl (childrenBi m)
   where
     idecl :: DataFamInstDecl GhcPs -> Derives
-    idecl (DataFamInstDecl FamEqn {feqn_rhs=HsDataDefn {dd_ND=dn, dd_derivs=ds}}) = g dn ds
+    idecl (DataFamInstDecl FamEqn {feqn_rhs=HsDataDefn {dd_cons=data_defn_cons, dd_derivs=ds}}) = g (dataDefnConsNewOrData data_defn_cons) ds
 
     decl :: LHsDecl GhcPs -> Derives
-    decl (L _ (TyClD _ (DataDecl _ _ _ _ HsDataDefn {dd_ND=dn, dd_derivs=ds}))) = g dn ds -- Data declaration.
+    decl (L _ (TyClD _ (DataDecl _ _ _ _ HsDataDefn {dd_cons=data_defn_cons, dd_derivs=ds}))) = g (dataDefnConsNewOrData data_defn_cons) ds -- Data declaration.
     decl (L _ (DerivD _ (DerivDecl _ (HsWC _ sig) strategy _))) = addDerives Nothing (fmap unLoc strategy) [derivedToStr sig] -- A deriving declaration.
     decl _ = mempty
 

--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -169,7 +169,7 @@ lambdaBind
     where
           reform :: [LPat GhcPs] -> LHsExpr GhcPs -> Located (HsDecl GhcPs)
           reform ps b = L (combineSrcSpans (locA loc1) (locA loc2)) $ ValD noExtField $
-             origBind {fun_matches = MG noExtField (noLocA [noLocA $ Match EpAnnNotUsed ctxt ps $ GRHSs emptyComments [noLocA $ GRHS EpAnnNotUsed [] b] $ EmptyLocalBinds noExtField]) Generated}
+             origBind {fun_matches = MG Generated (noLocA [noLocA $ Match EpAnnNotUsed ctxt ps $ GRHSs emptyComments [noLocA $ GRHS EpAnnNotUsed [] b] $ EmptyLocalBinds noExtField])}
 
           mkSubtsAndTpl newPats newBody = (sub, tpl)
             where
@@ -265,7 +265,7 @@ lambdaExp _ o@(SimpleLambda [view -> PVar_ x] (L _ expr)) =
                  -- we need to
                  --     * add brackets to the match, because matches in lambdas require them
                  --     * mark match as being in a lambda context so that it's printed properly
-                 oldMG@(MG _ (L _ [L _ oldmatch]) _)
+                 oldMG@(MG _ (L _ [L _ oldmatch]))
                    | all (\(L _ (GRHS _ stmts _)) -> null stmts) (grhssGRHSs (m_grhss oldmatch)) ->
                      let patLocs = fmap (locA . getLoc) (m_pats oldmatch)
                          bodyLocs = concatMap (\case L _ (GRHS _ _ body) -> [locA (getLoc body)])
@@ -293,7 +293,7 @@ lambdaExp _ o@(SimpleLambda [view -> PVar_ x] (L _ expr)) =
                          ]
 
                  -- otherwise we should use @LambdaCase@
-                 MG _ (L _ _) _ ->
+                 MG _ (L _ _) ->
                      [(suggestN "Use lambda-case" (reLoc o) $ noLoc $ HsLamCase EpAnnNotUsed LamCase matchGroup)
                          {ideaNote=[RequiresExtension "LambdaCase"]}]
         _ -> []

--- a/src/Hint/List.hs
+++ b/src/Hint/List.hs
@@ -47,14 +47,13 @@ import Data.List.Extra
 import Data.Maybe
 import Prelude
 
-import Hint.Type(DeclHint,Idea,suggest,ignore,substVars,toRefactSrcSpan,toSSA,modComments)
+import Hint.Type(DeclHint,Idea,suggest,ignore,substVars,toRefactSrcSpan,toSSA,modComments,firstDeclComments)
 
 import Refact.Types hiding (SrcSpan)
 import qualified Refact.Types as R
 
 import GHC.Hs
 import GHC.Types.SrcLoc
-import GHC.Types.Basic hiding (Pattern)
 import GHC.Types.SourceText
 import GHC.Types.Name.Reader
 import GHC.Data.FastString
@@ -72,7 +71,11 @@ import Language.Haskell.GhclibParserEx.GHC.Types.Name.Reader
 listHint :: DeclHint
 listHint _ modu = listDecl overloadedListsOn
   where
-    exts = concatMap snd (languagePragmas (pragmas (modComments modu)))
+    -- Comments appearing without a line-break before the first
+    -- declaration in a module are now associated with the declaration
+    -- not the module so to be safe, look also at `firstDeclComments
+    -- modu` (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9517).
+    exts = concatMap snd (languagePragmas (pragmas (modComments modu) ++ pragmas (firstDeclComments modu)))
     overloadedListsOn = "OverloadedLists" `elem` exts
 
 listDecl :: Bool -> LHsDecl GhcPs -> [Idea]

--- a/src/Hint/ListRec.hs
+++ b/src/Hint/ListRec.hs
@@ -135,7 +135,7 @@ asDo :: LHsExpr GhcPs -> [LStmt GhcPs (LHsExpr GhcPs)]
 asDo (view ->
        App2 bind lhs
          (L _ (HsLam _ MG {
-              mg_origin=FromSource
+              mg_ext=FromSource
             , mg_alts=L _ [
                  L _ Match {  m_ctxt=LambdaExpr
                             , m_pats=[v@(L _ VarPat{})]
@@ -157,7 +157,7 @@ findCase :: LHsDecl GhcPs -> Maybe (ListCase, LHsExpr GhcPs -> LHsDecl GhcPs)
 findCase x = do
   -- Match a function binding with two alternatives.
   (L _ (ValD _ FunBind {fun_matches=
-              MG{mg_origin=FromSource, mg_alts=
+              MG{mg_ext=FromSource, mg_alts=
                      (L _
                             [ x1@(L _ Match{..}) -- Match fields.
                             , x2]), ..} -- Match group fields.
@@ -176,7 +176,7 @@ findCase x = do
       gRHS e = noLocA $ GRHS EpAnnNotUsed [] e :: LGRHS GhcPs (LHsExpr GhcPs) -- Guarded rhs.
       gRHSSs e = GRHSs emptyComments [gRHS e] emptyLocalBinds -- Guarded rhs set.
       match e = Match{m_ext=EpAnnNotUsed,m_pats=ps12, m_grhss=gRHSSs e, ..} -- Match.
-      matchGroup e = MG{mg_alts=noLocA [noLocA $ match e], mg_origin=Generated, ..} -- Match group.
+      matchGroup e = MG{mg_alts=noLocA [noLocA $ match e], mg_ext=Generated, ..} -- Match group.
       funBind e = FunBind {fun_matches=matchGroup e, ..} :: HsBindLR GhcPs GhcPs -- Fun bind.
 
   pure (ListCase ps b1 (x, xs, b2), noLocA . ValD noExtField . funBind)

--- a/src/Hint/Monad.hs
+++ b/src/Hint/Monad.hs
@@ -189,7 +189,7 @@ modifyAppHead :: forall a. (LIdP GhcPs -> (LIdP GhcPs, a)) -> LHsExpr GhcPs -> (
 modifyAppHead f = go id
   where
     go :: (LHsExpr GhcPs -> LHsExpr GhcPs) -> LHsExpr GhcPs -> (LHsExpr GhcPs, Maybe a)
-    go wrap (L l (HsPar _ p x q )) = go (wrap . L l . \x -> HsPar EpAnnNotUsed p x q) x
+    go wrap (L l (HsPar _ p x q)) = go (wrap . L l . \y -> HsPar EpAnnNotUsed p y q) x
     go wrap (L l (HsApp _ x y)) = go (\x -> wrap $ L l (HsApp EpAnnNotUsed x y)) x
     go wrap (L l (OpApp _ x op y)) | isDol op = go (\x -> wrap $ L l (OpApp EpAnnNotUsed x op y)) x
     go wrap (L l (HsVar _ x)) = (wrap (L l (HsVar NoExtField x')), Just a)
@@ -297,7 +297,7 @@ monadLet xs = mapMaybe mkLet xs
             grhs = noLocA (GRHS EpAnnNotUsed [] rhs)
             grhss = GRHSs emptyComments [grhs] (EmptyLocalBinds noExtField)
             match = noLocA $ Match EpAnnNotUsed (FunRhs p Prefix NoSrcStrict) [] grhss
-            fb = noLocA $ FunBind noExtField p (MG noExtField (noLocA [match]) Generated) []
+            fb = noLocA $ FunBind noExtField p (MG Generated (noLocA [match]))
             binds = unitBag fb
             valBinds = ValBinds NoAnnSortKey binds []
             localBinds = HsValBinds EpAnnNotUsed valBinds

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -44,6 +44,7 @@ module Hint.Naming(namingHint) where
 import Hint.Type (Idea,DeclHint,suggest,ghcModule)
 import Data.Generics.Uniplate.DataOnly
 import Data.List.Extra (nubOrd, isPrefixOf)
+import Data.List.NonEmpty (toList)
 import Data.Data
 import Data.Char
 import Data.Maybe
@@ -85,9 +86,9 @@ naming seen originalDecl =
         replacedDecl = replaceNames suggestedNames originalDecl
 
 shorten :: LHsDecl GhcPs -> LHsDecl GhcPs
-shorten (L locDecl (ValD ttg0 bind@(FunBind _ _ matchGroup@(MG _ (L locMatches matches) FromSource) _))) =
+shorten (L locDecl (ValD ttg0 bind@(FunBind _ _ matchGroup@(MG FromSource (L locMatches matches))))) =
     L locDecl (ValD ttg0 bind {fun_matches = matchGroup {mg_alts = L locMatches $ map shortenMatch matches}})
-shorten (L locDecl (ValD ttg0 bind@(PatBind _ _ grhss@(GRHSs _ rhss _) _))) =
+shorten (L locDecl (ValD ttg0 bind@(PatBind _ _ grhss@(GRHSs _ rhss _)))) =
     L locDecl (ValD ttg0 bind {pat_rhs = grhss {grhssGRHSs = map shortenLGRHS rhss}})
 shorten x = x
 
@@ -106,14 +107,17 @@ getNames :: LHsDecl GhcPs -> [String]
 getNames decl = maybeToList (declName decl) ++ getConstructorNames (unLoc decl)
 
 getConstructorNames :: HsDecl GhcPs -> [String]
-getConstructorNames (TyClD _ (DataDecl _ _ _ _ (HsDataDefn _ _ _ _ _ cons _))) =
-    concatMap (map unsafePrettyPrint . getConNames' . unLoc) cons
-    where
-      getConNames' ConDeclH98  {con_name  = name}  = [name]
-      getConNames' ConDeclGADT {con_names = names} = names
-      getConNames' XConDecl{} = []
+getConstructorNames tycld = case tycld of
+    (TyClD _ (DataDecl _ _ _ _ (HsDataDefn _ _ _ _ (NewTypeCon con) _))) -> conNames [con]
+    (TyClD _ (DataDecl _ _ _ _ (HsDataDefn _ _ _ _ (DataTypeCons _ cons) _))) -> conNames cons
+    _ -> []
+  where
+    conNames :: [LConDecl GhcPs] -> [String]
+    conNames =  concatMap (map unsafePrettyPrint . conNamesInDecl . unLoc)
 
-getConstructorNames _ = []
+    conNamesInDecl :: ConDecl GhcPs -> [LIdP GhcPs]
+    conNamesInDecl ConDeclH98  {con_name  = name}  = [name]
+    conNamesInDecl ConDeclGADT {con_names = names} = Data.List.NonEmpty.toList names
 
 isSym :: String -> Bool
 isSym (x:_) = not $ isAlpha x || x `elem` "_'"

--- a/src/Hint/Pattern.hs
+++ b/src/Hint/Pattern.hs
@@ -58,7 +58,7 @@ otherwise = True
 
 module Hint.Pattern(patternHint) where
 
-import Hint.Type(DeclHint,Idea,modComments,ideaTo,toSSA,toRefactSrcSpan,suggest,suggestRemove,warn)
+import Hint.Type(DeclHint,Idea,modComments,firstDeclComments,ideaTo,toSSA,toRefactSrcSpan,suggest,suggestRemove,warn)
 import Data.Generics.Uniplate.DataOnly
 import Data.Function
 import Data.List.Extra
@@ -87,11 +87,16 @@ patternHint _scope modu x =
     concatMap (uncurry hints . swap) (asPattern x) ++
     -- PatBind (used in 'let' and 'where') contains lazy-by-default
     -- patterns, everything else is strict.
-    concatMap (patHint strict False) [p | PatBind _ p _ _ <- universeBi x :: [HsBind GhcPs]] ++
+    concatMap (patHint strict False) [p | PatBind _ p _ <- universeBi x :: [HsBind GhcPs]] ++
     concatMap (patHint strict True) (universeBi $ transformBi noPatBind x) ++
     concatMap expHint (universeBi x)
   where
-    exts = nubOrd $ concatMap snd (languagePragmas (pragmas (modComments modu))) -- language extensions enabled at source
+    -- Comments appearing without an empty line before the first
+    -- declaration in a module are now associated with the declaration
+    -- not the module so to be safe, look also at `firstDeclComments
+    -- modu`
+    -- (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9517).
+    exts = nubOrd $ concatMap snd (languagePragmas (pragmas (modComments modu) ++ pragmas (firstDeclComments modu))) -- language extensions enabled at source
     strict = "Strict" `elem` exts
 
     noPatBind :: LHsBind GhcPs -> LHsBind GhcPs
@@ -184,8 +189,8 @@ asPattern :: LHsDecl GhcPs  -> [(Pattern, String -> Pattern -> [Refactoring R.Sr
 asPattern (L loc x) = concatMap decl (universeBi x)
   where
     decl :: HsBind GhcPs -> [(Pattern, String -> Pattern -> [Refactoring R.SrcSpan] -> Idea)]
-    decl o@(PatBind _ pat rhs _) = [(Pattern (locA loc) Bind [pat] rhs, \msg (Pattern _ _ [pat] rhs) rs -> suggest msg (noLoc o :: Located (HsBind GhcPs)) (noLoc (PatBind EpAnnNotUsed pat rhs ([], [])) :: Located (HsBind GhcPs)) rs)]
-    decl (FunBind _ _ (MG _ (L _ xs) _) _) = map match xs
+    decl o@(PatBind _ pat rhs) = [(Pattern (locA loc) Bind [pat] rhs, \msg (Pattern _ _ [pat] rhs) rs -> suggest msg (noLoc o :: Located (HsBind GhcPs)) (noLoc (PatBind EpAnnNotUsed pat rhs) :: Located (HsBind GhcPs)) rs)]
+    decl (FunBind _ _ (MG _ (L _ xs))) = map match xs
     decl _ = []
 
     match :: LMatch GhcPs (LHsExpr GhcPs) -> (Pattern, String -> Pattern -> [Refactoring R.SrcSpan] -> Idea)
@@ -208,7 +213,7 @@ patHint lang strict o@(L _ (BangPat _ pat@(L _ x)))
   where
     f :: Pat GhcPs -> Bool
     f (ParPat _ _ (L _ x) _) = f x
-    f (AsPat _ _ (L _ x)) = f x
+    f (AsPat _ _ _ (L _ x)) = f x
     f LitPat {} = True
     f NPat {} = True
     f ConPat {} = True
@@ -222,22 +227,22 @@ patHint False _ o@(L _ (LazyPat _ pat@(L _ x)))
   where
     f :: Pat GhcPs -> Bool
     f (ParPat _ _ (L _ x) _) = f x
-    f (AsPat _ _ (L _ x)) = f x
+    f (AsPat _ _ _ (L _ x)) = f x
     f WildPat{} = True
     f VarPat{} = True
     f _ = False
     r = Replace R.Pattern (toSSA o) [("x", toSSA pat)] "x"
-patHint _ _ o@(L _ (AsPat _ v (L _ (WildPat _)))) =
+patHint _ _ o@(L _ (AsPat _ v _ (L _ (WildPat _)))) =
   [warn "Redundant as-pattern" (reLoc o) (reLoc v) [Replace R.Pattern (toSSA o) [] (rdrNameStr v)]]
 patHint _ _ _ = []
 
 expHint :: LHsExpr GhcPs -> [Idea]
  -- Note the 'FromSource' in these equations (don't warn on generated match groups).
-expHint o@(L _ (HsCase _ _ (MG _ (L _ [L _ (Match _ CaseAlt [L _ (WildPat _)] (GRHSs _ [L _ (GRHS _ [] e)] (EmptyLocalBinds _))) ]) FromSource ))) =
+expHint o@(L _ (HsCase _ _ (MG FromSource (L _ [L _ (Match _ CaseAlt [L _ (WildPat _)] (GRHSs _ [L _ (GRHS _ [] e)] (EmptyLocalBinds _))) ])))) =
   [suggest "Redundant case" (reLoc o) (reLoc e) [r]]
   where
     r = Replace Expr (toSSA o) [("x", toSSA e)] "x"
-expHint o@(L _ (HsCase _ (L _ (HsVar _ (L _ x))) (MG _ (L _ [L _ (Match _ CaseAlt [L _ (VarPat _ (L _ y))] (GRHSs _ [L _ (GRHS _ [] e)] (EmptyLocalBinds _))) ]) FromSource )))
+expHint o@(L _ (HsCase _ (L _ (HsVar _ (L _ x))) (MG FromSource (L _ [L _ (Match _ CaseAlt [L _ (VarPat _ (L _ y))] (GRHSs _ [L _ (GRHS _ [] e)] (EmptyLocalBinds _))) ]))))
   | occNameStr x == occNameStr y =
       [suggest "Redundant case" (reLoc o) (reLoc e) [r]]
   where

--- a/src/Hint/Pragma.hs
+++ b/src/Hint/Pragma.hs
@@ -32,7 +32,7 @@
 
 module Hint.Pragma(pragmaHint) where
 
-import Hint.Type(ModuHint,Idea(..),Severity(..),toSSAnc,rawIdea,modComments)
+import Hint.Type(ModuHint,Idea(..),Severity(..),toSSAnc,rawIdea,modComments,firstDeclComments)
 import Data.List.Extra
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe
@@ -48,7 +48,11 @@ import GHC.Driver.Session
 
 pragmaHint :: ModuHint
 pragmaHint _ modu =
-  let ps = pragmas (modComments modu)
+  -- Comments appearing without a line-break before the first
+  -- declaration in a module are now associated with the declaration
+  -- not the module so to be safe, look also at `firstDeclComments
+  -- modu` (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9517).
+  let ps = pragmas (modComments modu) ++ pragmas (firstDeclComments modu)
       opts = flags ps
       lang = languagePragmas ps in
     languageDupes lang ++ optToPragma opts lang

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -128,7 +128,7 @@ declSpans :: LHsDecl GhcPs -> [(SrcSpan, Idea)]
 declSpans
    (L _ (ValD _
      FunBind {fun_matches=MG {
-                   mg_origin=FromSource
+                   mg_ext=FromSource
                  , mg_alts=(L _ [L _ Match {
                        m_ctxt=ctx
                      , m_grhss=GRHSs{grhssGRHSs=[locGrhs]

--- a/src/Hint/Unsafe.hs
+++ b/src/Hint/Unsafe.hs
@@ -54,7 +54,7 @@ unsafeHint _ (ModuleEx (L _ m)) = \ld@(L loc d) ->
      -- 'x' does not declare a new function.
      | d@(ValD _
            FunBind {fun_id=L _ (Unqual x)
-                      , fun_matches=MG{mg_origin=FromSource,mg_alts=L _ [L _ Match {m_pats=[]}]}}) <- [d]
+                      , fun_matches=MG{mg_ext=FromSource,mg_alts=L _ [L _ Match {m_pats=[]}]}}) <- [d]
      -- 'x' is a synonym for an appliciation involing 'unsafePerformIO'
      , isUnsafeDecl d
      -- 'x' is not marked 'NOINLINE'.
@@ -70,7 +70,7 @@ unsafeHint _ (ModuleEx (L _ m)) = \ld@(L loc d) ->
         ) <- hsmodDecls m]
 
 isUnsafeDecl :: HsDecl GhcPs -> Bool
-isUnsafeDecl (ValD _ FunBind {fun_matches=MG {mg_origin=FromSource,mg_alts=L _ alts}}) =
+isUnsafeDecl (ValD _ FunBind {fun_matches=MG {mg_ext=FromSource,mg_alts=L _ alts}}) =
   any isUnsafeApp (childrenBi alts) || any isUnsafeDecl (childrenBi alts)
 isUnsafeDecl _ = False
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,12 @@
-resolver: lts-19.8 # ghc-9.0.2
+# For hlint/ghc-9.6.*, the minimum build compiler is ghc-9.2.2 (ghc-9.2.1 was a broken release). 9.2.2 exhibits the "'ffitarget_x86.h' file not found" problem on macOS.  in this case, build with invoke `C_INCLUDE_PATH="$(xcrun --show-sdk-path)"/usr/include/ffi stack build`.
+resolver:  nightly-2023-03-12 # ghc-9.4.4
 
 packages:
   - .
 
 extra-deps:
-  - ghc-lib-parser-9.4.1.20220807
-  - ghc-lib-parser-ex-9.4.0.0
+  - ghc-lib-parser-9.6.1.20230312
+  - ghc-lib-parser-ex-9.6.0.0
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex/ghc-lib-parser-ex-8.10.0.18.tar.gz

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -44,7 +44,8 @@ FILE tests/cpp-ext-enable.hs
 main = undefined
 EXIT 1
 OUTPUT
-tests/cpp-ext-enable.hs:1:1: Error: Parse error: tests/cpp-ext-enable.hs:3:14: error: Unsupported extension: Foo
+tests/cpp-ext-enable.hs:1:1: Error: Parse error: tests/cpp-ext-enable.hs:3:14: error: [GHC-46537]
+    Unsupported extension: Foo
 Found:
   {-# LANGUAGE CPP #-}
 

--- a/tests/parse-error.test
+++ b/tests/parse-error.test
@@ -25,7 +25,7 @@ RUN tests/ignore-parse-error3.hs
 FILE tests/ignore-parse-error3.hs
 {-# LANGUAGE InvalidExtension #-}
 OUTPUT
-tests/ignore-parse-error3.hs:1:1: Error: Parse error: tests/ignore-parse-error3.hs:1:14: error:
+tests/ignore-parse-error3.hs:1:1: Error: Parse error: tests/ignore-parse-error3.hs:1:14: error: [GHC-46537]
     Unsupported extension: InvalidExtension
 Found:
   {-# LANGUAGE InvalidExtension #-}

--- a/tests/serialise.test
+++ b/tests/serialise.test
@@ -40,7 +40,6 @@ OUTPUT
 [("tests/serialise-four.hs:2:1-20: Warning: Use fewer LANGUAGE pragmas\nFound:\n  {-# LANGUAGE CPP #-}\n  {-# LANGUAGE CPP #-}\nPerhaps:\n  {-# LANGUAGE CPP #-}\n",[ModifyComment {pos = SrcSpan {startLine = 2, startCol = 1, endLine = 2, endCol = 21}, newComment = "{-# LANGUAGE CPP #-}"},ModifyComment {pos = SrcSpan {startLine = 1, startCol = 1, endLine = 1, endCol = 21}, newComment = ""}])]
 
 
-
 ---------------------------------------------------------------------
 RUN tests/serialise-five.hs --serialise
 FILE tests/serialise-five.hs


### PR DESCRIPTION
the minimum build compiler becomes 9.2.2 (9.2.1 was a broken release). ~~https://github.com/ndmitchell/hlint/issues/1468 is the only known release blocker.~~ update: this pr bumps cmdargs to 0.10.22