### PR TITLE
Fix partial `comments` field accesses

### DIFF
--- a/src/Apply.hs
+++ b/src/Apply.hs
@@ -17,7 +17,7 @@ import Data.Ord
 import Config.Type
 import Config.Haskell
 import GHC.Types.SrcLoc
-import GHC.Hs
+import GHC.Hs hiding (comments)
 import Language.Haskell.GhclibParserEx.GHC.Hs
 import Data.HashSet qualified as Set
 import Prelude

--- a/src/GHC/All.hs
+++ b/src/GHC/All.hs
@@ -22,7 +22,7 @@ import Fixity
 import Extension
 import GHC.Data.FastString
 
-import GHC.Hs
+import GHC.Hs hiding (comments)
 import GHC.Types.SrcLoc
 import GHC.Types.Fixity
 import GHC.Types.Error

--- a/src/GHC/Util/ApiAnnotation.hs
+++ b/src/GHC/Util/ApiAnnotation.hs
@@ -1,9 +1,15 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 
 module GHC.Util.ApiAnnotation (
-    comment_, commentText, isCommentMultiline
-  , pragmas, flags, languagePragmas
-  , mkFlags, mkLanguagePragmas
+    comment_
+  , commentText
+  , GHC.Util.ApiAnnotation.comments
+  , isCommentMultiline
+  , pragmas
+  , flags
+  , languagePragmas
+  , mkFlags
+  , mkLanguagePragmas
   , extensions
 ) where
 
@@ -44,6 +50,12 @@ comment_ (L _ (EpaComment EpaEofComment _)) = ""
 -- | The comment string with delimiters removed.
 commentText :: LEpaComment -> String
 commentText = trimCommentDelims . comment_
+
+-- | Total replacement for the partial `GHC.Parser.Annotation.comments` field of
+-- `EpAnn`
+comments :: EpAnn ann -> EpAnnComments
+comments EpAnn{ GHC.Parser.Annotation.comments = result } = result
+comments EpAnnNotUsed = emptyComments
 
 isCommentMultiline :: LEpaComment -> Bool
 isCommentMultiline (L _ (EpaComment (EpaBlockComment _) _)) = True


### PR DESCRIPTION
I've been working on reviving the `splint` project for newer versions of GHC so that we can create a GHC plugin for `hlint`.

When running `hlint` as a plugin it seems to trip up on the `comments` field of `EpAnn`, which is not always present for the AST supplied to a GHC plugin.

This change fixes that by replacing all uses of the partial `comments` field with an alternative total function.