### PR TITLE
don't run ci workflow on the ghc-next branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 on:
   push:
+    branches-ignore:
+      - 'ghc-next'
   pull_request:
   schedule:
   - cron:  '0 3 * * 6' # 3am Saturday


### PR DESCRIPTION
don't run the ci workflow on pushes to the ghc-next branch. it is not expected to pass and wastes resources.
<img width="1025" alt="Screenshot 2024-01-27 at 5 16 10 PM" src="https://github.com/ndmitchell/hlint/assets/1500167/7a17d5b4-bda5-41b8-9ea8-2d1441df8cb1">
