### PR TITLE
Fix CI warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Get GHC libdir
       id: get-ghc-libdir
       run: |
-        echo "::set-output name=libdir::$(ghc --print-libdir)"
+        echo "libdir=$(ghc --print-libdir)" >> $GITHUB_OUTPUT
       shell: bash
     - run: cabal v2-freeze --enable-tests
     - uses: actions/cache@v2


### PR DESCRIPTION
Fixing this warning that pops up in CI

![Screenshot from 2023-08-28 14-57-51](https://github.com/ndmitchell/hlint/assets/2716069/ea2ef12b-42e9-4be5-bcf6-9b03a6d4d175)


More info [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
