### PR TITLE
more hints about eliminating Data.Foldable.toList

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -936,6 +936,16 @@
     - warn: {lhs: find f (Data.Foldable.toList x), rhs: find f x}
     - warn: {lhs: concat (Data.Foldable.toList x), rhs: concat x}
     - warn: {lhs: concatMap f (Data.Foldable.toList x), rhs: concatMap f x}
+    - warn: {lhs: foldrM f c (Data.Foldable.toList x), rhs: foldrM f c x}
+    - warn: {lhs: foldlM f c (Data.Foldable.toList x), rhs: foldlM f c x}
+    - warn: {lhs: traverse_ f (Data.Foldable.toList x), rhs: traverse_ f x}
+    - warn: {lhs: for_ (Data.Foldable.toList x) f, rhs: for_ x f}
+    - warn: {lhs: sequenceA_ (Data.Foldable.toList x), rhs: sequenceA_ x}
+    - warn: {lhs: asum (Data.Foldable.toList x), rhs: asum x}
+    - warn: {lhs: mapM_ f (Data.Foldable.toList x), rhs: mapM_ f x}
+    - warn: {lhs: forM_ (Data.Foldable.toList x) f, rhs: forM_ x f}
+    - warn: {lhs: sequence_ (Data.Foldable.toList x), rhs: sequence_ x}
+    - warn: {lhs: msum (Data.Foldable.toList x), rhs: msum x}
 
     # STATE MONAD
 

--- a/hints.md
+++ b/hints.md
@@ -13670,6 +13670,166 @@ concatMap f x
 <td>Warning</td>
 </tr>
 <tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+foldrM f c (Data.Foldable.toList x)
+</code>
+<br>
+RHS:
+<code>
+foldrM f c x
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+foldlM f c (Data.Foldable.toList x)
+</code>
+<br>
+RHS:
+<code>
+foldlM f c x
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+traverse_ f (Data.Foldable.toList x)
+</code>
+<br>
+RHS:
+<code>
+traverse_ f x
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+for_ (Data.Foldable.toList x) f
+</code>
+<br>
+RHS:
+<code>
+for_ x f
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+sequenceA_ (Data.Foldable.toList x)
+</code>
+<br>
+RHS:
+<code>
+sequenceA_ x
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+asum (Data.Foldable.toList x)
+</code>
+<br>
+RHS:
+<code>
+asum x
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+mapM_ f (Data.Foldable.toList x)
+</code>
+<br>
+RHS:
+<code>
+mapM_ f x
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+forM_ (Data.Foldable.toList x) f
+</code>
+<br>
+RHS:
+<code>
+forM_ x f
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+sequence_ (Data.Foldable.toList x)
+</code>
+<br>
+RHS:
+<code>
+sequence_ x
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
+<td>Redundant toList</td>
+<td>
+LHS:
+<code>
+msum (Data.Foldable.toList x)
+</code>
+<br>
+RHS:
+<code>
+msum x
+</code>
+<br>
+</td>
+<td>Warning</td>
+</tr>
+<tr>
 <td>Use gets</td>
 <td>
 LHS:


### PR DESCRIPTION
Essentially a continuation of the already merged https://github.com/ndmitchell/hlint/pull/1569.

One thing I'm unsure about: Would these hints also catch/apply to `Data.Set.toList` calls (based on the `Foldable` instance for `Set`)? Or would it be necessary to duplicate all these hints (the ones from the previous issue and these ones here) for `Data.Set.toList`?

