### PR TITLE
hlint-from-scratch workflow for ghc-next

### DIFF
--- a/.github/workflows/ghc-next.yml
+++ b/.github/workflows/ghc-next.yml
@@ -1,0 +1,32 @@
+name: ghc-next-from-scratch
+on:
+  push:
+    branches:
+      - 'ghc-next*'
+  schedule:
+    - cron:  '0 3 * * 5'
+jobs:
+  ghc-9-10:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+    steps:
+      - name: Install build tools
+        run: brew install automake
+        if: matrix.os == 'macos'
+      - name: Configure
+        # e.g. Don't recursively delete '.stack-work' (`stack clean --full`)
+        run: echo "GHCLIB_AZURE='1'" >> $GITHUB_ENV
+        shell: bash
+      - name: Boot
+        run: |-
+          cabal update
+          git clone https://github.com/shayne-fletcher/hlint-from-scratch.git
+          hlint-from-scratch/hlint-from-scratch.sh --init="$HOME/project"
+        shell: bash
+      - name: Build and Test ('ghc-next')
+        run: hlint-from-scratch/hlint-from-scratch.sh --ghc-flavor="" --stack-yaml=stack-exact.yaml --resolver=ghc-9.6.4 --no-checkout
+        shell: bash


### PR DESCRIPTION
this PR installs a workflow to build and test the ghc-next branch (via hlint-from-scratch).