### PR TITLE
[ghc-lib-parser-ex]: bump 9.6.0.2

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -90,7 +90,7 @@ library
       build-depends:
           ghc-lib-parser == 9.6.*
     build-depends:
-        ghc-lib-parser-ex >= 9.6.0.1 && < 9.6.1
+        ghc-lib-parser-ex >= 9.6.0.2 && < 9.6.1
 
     if flag(gpl)
         build-depends: hscolour >= 1.21


### PR DESCRIPTION
references:
- https://github.com/ndmitchell/hlint/pull/1535
- https://github.com/shayne-fletcher/ghc-lib-parser-ex/pull/158