### PR TITLE
add hlint rule for NonEmpty.unzip

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1122,6 +1122,7 @@
     - warn: {lhs: "[] /= x", rhs: not (null x), name: Use null}
     - warn: {lhs: "\"\" /= x", rhs: not (null x), name: Use null}
     - warn: {lhs: "maybe []", rhs: foldMap}
+    - warn: {lhs: "Data.List.NonEmpty.unzip", rhs: "Data.Functor.unzip", name: "Avoid NonEmpty.unzip", note: "Because the function is being deprecated"}
 
 - group:
     name: generalise-for-conciseness


### PR DESCRIPTION
For CLC ticket [#86](https://github.com/haskell/core-libraries-committee/issues/86).