### PR TITLE
import qualified post

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -16,6 +16,7 @@
 
 - extensions:
   - default: false
+  - name: [ImportQualifiedPost]
   - name: [DeriveDataTypeable, DeriveFunctor, GeneralizedNewtypeDeriving, NoMonomorphismRestriction, OverloadedStrings]
   - name: [MultiWayIf, PatternGuards, RecordWildCards, ViewPatterns, PatternSynonyms, TupleSections, LambdaCase]
   - name: [Rank2Types, ScopedTypeVariables]

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -171,7 +171,7 @@ library
         Test.Annotations
         Test.InputOutput
         Test.Util
-    ghc-options: -Wunused-binds -Wunused-imports -Worphans
+    ghc-options: -Wunused-binds -Wunused-imports -Worphans -Wprepositive-qualified-module
 
 
 executable hlint

--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 
 module Apply(applyHints, applyHintFile, applyHintFiles) where
 
@@ -18,7 +19,7 @@ import Config.Haskell
 import GHC.Types.SrcLoc
 import GHC.Hs
 import Language.Haskell.GhclibParserEx.GHC.Hs
-import qualified Data.HashSet as Set
+import Data.HashSet qualified as Set
 import Prelude
 import Util
 import Timing

--- a/src/CC.hs
+++ b/src/CC.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 -- |
@@ -14,13 +15,13 @@ import Data.Aeson (ToJSON(..), (.=), encode, object)
 import Data.Char (toUpper)
 import Data.Text (Text)
 
-import qualified Data.Text as T
-import qualified Data.ByteString.Lazy.Char8 as C8
+import Data.Text qualified as T
+import Data.ByteString.Lazy.Char8 qualified as C8
 
 import Idea (Idea(..), Severity(..))
 
-import qualified GHC.Types.SrcLoc as GHC
-import qualified GHC.Util as GHC
+import GHC.Types.SrcLoc qualified as GHC
+import GHC.Util qualified as GHC
 
 data Issue = Issue
     { issueType :: Text

--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE PatternGuards, DeriveDataTypeable, TupleSections #-}
 {-# OPTIONS_GHC -Wno-missing-fields -fno-cse -O0 #-}
 
@@ -9,7 +10,7 @@ module CmdLine(
 
 import Control.Monad.Extra
 import Control.Exception.Extra
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Char
 import Data.List.Extra
 import Data.Maybe

--- a/src/Config/Haskell.hs
+++ b/src/Config/Haskell.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE PatternGuards, ViewPatterns, TupleSections #-}
 module Config.Haskell(
     readPragma,
@@ -23,7 +24,7 @@ import GHC.Hs.Lit
 import GHC.Data.FastString
 import GHC.Parser.Annotation
 import GHC.Utils.Outputable
-import qualified GHC.Data.Strict
+import GHC.Data.Strict qualified
 
 import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
 import Language.Haskell.GhclibParserEx.GHC.Types.Name.Reader

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DataKinds #-}
@@ -18,7 +19,7 @@ import Data.Monoid
 import Prelude
 
 
-import qualified GHC.Hs
+import GHC.Hs qualified
 import Fixity
 import GHC.Util
 import Language.Haskell.GhclibParserEx.GHC.Hs.ExtendInstances

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings, ViewPatterns, RecordWildCards, GeneralizedNewtypeDeriving, TupleSections #-}
@@ -31,10 +32,10 @@ import Data.Maybe
 import Data.List.Extra
 import Data.Tuple.Extra
 import Control.Monad.Extra
-import qualified Data.Text as T
-import qualified Data.Vector as V
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.HashMap.Strict as Map
+import Data.Text qualified as T
+import Data.Vector qualified as V
+import Data.ByteString.Char8 qualified as BS
+import Data.HashMap.Strict qualified as Map
 import Data.Generics.Uniplate.DataOnly
 import GHC.All
 import Fixity
@@ -67,7 +68,7 @@ import Data.YAML (Pos)
 import Data.YAML.Aeson (encode1Strict, decode1Strict)
 import Data.Aeson hiding (encode)
 import Data.Aeson.Types (Parser)
-import qualified Data.ByteString as BSS
+import Data.ByteString qualified as BSS
 
 decodeFileEither :: FilePath -> IO (Either (Pos, String) ConfigYaml)
 decodeFileEither path = decode1Strict <$> BSS.readFile path

--- a/src/Extension.hs
+++ b/src/Extension.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 module Extension(
   defaultExtensions,
   configExtensions,
@@ -6,9 +7,9 @@ module Extension(
   ) where
 
 import Data.List.Extra
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import GHC.LanguageExtensions.Type
-import qualified Language.Haskell.GhclibParserEx.GHC.Driver.Session as GhclibParserEx
+import Language.Haskell.GhclibParserEx.GHC.Driver.Session qualified as GhclibParserEx
 
 badExtensions =
   reallyBadExtensions ++

--- a/src/GHC/Util/ApiAnnotation.hs
+++ b/src/GHC/Util/ApiAnnotation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 
 module GHC.Util.ApiAnnotation (
     comment_, commentText, isCommentMultiline
@@ -16,7 +17,7 @@ import Language.Haskell.GhclibParserEx.GHC.Driver.Session
 import Control.Applicative
 import Data.List.Extra
 import Data.Maybe
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 
 trimCommentStart :: String -> String
 trimCommentStart s

--- a/src/GHC/Util/FreeVars.hs
+++ b/src/GHC/Util/FreeVars.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -19,7 +20,7 @@ import Data.Monoid
 import Data.Semigroup
 import Data.List.Extra
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Prelude
 
 ( ^+ ) :: Set OccName -> Set OccName -> Set OccName

--- a/src/GHC/Util/HsExpr.hs
+++ b/src/GHC/Util/HsExpr.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns, MultiParamTypeClasses, FlexibleInstances, FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
@@ -39,7 +40,7 @@ import Data.Maybe
 
 import Refact (substVars, toSSA)
 import Refact.Types hiding (SrcSpan, Match)
-import qualified Refact.Types as R (SrcSpan)
+import Refact.Types qualified as R (SrcSpan)
 
 import Language.Haskell.GhclibParserEx.GHC.Hs.Pat
 import Language.Haskell.GhclibParserEx.GHC.Hs.Expr

--- a/src/GHC/Util/SrcLoc.hs
+++ b/src/GHC/Util/SrcLoc.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module GHC.Util.SrcLoc (
@@ -10,7 +11,7 @@ import GHC.Parser.Annotation
 import GHC.Types.SrcLoc
 import GHC.Utils.Outputable
 import GHC.Data.FastString
-import qualified GHC.Data.Strict
+import GHC.Data.Strict qualified
 
 import Data.Default
 import Data.Data

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
@@ -36,7 +37,7 @@ import GHC.All
 import CC
 import EmbedData
 
-import qualified SARIF
+import SARIF qualified
 
 -- | This function takes a list of command line arguments, and returns the given hints.
 --   To see a list of arguments type @hlint --help@ at the console.

--- a/src/Hint/Comment.hs
+++ b/src/Hint/Comment.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 
 {-
 <TEST>
@@ -21,7 +22,7 @@ import Refact.Types(Refactoring(ModifyComment))
 import GHC.Types.SrcLoc
 import GHC.Parser.Annotation
 import GHC.Util
-import qualified GHC.Data.Strict
+import GHC.Data.Strict qualified
 
 directives :: [String]
 directives = words $

--- a/src/Hint/Duplicate.hs
+++ b/src/Hint/Duplicate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE PatternGuards, ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 
@@ -30,8 +31,8 @@ import Data.Default
 import Data.Maybe
 import Data.Tuple.Extra
 import Data.List hiding (find)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as Map
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as Map
 
 import GHC.Types.SrcLoc
 import GHC.Hs

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase, NamedFieldPuns, ScopedTypeVariables #-}
 
 {-
@@ -268,8 +269,8 @@ import Data.Maybe
 import Data.List.Extra
 import Data.Data
 import Refact.Types
-import qualified Data.Set as Set
-import qualified Data.Map as Map
+import Data.Set qualified as Set
+import Data.Map qualified as Map
 
 import GHC.Types.SrcLoc
 import GHC.Types.SourceText
@@ -277,7 +278,7 @@ import GHC.Hs
 import GHC.Types.Basic
 import GHC.Types.Name.Reader
 import GHC.Types.ForeignCall
-import qualified GHC.Data.Strict
+import GHC.Data.Strict qualified
 import GHC.Types.PkgQual
 
 import GHC.Util

--- a/src/Hint/Import.hs
+++ b/src/Hint/Import.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase, PatternGuards, RecordWildCards #-}
 {-
     Reduce the number of import declarations.
@@ -39,7 +40,7 @@ module Hint.Import(importHint) where
 
 import Hint.Type(ModuHint,ModuleEx(..),Idea(..),Severity(..),suggest,toSSA,rawIdea)
 import Refact.Types hiding (ModuleName)
-import qualified Refact.Types as R
+import Refact.Types qualified as R
 import Data.Tuple.Extra
 import Data.List.Extra
 import Data.Generics.Uniplate.DataOnly

--- a/src/Hint/Lambda.hs
+++ b/src/Hint/Lambda.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase, PatternGuards, TupleSections, ViewPatterns #-}
 
 {-
@@ -110,7 +111,7 @@ import Hint.Type (DeclHint, Idea, Note(RequiresExtension), suggest, warn, toSS, 
 import Util
 import Data.List.Extra
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Refact.Types hiding (Match)
 import Data.Generics.Uniplate.DataOnly (universe, universeBi, transformBi)
 

--- a/src/Hint/List.hs
+++ b/src/Hint/List.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE ViewPatterns, PatternGuards, FlexibleContexts #-}
 {-
     Find and match:
@@ -50,7 +51,7 @@ import Prelude
 import Hint.Type(DeclHint,Idea,suggest,ignore,substVars,toRefactSrcSpan,toSSA,modComments,firstDeclComments)
 
 import Refact.Types hiding (SrcSpan)
-import qualified Refact.Types as R
+import Refact.Types qualified as R
 
 import GHC.Hs
 import GHC.Types.SrcLoc

--- a/src/Hint/Match.hs
+++ b/src/Hint/Match.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE RecordWildCards, NamedFieldPuns, TupleSections #-}
 {-# LANGUAGE PatternGuards, ViewPatterns, FlexibleContexts #-}
 
@@ -43,8 +44,8 @@ import Hint.Type (ModuleEx,Idea,idea,ideaNote,toSSA)
 
 import Util
 import Timing
-import qualified Data.Set as Set
-import qualified Refact.Types as R
+import Data.Set qualified as Set
+import Refact.Types qualified as R
 
 import Control.Monad
 import Data.Tuple.Extra

--- a/src/Hint/Monad.hs
+++ b/src/Hint/Monad.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternGuards #-}
@@ -77,7 +78,7 @@ import GHC.Types.Basic
 import GHC.Types.Name.Reader
 import GHC.Types.Name.Occurrence
 import GHC.Data.Bag
-import qualified GHC.Data.Strict
+import GHC.Data.Strict qualified
 
 import Language.Haskell.GhclibParserEx.GHC.Hs.Pat
 import Language.Haskell.GhclibParserEx.GHC.Hs.Expr
@@ -90,7 +91,7 @@ import Data.Tuple.Extra
 import Data.Maybe
 import Data.List.Extra
 import Refact.Types hiding (Match)
-import qualified Refact.Types as R
+import Refact.Types qualified as R
 
 
 badFuncs :: [String]

--- a/src/Hint/Naming.hs
+++ b/src/Hint/Naming.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-
@@ -48,7 +49,7 @@ import Data.List.NonEmpty (toList)
 import Data.Data
 import Data.Char
 import Data.Maybe
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 
 import GHC.Types.Basic
 import GHC.Types.SourceText

--- a/src/Hint/Pattern.hs
+++ b/src/Hint/Pattern.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE ViewPatterns, PatternGuards, TypeFamilies #-}
 
 {-
@@ -66,7 +67,7 @@ import Data.Tuple
 import Data.Maybe
 import Data.Either
 import Refact.Types hiding (RType(Pattern, Match), SrcSpan)
-import qualified Refact.Types as R (RType(Pattern, Match), SrcSpan)
+import Refact.Types qualified as R (RType(Pattern, Match), SrcSpan)
 
 import GHC.Hs
 import GHC.Types.SrcLoc
@@ -74,7 +75,7 @@ import GHC.Types.Name.Reader
 import GHC.Types.Name.Occurrence
 import GHC.Data.Bag
 import GHC.Types.Basic hiding (Pattern)
-import qualified GHC.Data.Strict
+import GHC.Data.Strict qualified
 
 import GHC.Util
 import Language.Haskell.GhclibParserEx.GHC.Hs.Pat

--- a/src/Hint/Pragma.hs
+++ b/src/Hint/Pragma.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 
@@ -34,10 +35,10 @@ module Hint.Pragma(pragmaHint) where
 
 import Hint.Type(ModuHint,Idea(..),Severity(..),toSSAnc,rawIdea,modComments,firstDeclComments)
 import Data.List.Extra
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe
 import Refact.Types
-import qualified Refact.Types as R
+import Refact.Types qualified as R
 
 import GHC.Hs
 import GHC.Types.SrcLoc

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -25,9 +26,9 @@ import Config.Type
 import Util
 
 import Data.Generics.Uniplate.DataOnly
-import qualified Data.List.NonEmpty as NonEmpty
-import qualified Data.Set as Set
-import qualified Data.Map as Map
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Set qualified as Set
+import Data.Map qualified as Map
 import Data.List.Extra
 import Data.List.NonEmpty (nonEmpty)
 import Data.Maybe

--- a/src/Hint/Smell.hs
+++ b/src/Hint/Smell.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 
 module Hint.Smell (smellModuleHint,smellHint) where
 
@@ -80,7 +81,7 @@ import Config.Type
 
 import Data.Generics.Uniplate.DataOnly
 import Data.List.Extra
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 
 import GHC.Utils.Outputable
 import GHC.Types.Basic

--- a/src/Idea.hs
+++ b/src/Idea.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE RecordWildCards, NoMonomorphismRestriction #-}
 
 module Idea(
@@ -13,7 +14,7 @@ import Data.List.Extra
 import Config.Type
 import HsColour
 import Refact.Types hiding (SrcSpan)
-import qualified Refact.Types as R
+import Refact.Types qualified as R
 import Prelude
 import GHC.Types.SrcLoc
 import GHC.Utils.Outputable

--- a/src/Language/Haskell/HLint.hs
+++ b/src/Language/Haskell/HLint.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE PatternGuards, RecordWildCards #-}
 
 -- |  This module provides a way to apply HLint hints. If you want to just run @hlint@ in-process
@@ -33,13 +34,13 @@ module Language.Haskell.HLint(
 import Config.Type
 import Config.Read
 import Idea
-import qualified Apply as H
+import Apply qualified as H
 import HLint
 import Fixity
 import GHC.Data.FastString ( unpackFS )
 import GHC.All
 import Hint.All hiding (resolveHints)
-import qualified Hint.All as H
+import Hint.All qualified as H
 import GHC.Types.SrcLoc
 import CmdLine
 import Paths_hlint
@@ -49,7 +50,7 @@ import Data.Maybe
 import System.FilePath
 import Data.Functor
 import Prelude
-import qualified Hint.Restrict as Restrict
+import Hint.Restrict qualified as Restrict
 
 
 -- | Get the Cabal configured data directory of HLint.

--- a/src/Refact.hs
+++ b/src/Refact.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Refact
@@ -17,10 +18,10 @@ import System.Directory.Extra
 import System.Exit
 import System.IO.Extra
 import System.Process.Extra
-import qualified Refact.Types as R
+import Refact.Types qualified as R
 
-import qualified GHC.Types.SrcLoc as GHC
-import qualified GHC.Parser.Annotation as GHC
+import GHC.Types.SrcLoc qualified as GHC
+import GHC.Parser.Annotation qualified as GHC
 
 import GHC.Util.SrcLoc (getAncLoc)
 

--- a/src/Report.hs
+++ b/src/Report.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Report(writeReport) where
@@ -5,14 +6,14 @@ module Report(writeReport) where
 import Idea
 import Data.Tuple.Extra
 import Data.List.Extra
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe
 import Data.Version
 import Timing
 import Paths_hlint
 import HsColour
 import EmbedData
-import qualified GHC.Util as GHC
+import GHC.Util qualified as GHC
 
 
 writeTemplate :: FilePath -> [(String,[String])] -> FilePath -> IO ()

--- a/src/SARIF.hs
+++ b/src/SARIF.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -21,7 +22,7 @@ module SARIF ( printIdeas
 import Data.Aeson hiding (Error)
 import Data.Aeson.Encoding
 import Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy as B
+import Data.ByteString.Lazy qualified as B
 import Data.Text.Lazy (Text)
 import Data.Version (showVersion)
 import GHC.Util

--- a/src/Summary.hs
+++ b/src/Summary.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -5,7 +6,7 @@
 
 module Summary (generateMdSummary, generateJsonSummary, generateExhaustiveConfig) where
 
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Control.Monad.Extra
 import System.FilePath
 import Data.List.Extra

--- a/src/Test/Annotations.hs
+++ b/src/Test/Annotations.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE CPP, PatternGuards, RecordWildCards, ViewPatterns #-}
 
 -- | Check the <TEST> annotations within source and hint files.
@@ -17,7 +18,7 @@ import System.Exit
 import System.FilePath
 import System.IO.Extra
 import GHC.All
-import qualified Data.ByteString.Char8 as BS
+import Data.ByteString.Char8 qualified as BS
 
 import Config.Type
 import Idea

--- a/src/Timing.hs
+++ b/src/Timing.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 
 module Timing(
     timed, timedIO,
@@ -5,7 +6,7 @@ module Timing(
     printTimings
     ) where
 
-import qualified Data.HashMap.Strict as Map
+import Data.HashMap.Strict qualified as Map
 import Control.Exception
 import Data.IORef.Extra
 import Data.Tuple.Extra

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ extra-deps:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex/ghc-lib-parser-ex-8.10.0.18.tar.gz
 #    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
 
-ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-local-binds -Werror=unused-top-binds -Werror=orphans}
+ghc-options: {"$locals": -ddump-to-file -ddump-hi -Werror=unused-imports -Werror=unused-local-binds -Werror=unused-top-binds -Werror=orphans -Werror=prepositive-qualified-module}
 
 # Enabling this stanza forces both hlint and ghc-lib-parser-ex to
 # depend on ghc-lib-parser.


### PR DESCRIPTION
change qualified imports to postpositive syntax everywhere and enable `-Wprepositive-qualified-module`.

`ImportQualifiedPost` has been available since 8.10.1 and the minimum build compiler now is 9.2.2 so it's safe to do this now.
