### PR TITLE
Remove "Avoid NonEmpty.unzip" hint (fixes #1657)

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -680,7 +680,6 @@
     - hint: {lhs: "\\x y z -> (x, y, z)", rhs: "(,,)"}
     - hint: {lhs: "(,b) a", rhs: "(a,b)", side: isAtom a, name: Evaluate}
     - hint: {lhs: "(a,) b", rhs: "(a,b)", side: isAtom b, name: Evaluate}
-    - warn: {lhs: "Data.List.NonEmpty.unzip", rhs: "Data.Functor.unzip", name: "Avoid NonEmpty.unzip", note: "The function is being deprecated"}
 
     # MAYBE
 


### PR DESCRIPTION
Fixes #1657.

`base >= 4.19` exposes `Data.Functor.unzip` and GHC emits `-Wx-data-list-nonempty-unzip` for the `NonEmpty.unzip` form (core-libraries-committee/issues/258). The hlint hint is redundant with the compiler warning, cannot be CPP-gated per `base` version, and fires even when `unzip` is imported from `Data.Functor` rather than `Data.List.NonEmpty`.

Replaces PR #1682 (closed; was inadvertently stacked on unrelated commits).