### PR TITLE
CI: Correctly label macOS bindist as ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         - os: ubuntu-20.04
           SUFFIX: x86_64-linux.tar.gz
         - os: macOS-latest
-          SUFFIX: x86_64-osx.tar.gz
+          SUFFIX: arm64-osx.tar.gz
         - os: windows-latest
           SUFFIX: x86_64-windows.zip
 


### PR DESCRIPTION
This ensures that future macOS bindists will not be inaccurately labeled as x86_64. This should avoid mixups like the one observed in #1640.
