### PR TITLE
Fix: qualify Data.List.map in generalise group (fixes #1572)

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1167,7 +1167,7 @@
     imports:
     - package base
     rules:
-    - warn: {lhs: map, rhs: fmap}
+    - warn: {lhs: Data.List.map, rhs: fmap}
     - warn: {lhs: a ++ b, rhs: a <> b}
     - warn: {lhs: "sequence [a]", rhs: "pure <$> a"}
     - warn: {lhs: "x /= []", rhs: not (null x), name: Use null}


### PR DESCRIPTION
## Summary

Fixes #1572. The `generalise` group rule `map -> fmap` triggers even when
`map` is a locally-bound parameter (e.g. `test map = map`). The resulting
refactoring `test map = fmap` does not compile.

Qualifying the LHS as `Data.List.map` restricts the match to the actual
library function, leaving shadowed locals alone.

## Test plan
- [ ] `test map = map` no longer triggers the suggestion under `--hint=generalise`
- [ ] `test xs = map f xs` still triggers under `--hint=generalise`