### PR TITLE
add setup to ghc-9.10 workflow

### DIFF
--- a/.github/workflows/ghc-9.10.yml
+++ b/.github/workflows/ghc-9.10.yml
@@ -14,6 +14,10 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
     steps:
+      - uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: 'latest'
       - name: Install build tools
         run: brew install automake
         if: matrix.os == 'macos'


### PR DESCRIPTION
since last week, macOS runners don't have a haskell toolchain preinstalled