### PR TITLE
Fix no warn on (x.y) by treating x.y as atom

### DIFF
--- a/src/GHC/Util/Brackets.hs
+++ b/src/GHC/Util/Brackets.hs
@@ -38,6 +38,8 @@ instance Brackets (LocatedA (HsExpr GhcPs)) where
       HsUnboundVar{} -> True
       -- Technically atomic, but lots of people think it shouldn't be
       HsRecSel{} -> False
+      -- Only relevant for OverloadedRecordDot extension
+      HsGetField{} -> True
       HsOverLabel{} -> True
       HsIPVar{} -> True
       -- Note that sections aren't atoms (but parenthesized sections are).

--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -50,7 +50,7 @@ referenceDesignator = ReferenceDesignator (p.placementReferenceDesignator)
 
 -- record dot syntax
 {-# LANGUAGE OverloadedRecordDot #-} \
-referenceDesignator = ReferenceDesignator (p.placementReferenceDesignator) -- p.placementReferenceDesignator
+referenceDesignator = ReferenceDesignator (p.placementReferenceDesignator) -- p.placementReferenceDesignator @NoRefactor: refactor requires GHC >= 9.2.1
 
 -- type bracket reduction
 foo :: (Int -> Int) -> Int

--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -44,7 +44,13 @@ issue970 = (f x +) (g x) -- f x + (g x)
 issue969 = (Just \x -> x || x) *> Just True
 issue1179 = do(this is a test) -- do this is a test
 issue1212 = $(Git.hash)
-issue1471 = (x.y) -- @Suggestion x.y
+
+-- no record dot syntax
+referenceDesignator = ReferenceDesignator (p.placementReferenceDesignator)
+
+-- record dot syntax
+{-# LANGUAGE OverloadedRecordDot #-} \
+referenceDesignator = ReferenceDesignator (p.placementReferenceDesignator) -- p.placementReferenceDesignator
 
 -- type bracket reduction
 foo :: (Int -> Int) -> Int

--- a/src/Hint/Bracket.hs
+++ b/src/Hint/Bracket.hs
@@ -44,6 +44,7 @@ issue970 = (f x +) (g x) -- f x + (g x)
 issue969 = (Just \x -> x || x) *> Just True
 issue1179 = do(this is a test) -- do this is a test
 issue1212 = $(Git.hash)
+issue1471 = (x.y) -- @Suggestion x.y
 
 -- type bracket reduction
 foo :: (Int -> Int) -> Int


### PR DESCRIPTION
This is to resolve issue #1471 