### PR TITLE
Correct Functor law hint

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -472,11 +472,12 @@
     # FUNCTOR
 
     - warn: {lhs: fmap f (fmap g x), rhs: fmap (f . g) x, name: Functor law}
-    - warn: {lhs: f <$> g <$> x, rhs: f . g <$> x, name: Functor law}
+    - warn: {lhs: f <$> (g <$> x), rhs: f . g <$> x, name: Functor law}
     - warn: {lhs: x <&> g <&> f, rhs: x <&> f . g, name: Functor law}
     - warn: {lhs: fmap id, rhs: id, name: Functor law}
     - warn: {lhs: id <$> x, rhs: x, name: Functor law}
     - warn: {lhs: x <&> id, rhs: x, name: Functor law}
+    - warn: {lhs: f <$> g <$> x, rhs: f . g <$> x}
     - hint: {lhs: fmap f $ x, rhs: f <$> x, side: isApp x || isAtom x}
     - hint: {lhs: \x -> a <$> b x, rhs: fmap a . b}
     - hint: {lhs: \x -> b x <&> a, rhs: fmap a . b}

--- a/hints.md
+++ b/hints.md
@@ -7226,7 +7226,7 @@ fmap (f . g) x
 <td>
 LHS:
 <code>
-f <$> g <$> x
+f <$> (g <$> x)
 </code>
 <br>
 RHS:
@@ -7296,6 +7296,22 @@ x <&> id
 RHS:
 <code>
 x
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant <$></td>
+<td>
+LHS:
+<code>
+f <$> g <$> x
+</code>
+<br>
+RHS:
+<code>
+f . g <$> x
 </code>
 <br>
 </td>


### PR DESCRIPTION
`<$>` associates to the left, so `f <$> g <$> x` is equivalent to `f . g <$> x` not because of a Functor law, but because for functions `(<$>) == (.)`.

The actual Functor law was missing, so I added it.

The original hint could perhaps be generalized to `f <$> g` &mapsto; `f . g`, but I could not figure out how to express that `g` should be a function.