### PR TITLE
bugfix impliedDisables; don't drop ext on the floor

### DIFF
--- a/hlint.cabal
+++ b/hlint.cabal
@@ -90,7 +90,7 @@ library
       build-depends:
           ghc-lib-parser == 9.12.*
     build-depends:
-        ghc-lib-parser-ex >= 9.12.0.0 && < 9.13.0
+        ghc-lib-parser-ex >= 9.12 && < 9.13
 
     if flag(gpl)
         build-depends: hscolour >= 1.21

--- a/src/GHC/All.hs
+++ b/src/GHC/All.hs
@@ -174,7 +174,7 @@ impliedEnables ext = case Data.List.lookup ext extensionImplications of
 impliedDisables :: Extension -> [Extension]
 impliedDisables ext = case Data.List.lookup ext extensionImplications  of
   Just exts -> ext : snd exts
-  Nothing -> []
+  Nothing -> [ext]
 
 -- | Parse a Haskell module. Applies the C pre processor, and uses
 -- best-guess fixity resolution if there are ambiguities.  The


### PR DESCRIPTION
`impliedDisables` had a bug which allowed disabled extensions to get dropped on the floor.

this will probably fix https://github.com/ndmitchell/hlint/issues/1655 (at least in so far as `-XNoStarIsType` is now shown to be respected).

incidentally, this diff contains a fix for the currently broken CI