### PR TITLE
Removed deprecated call for simulated ANSI.

### DIFF
--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -21,7 +21,7 @@ import Language.Haskell.GhclibParserEx.GHC.Driver.Session as GhclibParserEx
 import GHC.Driver.Session hiding (verbosity)
 
 import Language.Preprocessor.Cpphs
-import System.Console.ANSI(hSupportsANSIWithoutEmulation)
+import System.Console.ANSI(hSupportsANSI)
 import System.Console.CmdArgs.Explicit(helpText, HelpFormat(..))
 import System.Console.CmdArgs.Implicit
 import System.Directory.Extra
@@ -236,8 +236,8 @@ cmdUseColour cmd = do
     Always -> pure True
     Never  -> pure False
     Auto   -> do
-      supportsANSI <- hSupportsANSIWithoutEmulation stdout
-      pure $ Just True == supportsANSI && isNothing noColor
+      supportsANSI <- hSupportsANSI stdout
+      pure $ supportsANSI && isNothing noColor
 
 "." <\> x = x
 x <\> y = x </> y


### PR DESCRIPTION
hlint called  `hSupportsANSIWithoutEmulation`, which has been deprecated. The ansi-terminal package no longer supports legacy versions of windows that required emulation.