### PR TITLE
generalize zip on empty lists hint

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -974,7 +974,10 @@
     - warn: {lhs: "concat []", rhs: "[]", name: Evaluate}
     - warn: {lhs: "concatMap f [a]", rhs: f a, name: Evaluate}
     - warn: {lhs: "concatMap f []", rhs: "[]", name: Evaluate}
-    - warn: {lhs: "zip [] []", rhs: "[]", name: Evaluate}
+    - warn: {lhs: "zip [] x", rhs: "[]", name: Evaluate}
+    - warn: {lhs: "zip x []", rhs: "[]", side: notEq x [], note: IncreasesLaziness, name: Evaluate}
+    - warn: {lhs: "zipWith f [] x", rhs: "[]", name: Evaluate}
+    - warn: {lhs: "zipWith f x []", rhs: "[]", side: notEq x [], note: IncreasesLaziness, name: Evaluate}
     - warn: {lhs: const x y, rhs: x, name: Evaluate}
     - warn: {lhs: any (const False), rhs: const False, note: IncreasesLaziness, name: Evaluate}
     - warn: {lhs: all (const True), rhs: const True, note: IncreasesLaziness, name: Evaluate}
@@ -1306,6 +1309,8 @@
     - warn: {lhs: "atomicModifyIORef' a (\\ v -> (b v, ()))", rhs: "atomicModifyIORef'_ a b"}
     - warn: {lhs: "null (intersect a b)", rhs: "disjoint a b"}
     - warn: {lhs: "[minBound .. maxBound]", rhs: "enumerate"}
+    - warn: {lhs: "zipFrom x []", rhs: "[]", name: Evaluate}
+    - warn: {lhs: "zipWithFrom f x []", rhs: "[]", name: Evaluate}
     - warn: {lhs: "zipWithFrom (,)", rhs: "zipFrom"}
     - warn: {lhs: "zip [i..]", rhs: "zipFrom i"}
     - warn: {lhs: "zipWith f [i..]", rhs: "zipWithFrom f i"}


### PR DESCRIPTION
Will the `notEq x []` in the side condition work as intended, or is extra "escaping" of the list brackets necessary as in `lhs` and `rhs`?