### PR TITLE
ignore files match ignore-glob even if it is explicit provided under arg like `--git` in cmd 

### DIFF
--- a/src/CmdLine.hs
+++ b/src/CmdLine.hs
@@ -279,7 +279,8 @@ getFile ignore (p:ath) exts t file = do
         pure [x | x <- xs, drop1 (takeExtension x) `elem` exts, not $ avoidFile x]
      else do
         isFil <- doesFileExist $ p <\> file
-        if isFil then pure [p <\> file]
+        if isFil then 
+            pure (if (ignore (p <\> file)) then [] else [p <\> file])
          else do
             res <- getModule p exts file
             case res of


### PR DESCRIPTION
It should fix problems such as with "--git:, would not ignore files matching the ignore-glob
Should fix #1552 