### PR TITLE
Fix: treat top-level QuasiQuote splices as using QuasiQuotes (fixes #1650)

### DIFF
--- a/src/Hint/Extensions.hs
+++ b/src/Hint/Extensions.hs
@@ -19,6 +19,8 @@ $(deriveNewtypes typeInfo)
 main = foo ''Bar --
 {-# LANGUAGE QuasiQuotes, TemplateHaskell #-} \
 f x = x + [e| x + 1 |] + [foo| x + 1 |] -- {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE QuasiQuotes #-} \
+[qq| top-level quasi-quote splice |]
 {-# LANGUAGE PatternGuards #-} \
 test = case x of _ | y <- z -> w
 {-# LANGUAGE TemplateHaskell,EmptyDataDecls #-} \
@@ -475,7 +477,7 @@ used PackageImports = hasS f
       f :: ImportDecl GhcPs -> Bool
       f ImportDecl{ideclPkgQual=RawPkgQual _} = True
       f _ = False
-used QuasiQuotes = hasS isQuasiQuoteExpr ||^ hasS isTyQuasiQuote
+used QuasiQuotes = hasS isQuasiQuoteExpr ||^ hasS isTyQuasiQuote ||^ hasS isQuasiQuoteSplice
 used ViewPatterns = hasS isPViewPat
 used InstanceSigs = hasS f
   where


### PR DESCRIPTION
Fixes #1650.

Top-level quasi-quote declarations like

```haskell
{-# LANGUAGE QuasiQuotes #-}
[qq| ... |]
```

produce an `HsSpliceD` node, not an `HsExpr`. The `used QuasiQuotes` predicate in `src/Hint/Extensions.hs` only checked `HsExpr`-level (`isQuasiQuoteExpr`) and type-level (`isTyQuasiQuote`), so the pragma was flagged as "Unused LANGUAGE pragma" even though removing it breaks the parse.

Extend the check with `isQuasiQuoteSplice`, already exported from `ghc-lib-parser-ex` and already used in the `TemplateHaskell` predicate for the complementary purpose.

Test added to `<TEST>` block in `src/Hint/Extensions.hs`. Self-test: 965 tests, all pass.