### PR TITLE
[hlint]: upgrade to ghc-lib-parser-ex-9.6.0.1

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -90,7 +90,7 @@ library
       build-depends:
           ghc-lib-parser == 9.6.*
     build-depends:
-        ghc-lib-parser-ex >= 9.6.0.0 && < 9.6.1
+        ghc-lib-parser-ex >= 9.6.0.1 && < 9.6.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,8 +5,8 @@ packages:
   - .
 
 extra-deps:
-  - ghc-lib-parser-9.6.1.20230312
-  - ghc-lib-parser-ex-9.6.0.0
+  - ghc-lib-parser-9.6.2.20230523
+  - ghc-lib-parser-ex-9.6.0.1
 # To test hlint against experimental builds of ghc-lib-parser-ex,
 # modify extra-deps like this:
 #  - archive: /users/shayne/project/ghc-lib-parser-ex/ghc-lib-parser-ex-8.10.0.18.tar.gz


### PR DESCRIPTION
upgrade to ghc-lib-parse-ex-9.6.0.1 which includes predicates that might be useful to https://github.com/ndmitchell/hlint/pull/1490