### PR TITLE
Add hints for when 'x <*> y' could be 'y'

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -513,7 +513,6 @@
     - warn: {lhs: "x <*> Last Nothing", rhs: "Last Nothing" }
     - warn: {lhs: "x <*> Left a", rhs: "Left a" }
     - warn: {lhs: "x <*> Ap []", rhs: "Ap []" }
-    - warn: {lhs: "x <*> Ap mempty", rhs: "Ap mempty" }
     - warn: {lhs: "x <*> []", rhs: "[]" }
 
     # MONAD

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -508,6 +508,13 @@
     - warn: {lhs: x <* return y, rhs: x}
     - warn: {lhs: pure x *> y, rhs: "y", name: Redundant *>}
     - warn: {lhs: return x *> y, rhs: "y", name: Redundant *>}
+    - warn: {lhs: "x <*> Nothing", rhs: "Nothing" }
+    - warn: {lhs: "x <*> First Nothing", rhs: "First Nothing" }
+    - warn: {lhs: "x <*> Last Nothing", rhs: "Last Nothing" }
+    - warn: {lhs: "x <*> Left a", rhs: "Left a" }
+    - warn: {lhs: "x <*> Ap []", rhs: "Ap []" }
+    - warn: {lhs: "x <*> Ap mempty", rhs: "Ap mempty" }
+    - warn: {lhs: "x <*> []", rhs: "[]" }
 
     # MONAD
 


### PR DESCRIPTION
I haven't added all the alternatives with `mempty` and `empty` as hlint doesn't
know about types, and there could be lawless instances out there I suppose. So
it's safer just to deal with concrete types.

```
ghci> :{
ghci| let f :: Applicative m => m (b -> (Int, b))
ghci|     f = (,) <$> pure 5
ghci| :}
ghci> f <*> mempty :: Ap [] (Int, Sum Int)
Ap {getAp = [(5,Sum {getSum = 0})]}
ghci> f <*> empty :: Ap [] (Int, Sum Int)
Ap {getAp = []}
```

Would be nice to detect the last one, but hlint can't know that it's `empty` on `Ap [] (..., Sum ...)`.
