### PR TITLE
Fix: dont suggest "Use :" when OverloadedLists is enabled (fixes #1602)

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -211,7 +211,8 @@
     - hint: {lhs: any (const True) x, rhs: not (null x), name: Use null}
     - hint: {lhs: length x /= 0, rhs: not (null x), note: IncreasesLaziness, name: Use null}
     - hint: {lhs: 0 /= length x, rhs: not (null x), note: IncreasesLaziness, name: Use null}
-    - hint: {lhs: "\\x -> [x]", rhs: "(:[])", name: "Use :"}
+    # Moved to code-based hint in Hint/List.hs to skip under OverloadedLists (issue #1602)
+    # - hint: {lhs: "\\x -> [x]", rhs: "(:[])", name: "Use :"}
     - hint: {lhs: map f (zip x y), rhs: zipWith (curry f) x y, side: not (isApp f)}
     - hint: {lhs: "map f (fromMaybe [] x)", rhs: "maybe [] (map f) x"}
     - hint: {lhs: "concatMap f (fromMaybe [] x)", rhs: "maybe [] (concatMap f) x"}

--- a/src/Hint/List.hs
+++ b/src/Hint/List.hs
@@ -37,6 +37,9 @@ foo = [_ | x <- _, let _ = A{x}]
 issue1039 = foo (map f [1 | _ <- []]) -- [f 1 | _ <- []]
 {-# LANGUAGE OverloadedLists #-} \
 issue114 = True:[]
+{-# LANGUAGE OverloadedLists #-} \
+no_issue1602 = \x -> [x]
+yes_issue1602 = \x -> [x] -- (:[])
 </TEST>
 -}
 
@@ -188,6 +191,7 @@ checks overloadedListsOn = let (*) = (,) in drop1 -- see #174
   , "Use :" * useCons
   ]
   <> ["Use list literal" * useList | not overloadedListsOn ] -- see #114
+  <> ["Use :" * useConsLambda | not overloadedListsOn ] -- see #1602
 
 pchecks :: [(String, LPat GhcPs -> Maybe (LPat GhcPs, [(String, R.SrcSpan)], String))]
 pchecks = let (*) = (,) in drop1 -- see #174
@@ -262,6 +266,20 @@ useCons False (view -> App2 op x y) | varToStr op == "++"
     gen :: LHsExpr GhcPs -> LHsExpr GhcPs -> LHsExpr GhcPs
     gen x = noLocA . OpApp noExtField x (noLocA (HsVar noExtField  (noLocA consDataCon_RDR)))
 useCons _ _ = Nothing
+
+-- Suggest `(: [])` for `\x -> [x]`. Gated on `not overloadedListsOn`
+-- because under OverloadedLists the literal `[x]` can be polymorphic
+-- (e.g. Vector a, Set a, NonEmpty a), whereas `(: [])` specialises
+-- to the list type and the rewrite produces code that no longer
+-- type-checks (issue #1602).
+useConsLambda :: Bool -> LHsExpr GhcPs -> Maybe (LHsExpr GhcPs, [(String, R.SrcSpan)], String)
+useConsLambda _ (SimpleLambda [view -> PVar_ x] (L _ (ExplicitList _ [L _ (HsVar _ (L _ y))])))
+  | occNameStr y == x =
+    let consSection = noLocA (HsPar noAnn (noLocA (SectionR noExtField
+                        (noLocA (HsVar noExtField (noLocA consDataCon_RDR)))
+                        (noLocA (ExplicitList noAnn [])))))
+    in Just (consSection, [], "(: [])")
+useConsLambda _ _ = Nothing
 
 typeListChar :: LHsType GhcPs
 typeListChar =


### PR DESCRIPTION
Fixes #1602.

With `OverloadedLists`, `\x -> [x]` and `(: [])` have different types: the former produces any `IsList` instance (`Vector a`, `Set a`, `NonEmpty a`, …) while the latter specialises to `[a]`. Applying the suggestion produces code that no longer type-checks.

Move the hint from `data/hlint.yaml` into a code-based hint in `src/Hint/List.hs`, gated on `not overloadedListsOn` (same pattern as #114 for "Use list literal").

The hint still fires for `\x -> [x]` when the module does not enable `OverloadedLists`, and is suppressed per-file when it does.

Tests added to the TEST block in `src/Hint/List.hs`. Self-test: 966 tests, all pass.