### PR TITLE
CodeWorld: remove redundant 'translated'

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1408,6 +1408,7 @@
     - warn: {lhs: "duller (- a)", rhs: "brighter a"}
     - warn: {lhs: "darker (- a)", rhs: "lighter a"}
     - warn: {lhs: translated x y (translated u v p), rhs: translated (x + u) (y + v) p, name: Use translated once}
+    - warn: {lhs: translated 0 0 p, rhs: p}
 
 - group:
     name: teaching


### PR DESCRIPTION
I've seen students doing that, typically in the context of composing a larger picture/expression comprised of many smaller pictures being positioned by `translated` calls; and for some reason sub-pictures that need no moving are still wrapped in a "zero-only" `translated` call.