### PR TITLE
rules for (elem False) and (notElem True)

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -233,6 +233,10 @@
     - warn: {lhs: notElem False, rhs: and}
     - warn: {lhs: True `elem` l, rhs: or l}
     - warn: {lhs: False `notElem` l, rhs: and l}
+    - warn: {lhs: elem False, rhs: any not, name: Use any}
+    - warn: {lhs: notElem True, rhs: all not, name: Use all}
+    - warn: {lhs: False `elem` l, rhs: any not l, name: Use any}
+    - warn: {lhs: True `notElem` l, rhs: all not l, name: Use all}
     - warn: {lhs: findIndex ((==) a), rhs: elemIndex a}
     - warn: {lhs: findIndex (a ==), rhs: elemIndex a}
     - warn: {lhs: findIndex (== a), rhs: elemIndex a}


### PR DESCRIPTION
Among other things, these would allow more fusion. For example, I had a student code:
```haskell
False `elem` map (...) (...)
```
There is no rule about `elem` and `map`, but with one of the newly proposed rules the above becomes
```haskell
any not (map (...) (...))
```
after which https://github.com/ndmitchell/hlint/blob/23d5d2211892935167862d72905b809cc0693dad/data/hlint.yaml#L192 can fire.