### PR TITLE
Add opt-in performance group with STM-avoidance hints

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -65,6 +65,18 @@
     modules:
     - import CodeWorld
 
+- package:
+    name: stm
+    modules:
+    - import Control.Concurrent.STM
+    - import Control.Concurrent.STM.TVar
+    - import Control.Concurrent.STM.TMVar
+    - import Control.Concurrent.STM.TChan
+    - import Control.Concurrent.STM.TQueue
+    - import Control.Concurrent.STM.TBQueue
+    - import Control.Concurrent.STM.TSem
+    - import Control.Concurrent.STM.TArray
+
 - group:
     name: default
     enabled: true
@@ -1475,6 +1487,65 @@
     - warn: {lhs: foldl1 f (reverse x), rhs: foldr1 (flip f) x, note: IncreasesLaziness, name: Use right fold instead of left fold}
     - warn: {lhs: foldr' f c (reverse x), rhs: foldl' (flip f) c x, name: Use left fold instead of right fold}
     - warn: {lhs: foldl' f c (reverse x), rhs: foldr (flip f) c x, note: IncreasesLaziness, name: Use right fold instead of left fold}
+
+- group:
+    name: performance
+    enabled: false
+    imports:
+    - package stm
+    rules:
+
+    # STM transactional variables carry per-access overhead from the
+    # transaction log, commit-time validation, and retry machinery - a
+    # cost that is unjustified when the transaction touches a single
+    # variable and needs no composition. Prefer non-transactional
+    # primitives from Data.IORef / Control.Concurrent.MVar /
+    # Control.Concurrent.Chan, which give you the same operation at a
+    # fraction of the cost.
+
+    # TVar - single-op transactions collapse to IORef
+    - warn: {lhs: atomically (readTVar v), rhs: readIORef v, name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use readIORef."}
+    - warn: {lhs: readTVarIO v, rhs: readIORef v, name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use readIORef."}
+    - warn: {lhs: atomically (writeTVar v x), rhs: atomicWriteIORef v x, name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicWriteIORef."}
+    - warn: {lhs: atomically (modifyTVar v f), rhs: "atomicModifyIORef' v (\\x -> (f x, ()))", name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicModifyIORef'."}
+    - warn: {lhs: atomically (modifyTVar' v f), rhs: "atomicModifyIORef' v (\\x -> (f x, ()))", name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicModifyIORef'."}
+    - warn: {lhs: atomically (swapTVar v x), rhs: "atomicModifyIORef' v (\\old -> (x, old))", name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicModifyIORef'."}
+    - warn: {lhs: atomically (stateTVar v f), rhs: "atomicModifyIORef' v (\\x -> let (a, s) = f x in (s, a))", name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicModifyIORef'."}
+    - warn: {lhs: newTVarIO x, rhs: newIORef x, name: "Avoid STM", note: "TVar with single-variable access - migrate to IORef and use newIORef."}
+    - warn: {lhs: atomically (newTVar x), rhs: newIORef x, name: "Avoid STM", note: "TVar with single-variable access - migrate to IORef and use newIORef."}
+
+    # TMVar - MVar is the non-transactional analogue
+    - warn: {lhs: atomically (takeTMVar v), rhs: takeMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use takeMVar."}
+    - warn: {lhs: atomically (putTMVar v x), rhs: putMVar v x, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use putMVar."}
+    - warn: {lhs: atomically (readTMVar v), rhs: readMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use readMVar."}
+    - warn: {lhs: atomically (tryTakeTMVar v), rhs: tryTakeMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use tryTakeMVar."}
+    - warn: {lhs: atomically (tryPutTMVar v x), rhs: tryPutMVar v x, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use tryPutMVar."}
+    - warn: {lhs: atomically (tryReadTMVar v), rhs: tryReadMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use tryReadMVar."}
+    - warn: {lhs: atomically (swapTMVar v x), rhs: swapMVar v x, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use swapMVar."}
+    - warn: {lhs: atomically (isEmptyTMVar v), rhs: isEmptyMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use isEmptyMVar."}
+    - warn: {lhs: newTMVarIO x, rhs: newMVar x, name: "Avoid STM", note: "Migrate to MVar and use newMVar."}
+    - warn: {lhs: newEmptyTMVarIO, rhs: newEmptyMVar, name: "Avoid STM", note: "Migrate to MVar and use newEmptyMVar."}
+    - warn: {lhs: atomically (newTMVar x), rhs: newMVar x, name: "Avoid STM", note: "Migrate to MVar and use newMVar."}
+    - warn: {lhs: atomically newEmptyTMVar, rhs: newEmptyMVar, name: "Avoid STM", note: "Migrate to MVar and use newEmptyMVar."}
+
+    # TChan - Chan is the non-transactional analogue
+    - warn: {lhs: atomically (readTChan c), rhs: readChan c, name: "Avoid STM", note: "Migrate the variable from TChan to Chan (Control.Concurrent.Chan) and use readChan."}
+    - warn: {lhs: atomically (writeTChan c x), rhs: writeChan c x, name: "Avoid STM", note: "Migrate the variable from TChan to Chan (Control.Concurrent.Chan) and use writeChan."}
+    - warn: {lhs: atomically (dupTChan c), rhs: dupChan c, name: "Avoid STM", note: "Migrate the variable from TChan to Chan (Control.Concurrent.Chan) and use dupChan."}
+    - warn: {lhs: newTChanIO, rhs: newChan, name: "Avoid STM", note: "Migrate to Chan (Control.Concurrent.Chan) and use newChan."}
+    - warn: {lhs: atomically newTChan, rhs: newChan, name: "Avoid STM", note: "Migrate to Chan (Control.Concurrent.Chan) and use newChan."}
+
+    # TQueue / TBQueue - prefer Chan (unbounded) or a dedicated bounded
+    # queue (unagi-chan / stm-chans is STM, so not a replacement); for
+    # most uses Chan is the right answer.
+    - warn: {lhs: atomically (readTQueue q), rhs: readChan q, name: "Avoid STM", note: "Migrate the variable from TQueue to Chan (Control.Concurrent.Chan) and use readChan."}
+    - warn: {lhs: atomically (writeTQueue q x), rhs: writeChan q x, name: "Avoid STM", note: "Migrate the variable from TQueue to Chan (Control.Concurrent.Chan) and use writeChan."}
+    - warn: {lhs: newTQueueIO, rhs: newChan, name: "Avoid STM", note: "Migrate to Chan (Control.Concurrent.Chan) and use newChan."}
+
+    # TSem - QSem is the non-transactional analogue
+    - warn: {lhs: atomically (waitTSem s), rhs: waitQSem s, name: "Avoid STM", note: "Migrate the variable from TSem to QSem (Control.Concurrent.QSem) and use waitQSem."}
+    - warn: {lhs: atomically (signalTSem s), rhs: signalQSem s, name: "Avoid STM", note: "Migrate the variable from TSem to QSem (Control.Concurrent.QSem) and use signalQSem."}
+    - warn: {lhs: atomically (newTSem n), rhs: newQSem n, name: "Avoid STM", note: "Migrate to QSem (Control.Concurrent.QSem) and use newQSem."}
 
 - group:
     # used for tests, enabled when testing this file

--- a/tests/flag-with-group-performance.test
+++ b/tests/flag-with-group-performance.test
@@ -1,0 +1,30 @@
+---------------------------------------------------------------------
+FILE tests/flag-with-group-performance.hs
+import Control.Concurrent.STM
+foo v x = atomically (writeTVar v x)
+bar v = atomically (takeTMVar v)
+baz c x = atomically (writeTChan c x)
+RUN "--with-group=performance" tests/flag-with-group-performance.hs
+OUTPUT
+tests/flag-with-group-performance.hs:2:11-36: Warning: Avoid STM
+Found:
+  atomically (writeTVar v x)
+Perhaps:
+  atomicWriteIORef v x
+Note: TVar with single-variable access - migrate the variable to IORef and use atomicWriteIORef.
+
+tests/flag-with-group-performance.hs:3:9-32: Warning: Avoid STM
+Found:
+  atomically (takeTMVar v)
+Perhaps:
+  takeMVar v
+Note: Migrate the variable from TMVar to MVar and use takeMVar.
+
+tests/flag-with-group-performance.hs:4:11-37: Warning: Avoid STM
+Found:
+  atomically (writeTChan c x)
+Perhaps:
+  writeChan c x
+Note: Migrate the variable from TChan to Chan (Control.Concurrent.Chan) and use writeChan.
+
+3 hints


### PR DESCRIPTION
## Summary

Add a new `performance` group (disabled by default) that flags single-primitive uses of STM where a non-transactional primitive from `Data.IORef` / `Control.Concurrent.MVar` / `Control.Concurrent.Chan` / `Control.Concurrent.QSem` gives the same operation at a fraction of the cost.

The transaction log, commit-time validation, and retry machinery are pure overhead when a transaction touches a single variable and needs no composition. Students toggle the group off (the default); users who care about per-access overhead opt in with `--with-group=performance`.

## What's covered

- **TVar**: `atomically (readTVar/writeTVar/modifyTVar/modifyTVar'/swapTVar/stateTVar v)`, `readTVarIO`, `newTVarIO` → `readIORef` / `atomicWriteIORef` / `atomicModifyIORef'` / `newIORef`.
- **TMVar**: the full `takeTMVar` / `putTMVar` / `readTMVar` / `tryTakeTMVar` / `tryPutTMVar` / `tryReadTMVar` / `swapTMVar` / `isEmptyTMVar` / `newTMVarIO` / `newEmptyTMVarIO` family → `MVar` equivalents.
- **TChan**: `readTChan` / `writeTChan` / `dupTChan` / `newTChanIO` → `Chan` equivalents.
- **TQueue**: `readTQueue` / `writeTQueue` / `newTQueueIO` → `Chan` equivalents.
- **TSem**: `waitTSem` / `signalTSem` / `newTSem` → `QSem` equivalents.

## What's deliberately *not* covered

- Multi-variable `atomically $ do { ... }` transactions.
- `retry` / `orElse` / `check`.

## Tests done

- [x] `hlint --test` — 965 tests pass.
- [x] New `tests/flag-with-group-performance.test` exercises three hints (writeTVar/takeTMVar/writeTChan) under `--with-group=performance`.
- [x] Asample module with both single-primitive STM and a multi-TVar transfer transaction: the first got eight hints, the second got zero (correct).
- [x] Default mode: only the pre-existing `readTVarIO`/`newTVarIO` hints fire (no new noise).