### PR TITLE
Allow inplace refactoring of multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,6 @@ If you're using git, it may be helpful to only run hlint on changed files. This 
 { git diff --diff-filter=d --name-only $(git merge-base HEAD origin/master) -- "***.hs" && git ls-files -o --exclude-standard -- "***.hs"; } | xargs hlint
 ```
 
-Because hlint's `--refactor` option only works when you pass a single file, this approach is also helpful to enable refactoring many files in a single command:
-
-```bash
-{ git diff --diff-filter=d --name-only $(git merge-base HEAD origin/master) -- "***.hs" && git ls-files -o --exclude-standard -- "***.hs"; } | xargs -I file hlint file --refactor --refactor-options="--inplace --step"
-```
-
 ### Configuration
 
 #### Why doesn't HLint know the fixity for my custom !@%$ operator?

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -222,7 +222,7 @@ handleRefactoring ideas files cmd@CmdMain{..} = do
             exitCode <- runRefactoring path file f enabledExtensions disabledExtensions cmdRefactorOptions
 
             case exitCode of
-              ExitSuccess   -> return ()
+              ExitSuccess   -> pure ()
               ExitFailure _ -> exitWith exitCode
 
 handleReporting :: [Idea] -> Cmd -> IO ()

--- a/src/HLint.hs
+++ b/src/HLint.hs
@@ -209,18 +209,21 @@ getIdeas cmd@CmdMain{..} settings = do
 -- #746: run refactor even if no hint, which ensures consistent output
 -- whether there are hints or not.
 handleRefactoring :: [Idea] -> [String] -> Cmd -> IO ()
-handleRefactoring ideas files cmd@CmdMain{..} =
-    case cmdFiles of
-        [file] -> do
-            -- Ensure that we can find the executable
-            path <- checkRefactor (if cmdWithRefactor == "" then Nothing else Just cmdWithRefactor)
-            -- writeFile "hlint.refact"
-            let hints =  show $ map (show &&& ideaRefactoring) ideas
-            withTempFile $ \f -> do
-                writeFile f hints
-                let ParseFlags{enabledExtensions, disabledExtensions} = cmdParseFlags cmd
-                exitWith =<< runRefactoring path file f enabledExtensions disabledExtensions cmdRefactorOptions
-        _ -> errorIO "Refactor flag can only be used with an individual file"
+handleRefactoring ideas files cmd@CmdMain{..} = do
+    -- Ensure that we can find the executable
+    path <- checkRefactor (if cmdWithRefactor == "" then Nothing else Just cmdWithRefactor)
+    forM_ cmdFiles $ \file -> do
+        -- writeFile "hlint.refact"
+        let fileIdeas = filter (\i -> file == ideaFile i) ideas
+        let hints =  show $ map (show &&& ideaRefactoring) fileIdeas
+        withTempFile $ \f -> do
+            writeFile f hints
+            let ParseFlags{enabledExtensions, disabledExtensions} = cmdParseFlags cmd
+            exitCode <- runRefactoring path file f enabledExtensions disabledExtensions cmdRefactorOptions
+
+            case exitCode of
+              ExitSuccess   -> return ()
+              ExitFailure _ -> exitWith exitCode
 
 handleReporting :: [Idea] -> Cmd -> IO ()
 handleReporting showideas cmd@CmdMain{..} = do

--- a/src/Idea.hs
+++ b/src/Idea.hs
@@ -6,6 +6,7 @@ module Idea(
     rawIdea, idea, suggest, suggestRemove, ideaRemove, warn, ignore,
     rawIdeaN, suggestN, ignoreNoSuggestion,
     showIdeasJson, showIdeaANSI,
+    ideaFile,
     Note(..), showNotes,
     Severity(..),
     ) where
@@ -16,6 +17,7 @@ import HsColour
 import Refact.Types hiding (SrcSpan)
 import Refact.Types qualified as R
 import Prelude
+import GHC.Data.FastString
 import GHC.Types.SrcLoc
 import GHC.Utils.Outputable
 import GHC.Util
@@ -35,6 +37,12 @@ data Idea = Idea
     ,ideaRefactoring :: [Refactoring R.SrcSpan] -- ^ How to perform this idea
     }
     deriving Eq
+
+ideaFile :: Idea -> String
+ideaFile idea =
+  case srcSpanFileName_maybe (ideaSpan idea) of
+    Just file -> unpackFS file
+    Nothing   -> error "SrcSpan has no associated file"
 
 -- I don't use aeson here for 2 reasons:
 -- 1) Aeson doesn't escape unicode characters, and I want to (allows me to ignore encoding)


### PR DESCRIPTION
Allow multiple files to be refactored at a time, applying ideas to each relevant file. I was bitten by this the other week at work while adding some [`pre-commit`](https://pre-commit.com/) hooks to a repository, so if it's convenient a release after approval would be appreciated :slightly_smiling_face: 

Closes https://github.com/ndmitchell/hlint/issues/1539.
