### PR TITLE
Support SARIF output

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -124,6 +124,7 @@ library
         Timing
         CC
         EmbedData
+        SARIF
         Summary
         Config.Compute
         Config.Haskell

--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -117,6 +117,7 @@ data Cmd
         ,cmdCppAnsi :: Bool
         ,cmdJson :: Bool                -- ^ display hint data as JSON
         ,cmdCC :: Bool                  -- ^ display hint data as Code Climate Issues
+        ,cmdSARIF :: Bool               -- ^ display hint data as SARIF
         ,cmdNoSummary :: Bool           -- ^ do not show the summary info
         ,cmdOnly :: [String]            -- ^ specify which hints explicitly
         ,cmdNoExitCode :: Bool
@@ -158,6 +159,7 @@ mode = cmdArgsMode $ modes
         ,cmdCppAnsi = nam_ "cpp-ansi" &= help "Use CPP in ANSI compatibility mode"
         ,cmdJson = nam_ "json" &= help "Display hint data as JSON"
         ,cmdCC = nam_ "cc" &= help "Display hint data as Code Climate Issues"
+        ,cmdSARIF = nam_ "sarif" &= help "Display hint data as SARIF"
         ,cmdNoSummary = nam_ "no-summary" &= help "Do not show summary information"
         ,cmdOnly = nam "only" &= typ "HINT" &= help "Specify which hints explicitly"
         ,cmdNoExitCode = nam_ "no-exit-code" &= help "Do not give a negative exit if hints"

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -36,6 +36,7 @@ import GHC.All
 import CC
 import EmbedData
 
+import qualified SARIF
 
 -- | This function takes a list of command line arguments, and returns the given hints.
 --   To see a list of arguments type @hlint --help@ at the console.
@@ -173,6 +174,8 @@ runHints args settings cmd@CmdMain{..} =
             putStrLn $ showIdeasJson ideas
          else if cmdCC then
             mapM_ (printIssue . fromIdea) ideas
+         else if cmdSARIF then
+            SARIF.printIdeas ideas
          else if cmdSerialise then do
             hSetBuffering stdout NoBuffering
             print $ map (show &&& ideaRefactoring) ideas

--- a/src/SARIF.hs
+++ b/src/SARIF.hs
@@ -1,0 +1,177 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{- |
+Description: Formats hlint ideas in the Statis Analysis Results Interchange Format (SARIF).
+License: BSD-3-Clause
+
+Supports the conversion of a list of HLint 'Idea's into SARIF.
+
+SARIF (Static Analysis Results Interchange Format) is an open interchange format
+for storing results from static analyses.
+-}
+module SARIF ( printIdeas
+             , showIdeas
+             , toJSONEncoding
+             -- * See also
+             --
+             -- $references
+             ) where
+
+import Data.Aeson hiding (Error)
+import Data.Aeson.Encoding
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as B
+import Data.Text.Lazy (Text)
+import Data.Version (showVersion)
+import GHC.Util
+import Idea
+import Paths_hlint (version)
+
+-- | Print the given ideas to standard output.
+--
+-- For example:
+--
+-- >>> hlint ["src"] >>= printIdeas
+--
+-- For printing ideas in SARIF without dependent modules
+-- having to import "Data.Aeson" or "Data.ByteString.Lazy".
+printIdeas :: [Idea] -> IO ()
+printIdeas = B.putStr . showIdeas
+
+-- | Format the given ideas in SARIF.
+--
+-- For converting ideas to SARIF without dependent modules
+-- having to import "Data.Aeson".
+showIdeas :: [Idea] -> ByteString
+showIdeas = encodingToLazyByteString . toJSONEncoding
+
+-- | Converts the given ideas to a "Data.Aeson" encoding in SARIF.
+toJSONEncoding :: [Idea] -> Encoding
+toJSONEncoding = pairs . sarif
+
+-- | Converts the given object to a top-level @sarifLog@ object.
+--
+-- See section 3.13 "sarifLog object", SARIF specification.
+sarif :: [Idea] -> Series
+sarif ideas =
+  pair "version" (lazyText "2.1.0") <>
+  pair "$schema" (lazyText schemaURI) <>
+  pair "runs" runs
+  where runs = list pairs [ pair "tool" (pairs tool) <>
+                            pair "results" (list (pairs . toResult) ideas) ]
+
+-- | A @tool@ object describing what created the output.
+--
+-- Obviously, it will describe that HLint created the output.
+--
+-- See section 3.18 "tool object", SARIF specification.
+tool :: Series
+tool = pair "driver" $ pairs $
+  pair "name" (lazyText "hlint") <>
+  pair "version" (string $ showVersion version) <>
+  pair "informationUri" (lazyText hlintURI)
+
+-- | Converts a given idea into a @result@ object.
+--
+-- It will describe the hint, the severity, suggestions for fixes, etc.
+--
+-- See section 3.27 "result object", SARIF specification.
+toResult :: Idea -> Series
+toResult idea@Idea{..} =
+  pair "message" (pairs $ pair "text" $ string $ show idea) <>
+  pair "level" (lazyText $ showSeverity ideaSeverity) <>
+  pair "locations" (list (pairs . toLocation) [idea]) <>
+  pair "fixes" (list (pairs . toFix) [idea]) <>
+  -- Use 'ideaHint' as the rule identifier.
+  --
+  -- "ruleId" is supposed to a stable, opaque identifier.
+  -- 'ideaHint' is not opaque, nor is it quite guaranteed to be stable,
+  -- but they will usually be stable enough, and disabling a hint is
+  -- based on the name in 'ideaHint'.
+  --
+  -- Most importantly, there is no requirement that "ruleId"
+  -- be a /unique/ identifier.
+  pair "ruleId" (string ideaHint)
+
+-- | Convert HLint severity to SARIF level.
+--
+-- See section 3.58.6 "level property", SARIF specification.
+showSeverity :: Severity -> Text
+showSeverity Error = "error"
+showSeverity Warning = "warning"
+showSeverity Suggestion = "note"
+showSeverity Ignore = "none"
+
+-- | Converts the location information in a given idea to a @location@ object.
+--
+-- See section 3.28 "location object", SARIF specification.
+toLocation :: Idea -> Series
+toLocation idea@Idea{ideaSpan=SrcSpan{..}, ..} =
+  physicalLocation <> logicalLocations ideaModule ideaDecl
+  where physicalLocation = pair "physicalLocation" $ pairs $
+          pair "artifactLocation"
+              (pairs $ pair "uri" (string srcSpanFilename)) <>
+          pair "region" (pairs $ toRegion idea)
+
+        logicalLocations [mod] [decl] = pair "logicalLocations" $
+          list pairs [ pair "name" (string decl) <>
+                       pair "fullyQualifiedName" (string $ mod ++ "." ++ decl) ]
+          -- It would be nice to include whether it is a function or type
+          -- in the "kind" field, but we do not have that information.
+
+        -- If the lists are empty, then there is obviously no logical location.
+        -- Logical location is still omitted when the lists are not singleton,
+        -- because the associations between modules and declarations are
+        -- not clear.
+        logicalLocations _ _ = mempty
+
+-- | Converts a given idea to a @fix@ object.
+--
+-- It will suggest how code can be improved to deal with an issue.
+-- This includes the file to be changed and how to change it.
+--
+-- See section 3.55 "fix object", SARIF specification.
+toFix :: Idea -> Series
+toFix idea@Idea{..} =
+  pair "description" (pairs $ pair "text" $ string ideaHint) <>
+  pair "artifactChanges" (list (pairs . toChange) [idea])
+
+-- | Converts a given idea to a @artifactChange@ object.
+--
+-- It will describe the details as to how the code can be changed.
+-- I.e., the text to remove and what it should be replaced with.
+--
+-- See section 3.56 "artifactChange object", SARIF specification.
+toChange :: Idea -> Series
+toChange idea@Idea{ideaSpan=SrcSpan{..}, ..} =
+  pair "artifactLocation" (pairs uri) <>
+  pair "replacements" (list pairs [deleted <> inserted])
+  where uri  = pair "uri" $ string srcSpanFilename
+        deleted = pair "deletedRegion" $ pairs $ toRegion idea
+        inserted = maybe mempty insertedContent ideaTo
+        insertedContent = pair "insertedContent" . pairs . pair "text" . string
+
+-- | Converts the source span in an idea to a SARIF region.
+--
+-- See 3.30 "region object", SARIF specification.
+toRegion :: Idea -> Series
+toRegion Idea{ideaSpan=SrcSpan{..}, ..} =
+  pair "startLine" (int srcSpanStartLine') <>
+  pair "startColumn" (int srcSpanStartColumn) <>
+  pair "endLine" (int srcSpanEndLine') <>
+  pair "endColumn" (int srcSpanEndColumn)
+
+-- | URI to SARIF schema definition.
+schemaURI :: Text
+schemaURI = "https://raw.githubusercontent.com/" <>
+            "oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+
+-- | URI to HLint home page.
+hlintURI :: Text
+hlintURI = "https://github.com/ndmitchell/hlint"
+
+-- $references
+--
+-- * [SARIF Tutorials](https://github.com/microsoft/sarif-tutorials)
+-- * [Static Analysis Results Interchange Format](https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html), version 2.1.0

--- a/tests/sarif.test
+++ b/tests/sarif.test
@@ -1,0 +1,38 @@
+---------------------------------------------------------------------
+RUN tests/sarif-none.hs --sarif
+FILE tests/sarif-none.hs
+foo = (+1)
+OUTPUT
+{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"hlint","version":"3.5","informationUri":"https://github.com/ndmitchell/hlint"}},"results":[]}]}
+
+---------------------------------------------------------------------
+RUN tests/sarif-one.hs --sarif
+FILE tests/sarif-one.hs
+foo = (+1)
+bar x = foo x
+OUTPUT
+{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"hlint","version":"3.5","informationUri":"https://github.com/ndmitchell/hlint"}},"results":[{"message":{"text":"tests/sarif-one.hs:2:1-13: Warning: Eta reduce\nFound:\n  bar x = foo x\nPerhaps:\n  bar = foo\n"},"level":"warning","locations":[{"physicalLocation":{"artifactLocation":{"uri":"tests/sarif-one.hs"},"region":{"startLine":2,"startColumn":1,"endLine":2,"endColumn":14}},"logicalLocations":[{"name":"bar","fullyQualifiedName":"Main.bar"}]}],"fixes":[{"description":{"text":"Eta reduce"},"artifactChanges":[{"artifactLocation":{"uri":"tests/sarif-one.hs"},"replacements":[{"deletedRegion":{"startLine":2,"startColumn":1,"endLine":2,"endColumn":14},"insertedContent":{"text":"bar = foo"}}]}]}],"ruleId":"Eta reduce"}]}]}
+
+---------------------------------------------------------------------
+RUN tests/sarif-two.hs --sarif
+FILE tests/sarif-two.hs
+foo = (+1)
+bar x = foo x
+baz = getLine >>= pure . upper
+OUTPUT
+{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"hlint","version":"3.5","informationUri":"https://github.com/ndmitchell/hlint"}},"results":[{"message":{"text":"tests/sarif-two.hs:2:1-13: Warning: Eta reduce\nFound:\n  bar x = foo x\nPerhaps:\n  bar = foo\n"},"level":"warning","locations":[{"physicalLocation":{"artifactLocation":{"uri":"tests/sarif-two.hs"},"region":{"startLine":2,"startColumn":1,"endLine":2,"endColumn":14}},"logicalLocations":[{"name":"bar","fullyQualifiedName":"Main.bar"}]}],"fixes":[{"description":{"text":"Eta reduce"},"artifactChanges":[{"artifactLocation":{"uri":"tests/sarif-two.hs"},"replacements":[{"deletedRegion":{"startLine":2,"startColumn":1,"endLine":2,"endColumn":14},"insertedContent":{"text":"bar = foo"}}]}]}],"ruleId":"Eta reduce"},{"message":{"text":"tests/sarif-two.hs:3:7-30: Suggestion: Use <&>\nFound:\n  getLine >>= pure . upper\nPerhaps:\n  getLine Data.Functor.<&> upper\n"},"level":"note","locations":[{"physicalLocation":{"artifactLocation":{"uri":"tests/sarif-two.hs"},"region":{"startLine":3,"startColumn":7,"endLine":3,"endColumn":31}},"logicalLocations":[{"name":"baz","fullyQualifiedName":"Main.baz"}]}],"fixes":[{"description":{"text":"Use <&>"},"artifactChanges":[{"artifactLocation":{"uri":"tests/sarif-two.hs"},"replacements":[{"deletedRegion":{"startLine":3,"startColumn":7,"endLine":3,"endColumn":31},"insertedContent":{"text":"getLine Data.Functor.<&> upper"}}]}]}],"ruleId":"Use <&>"}]}]}
+
+---------------------------------------------------------------------
+RUN tests/sarif-parse-error.hs --sarif
+FILE tests/sarif-parse-error.hs
+@
+OUTPUT
+{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"hlint","version":"3.5","informationUri":"https://github.com/ndmitchell/hlint"}},"results":[{"message":{"text":"tests/sarif-parse-error.hs:1:1: Error: Parse error: on input `@'\nFound:\n  > @\n"},"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"tests/sarif-parse-error.hs"},"region":{"startLine":1,"startColumn":1,"endLine":1,"endColumn":2}}}],"fixes":[{"description":{"text":"Parse error: on input `@'"},"artifactChanges":[{"artifactLocation":{"uri":"tests/sarif-parse-error.hs"},"replacements":[{"deletedRegion":{"startLine":1,"startColumn":1,"endLine":1,"endColumn":2}}]}]}],"ruleId":"Parse error: on input `@'"}]}]}
+
+---------------------------------------------------------------------
+RUN tests/sarif-note.hs --sarif
+FILE tests/sarif-note.hs
+foo = any (a ==)
+bar = foldl (&&) True
+OUTPUT
+{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"hlint","version":"3.5","informationUri":"https://github.com/ndmitchell/hlint"}},"results":[{"message":{"text":"tests/sarif-note.hs:1:7-16: Warning: Use elem\nFound:\n  any (a ==)\nPerhaps:\n  elem a\n"},"level":"warning","locations":[{"physicalLocation":{"artifactLocation":{"uri":"tests/sarif-note.hs"},"region":{"startLine":1,"startColumn":7,"endLine":1,"endColumn":17}},"logicalLocations":[{"name":"foo","fullyQualifiedName":"Main.foo"}]}],"fixes":[{"description":{"text":"Use elem"},"artifactChanges":[{"artifactLocation":{"uri":"tests/sarif-note.hs"},"replacements":[{"deletedRegion":{"startLine":1,"startColumn":7,"endLine":1,"endColumn":17},"insertedContent":{"text":"elem a"}}]}]}],"ruleId":"Use elem"},{"message":{"text":"tests/sarif-note.hs:2:7-21: Warning: Use and\nFound:\n  foldl (&&) True\nPerhaps:\n  and\nNote: increases laziness\n"},"level":"warning","locations":[{"physicalLocation":{"artifactLocation":{"uri":"tests/sarif-note.hs"},"region":{"startLine":2,"startColumn":7,"endLine":2,"endColumn":22}},"logicalLocations":[{"name":"bar","fullyQualifiedName":"Main.bar"}]}],"fixes":[{"description":{"text":"Use and"},"artifactChanges":[{"artifactLocation":{"uri":"tests/sarif-note.hs"},"replacements":[{"deletedRegion":{"startLine":2,"startColumn":7,"endLine":2,"endColumn":22},"insertedContent":{"text":"and"}}]}]}],"ruleId":"Use and"}]}]}


### PR DESCRIPTION
This adds the ability to output into SARIF from HLint.  SARIF is an open interchange format for exchanging results for static analyses.  In particular, GitHub uses SARIF for reading results from code scanning tools; this would allow HLint to be used as a code scanning tool in GitHub.  The output is complete enough such that output uploaded from a [test workflow](https://github.com/chungyc/hlint/blob/sarif-code-scanning/.github/workflows/scan.yaml) shows up as a code scanning alert.

The changes adds a `--sarif` flag and a "SARIF" module.  E.g., the following will result in the hints being output in SARIF.

```shell
$ hlint --sarif data/Test.hs
```

There are now quite a few output formats that HLint supports.  I.e., HLint-native JSON, Code Climate, HTML, Refactor, and now SARIF.  I was almost tempted to add a `--format=sarif` flag instead and put the module in "Format.SARIF", but I didn't in order to maintain consistency with existing practice.  However, if you would like such a change made, I would be _very_ happy to make it (obviously, I would keep the existing flags alone).

This change does not use the [sarif](https://hackage.haskell.org/package/sarif) package.  While it would have not added any new dependencies other than itself, I was a little worried by it having an extra module in the "Data.Aeson" namespace.  It is not on Stackage, either, so it would have been a little more work to get it working on stack.

This pull request will resolve https://github.com/ndmitchell/hlint/issues/1469.

---
By raising this pull request, I confirm I am licensing my contribution under all licenses that apply to this project and that I have no patents covering my contribution.
