### PR TITLE
cabal install apply-refact

### DIFF
--- a/.github/workflows/ghc-9.10.yml
+++ b/.github/workflows/ghc-9.10.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Boot
         run: |-
           cabal update
+          cabal install apply-refact
           git clone https://github.com/shayne-fletcher/hlint-from-scratch.git
           hlint-from-scratch/hlint-from-scratch.sh --init="$HOME/project"
         shell: bash


### PR DESCRIPTION
this adds a `cabal install apply-refact` step to the ghc-9.10.1 hlint-from-scratch github workflow