### PR TITLE
rename three of the hints introduced in #1481

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -876,9 +876,9 @@
     - hint: {lhs: foldr f z (concatMap g x), rhs: foldr (foldr f . g) z x}
     - warn: {lhs: fold (concatMap f x), rhs: foldMap (fold . f) x}
     - warn: {lhs: foldMap f (concatMap g x), rhs: foldMap (foldMap f . g) x}
-    - warn: {lhs: catMaybes (concatMap f x), rhs: concatMap (catMaybes . f) x, name: Move concatMap out}
-    - hint: {lhs: filter f (concatMap g x), rhs: concatMap (filter f . g) x, name: Move concatMap out}
-    - warn: {lhs: mapMaybe f (concatMap g x), rhs: concatMap (mapMaybe f . g) x, name: Move concatMap out}
+    - warn: {lhs: catMaybes (concatMap f x), rhs: concatMap (catMaybes . f) x, name: Move catMaybes}
+    - hint: {lhs: filter f (concatMap g x), rhs: concatMap (filter f . g) x, name: Move filter}
+    - warn: {lhs: mapMaybe f (concatMap g x), rhs: concatMap (mapMaybe f . g) x, name: Move mapMaybe}
     - warn: {lhs: or (fmap p x), rhs: any p x}
     - warn: {lhs: or (p <$> x), rhs: any p x}
     - warn: {lhs: or (x <&> p), rhs: any p x}


### PR DESCRIPTION
Sorry, I think the name `Move concatMap out` was not so good after all. For example, it's not like in `catMaybes (concatMap f x) ==> concatMap (catMaybes . f) x` the `concatMap`-call is afterwards "outside" a `catMaybes` call.

The new names proposed now instead emphasize the function that is moving from outside into the higher-order argument of `concatMap`. A bit in the spirit of the name of this existing hint: https://github.com/ndmitchell/hlint/blob/e05030a08b238ff4d196338d01be1db37e891341/data/hlint.yaml#L122