### PR TITLE
[#1477] Test GHC v9.6 In CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         ghc: ['9.6', '9.4', '9.2']
         include:
         - os: windows-latest
-          ghc: '9.4'
+          ghc: '9.6'
         - os: macOS-latest
-          ghc: '9.4'
+          ghc: '9.6'
 
     steps:
     - run: git config --global core.autocrlf false


### PR DESCRIPTION
`apply-refact` now works with GHC 9.6 so we can bring 9.6 back to CI. Runs still fail but GHC 9.6 can now get to the same failure state as the other versions :sweat_smile: 

Example run: https://github.com/prikhi/hlint/actions/runs/4969979914

Refs #1477 

---


Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
