### PR TITLE
[Patch+test] Fix bug with postqualified imports and qualifiedStyle=unrestricted

### DIFF
--- a/data/import_style.yaml
+++ b/data/import_style.yaml
@@ -5,3 +5,4 @@
   - {name: 'HypotheticalModule3.*', importStyle: unqualified}
   - {name: 'HypotheticalModule3.OtherSubModule', importStyle: unrestricted, qualifiedStyle: post}
   - {name: HypotheticalModule4, importStyle: qualified, as: HM4, asRequired: true}
+  - {name: HypotheticalModule5, importStyle: qualified, qualifiedStyle: post}

--- a/data/import_style.yaml
+++ b/data/import_style.yaml
@@ -4,3 +4,4 @@
   - {name: HypotheticalModule3, importStyle: qualified}
   - {name: 'HypotheticalModule3.*', importStyle: unqualified}
   - {name: 'HypotheticalModule3.OtherSubModule', importStyle: unrestricted, qualifiedStyle: post}
+  - {name: HypotheticalModule4, importStyle: qualified, as: HM4, asRequired: true}

--- a/tests/import_style.test
+++ b/tests/import_style.test
@@ -66,3 +66,10 @@ OUTPUT
 No hints
 
 ---------------------------------------------------------------------
+RUN tests/importStyle-3.hs --hint=data/import_style.yaml -XImportQualifiedPost
+FILE tests/importStyle-3.hs
+import HypotheticalModule2 qualified
+import HypotheticalModule4 qualified as HM4
+OUTPUT
+No hints
+---------------------------------------------------------------------

--- a/tests/import_style.test
+++ b/tests/import_style.test
@@ -66,10 +66,64 @@ OUTPUT
 No hints
 
 ---------------------------------------------------------------------
-RUN tests/importStyle-3.hs --hint=data/import_style.yaml -XImportQualifiedPost
-FILE tests/importStyle-3.hs
+RUN tests/importStyle-postqual-pos.hs --hint=data/import_style.yaml -XImportQualifiedPost
+FILE tests/importStyle-postqual-pos.hs
+import HypotheticalModule1 qualified as HM1
 import HypotheticalModule2 qualified
+import HypotheticalModule2 qualified as Arbitrary
+import HypotheticalModule3 qualified
+import HypotheticalModule3 qualified as Arbitrary
 import HypotheticalModule4 qualified as HM4
+import HypotheticalModule5 qualified
+import HypotheticalModule5 qualified as HM5
 OUTPUT
 No hints
+
+---------------------------------------------------------------------
+RUN tests/importStyle-postqual-neg.hs --hint=data/import_style.yaml -XImportQualifiedPost
+FILE tests/importStyle-postqual-neg.hs
+import HypotheticalModule1 qualified
+import qualified HypotheticalModule4
+import qualified HypotheticalModule4 as Verbotten
+import qualified HypotheticalModule4 as HM4
+import HypotheticalModule5 as HM5
+import qualified HypotheticalModule5
+
+OUTPUT
+tests/importStyle-postqual-neg.hs:1:1-36: Warning: Avoid restricted alias
+Found:
+  import HypotheticalModule1 qualified
+Perhaps:
+  import HypotheticalModule1 qualified as HM1
+Note: may break the code
+
+tests/importStyle-postqual-neg.hs:2:1-36: Warning: Avoid restricted alias
+Found:
+  import qualified HypotheticalModule4
+Perhaps:
+  import qualified HypotheticalModule4 as HM4
+Note: may break the code
+
+tests/importStyle-postqual-neg.hs:3:1-49: Warning: Avoid restricted alias
+Found:
+  import qualified HypotheticalModule4 as Verbotten
+Perhaps:
+  import qualified HypotheticalModule4 as HM4
+Note: may break the code
+
+tests/importStyle-postqual-neg.hs:5:1-33: Warning: HypotheticalModule5 should be imported post-qualified
+Found:
+  import HypotheticalModule5 as HM5
+Perhaps:
+  import HypotheticalModule5 qualified as HM5
+Note: may break the code
+
+tests/importStyle-postqual-neg.hs:6:1-36: Warning: HypotheticalModule5 should be imported post-qualified
+Found:
+  import qualified HypotheticalModule5
+Perhaps:
+  import HypotheticalModule5 qualified
+Note: may break the code
+
+5 hints
 ---------------------------------------------------------------------


### PR DESCRIPTION
Hi!

I'll be brief. The bug:

```
# testcase-rule.yaml

- modules:
  - name: Data.Text
    importStyle: qualified
    qualifiedStyle: unrestricted
    asRequired: True
    as: T
```
on the single-line file:
```haskell
import Data.Text qualified as T
```

emits, erroneously, a silly hint:
```
> hlint -h testcase-rule.yaml test.hs
test.hs:1:1-31: Warning: Data.Text should be imported qualified
Found:
  import Data.Text qualified as T
Perhaps:
  import qualified Data.Text as T
Note: may break the code

1 hint
```

I submit a direct testcase for the bug, then a fix, then more tests for better regression coverage.

Hoping for easy review & merge; release isn't urgent, batch up at will :raised_hands: Thanks in advance

Fixes #1499