### PR TITLE
Add "Redundant $ with block argument" hint

### DIFF
--- a/hints.md
+++ b/hints.md
@@ -74,6 +74,48 @@ foo . bar x <$> baz q
 <td>Suggestion</td>
 </tr>
 <tr>
+<td>Redundant $ with block argument</td>
+<td>
+Example: 
+<pre>
+{-# LANGUAGE BlockArguments #-} 
+a = f $ \case _ -> x
+</pre>
+Found:
+<code>
+f $ \case _ -> x
+</code>
+<br>
+Suggestion:
+<code>
+f \case _ -> x
+</code>
+<br>
+</td>
+<td>Suggestion</td>
+</tr>
+<tr>
+<td>Redundant $ with block argument</td>
+<td>
+Example: 
+<code>
+a = f $ \case _ -> x
+</code>
+<br>
+Found:
+<code>
+f $ \case _ -> x
+</code>
+<br>
+Suggestion:
+<code>
+f \case _ -> x
+</code>
+<br>
+</td>
+<td>Ignore</td>
+</tr>
+<tr>
 <td>Redundant $</td>
 <td>
 Example: 

--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -262,7 +262,7 @@ data T = MkT -- @NoRefactor: refactor requires GHC >= 9.6.1
 
 module Hint.Extensions(extensionsHint) where
 
-import Hint.Type(ModuHint,rawIdea,Severity(Warning),Note(..),toSSAnc,ghcModule,modComments,firstDeclComments)
+import Hint.Type(ModuHint,rawIdea,Severity(Warning),Note(..),toSSAnc,ghcExtensionsEnabledInModule,ghcModule,modComments,firstDeclComments)
 import Extension
 
 import Data.Generics.Uniplate.DataOnly
@@ -334,16 +334,7 @@ extensionsHint _ x =
 
     -- All the extensions defined to be used.
     extensions :: Set.Set Extension
-    extensions = Set.fromList $
-      concatMap
-      (mapMaybe readExtension . snd)
-      (languagePragmas
-        (pragmas (modComments x) ++ pragmas (firstDeclComments x)))
-      -- Comments appearing without an empty line before the first
-      -- declaration in a module are now associated with the
-      -- declaration not the module so to be safe, look also at
-      -- `firstDeclComments x`
-      -- (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9517).
+    extensions = ghcExtensionsEnabledInModule x
 
     -- Those extensions we detect to be useful.
     useful :: Set.Set Extension

--- a/src/Hint/List.hs
+++ b/src/Hint/List.hs
@@ -47,14 +47,16 @@ import Data.Generics.Uniplate.DataOnly
 import Data.List.NonEmpty qualified as NE
 import Data.List.Extra
 import Data.Maybe
+import Data.Set (member)
 import Prelude
 
-import Hint.Type(DeclHint,Idea,suggest,ignore,substVars,toRefactSrcSpan,toSSA,modComments,firstDeclComments)
+import Hint.Type(DeclHint,Idea,suggest,ignore,substVars,toRefactSrcSpan,toSSA,ghcExtensionsEnabledInModule)
 
 import Refact.Types hiding (SrcSpan)
 import Refact.Types qualified as R
 
 import GHC.Hs
+import GHC.LanguageExtensions.Type (Extension(..))
 import GHC.Types.SrcLoc
 import GHC.Types.SourceText
 import GHC.Types.Name.Reader
@@ -73,12 +75,8 @@ import Language.Haskell.GhclibParserEx.GHC.Types.Name.Reader
 listHint :: DeclHint
 listHint _ modu = listDecl overloadedListsOn
   where
-    -- Comments appearing without a line-break before the first
-    -- declaration in a module are now associated with the declaration
-    -- not the module so to be safe, look also at `firstDeclComments
-    -- modu` (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9517).
-    exts = concatMap snd (languagePragmas (pragmas (modComments modu) ++ pragmas (firstDeclComments modu)))
-    overloadedListsOn = "OverloadedLists" `elem` exts
+    exts = ghcExtensionsEnabledInModule modu
+    overloadedListsOn = OverloadedLists `member` exts
 
 listDecl :: Bool -> LHsDecl GhcPs -> [Idea]
 listDecl overloadedListsOn x =

--- a/src/Hint/NumLiteral.hs
+++ b/src/Hint/NumLiteral.hs
@@ -26,24 +26,18 @@ import GHC.Data.FastString
 import GHC.LanguageExtensions.Type (Extension (..))
 import GHC.Types.SrcLoc
 import GHC.Types.SourceText
-import GHC.Util.ApiAnnotation (extensions)
 import Data.Char (isDigit, isOctDigit, isHexDigit)
 import Data.List (intercalate)
-import Data.Set (union)
+import Data.Set (member)
 import Data.Generics.Uniplate.DataOnly (universeBi)
 import Refact.Types
 
-import Hint.Type (DeclHint, toSSA, modComments, firstDeclComments)
+import Hint.Type (DeclHint, toSSA, ghcExtensionsEnabledInModule)
 import Idea (Idea, suggest)
 
 numLiteralHint :: DeclHint
 numLiteralHint _ modu =
-  -- Comments appearing without an empty line before the first
-  -- declaration in a module are now associated with the declaration
-  -- not the module so to be safe, look also at `firstDeclComments
-  -- modu` (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9517).
-  let exts = union (extensions (modComments modu)) (extensions (firstDeclComments modu)) in
-  if NumericUnderscores `elem` exts then
+  if NumericUnderscores `member` ghcExtensionsEnabledInModule modu then
      concatMap suggestUnderscore . universeBi
   else
      const []


### PR DESCRIPTION
Unusually, this hint has two default severities:
  * Suggestion if BlockArguments is enabled in the module
  * Ignore otherwise

Either way, users can override the severity of this hint as usual.

Fixes #1547.