### PR TITLE
Extend performance group with strict IORef/State/container folds

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1547,6 +1547,21 @@
     - warn: {lhs: atomically (signalTSem s), rhs: signalQSem s, name: "Avoid STM", note: "Migrate the variable from TSem to QSem (Control.Concurrent.QSem) and use signalQSem."}
     - warn: {lhs: atomically (newTSem n), rhs: newQSem n, name: "Avoid STM", note: "Migrate to QSem (Control.Concurrent.QSem) and use newQSem."}
 
+    # Strictness: lazy left fold and scan build up thunks of depth proportional
+    # to the list length, which blows the stack on forcing. The strict variants
+    # are drop-in replacements whenever the accumulator is strict-amenable,
+    # which it almost always is in practice.
+    #
+    # Match only the list-qualified forms. Unqualified `foldl` in Prelude
+    # is Data.Foldable.foldl (Foldable-polymorphic), where the
+    # Data.List.foldl' rewrite would be ill-typed on non-list containers.
+    # Apply the same safety to scanl against future generalisations.
+    - warn: {lhs: Data.List.foldl f z x, rhs: Data.List.foldl' f z x, name: "Use foldl'"}
+    - warn: {lhs: Data.List.scanl f z x, rhs: Data.List.scanl' f z x, name: "Use scanl'"}
+
+    # Round-tripping through a list is wasted work; Data.Set.map does it in one pass.
+    - warn: {lhs: Data.Set.fromList (map f (Data.Set.toList s)), rhs: Data.Set.map f s, name: "Use Data.Set.map"}
+
 - group:
     # used for tests, enabled when testing this file
     name: testing

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1562,6 +1562,25 @@
     # Round-tripping through a list is wasted work; Data.Set.map does it in one pass.
     - warn: {lhs: Data.Set.fromList (map f (Data.Set.toList s)), rhs: Data.Set.map f s, name: "Use Data.Set.map"}
 
+    # IORef strict updates. modifyIORef / atomicModifyIORef hold onto the old
+    # thunk; the primed forms force the new value.
+    - warn: {lhs: Data.IORef.modifyIORef r f, rhs: Data.IORef.modifyIORef' r f, name: "Use modifyIORef'"}
+    - warn: {lhs: Data.IORef.atomicModifyIORef r f, rhs: Data.IORef.atomicModifyIORef' r f, name: "Use atomicModifyIORef'"}
+
+    # State monad strict update. `modify` leaves a thunk in the state; `modify'`
+    # forces it, which is almost always what you want.
+    - warn: {lhs: Control.Monad.State.modify f, rhs: Control.Monad.State.modify' f, name: "Use modify'"}
+
+    # Strict left folds over containers. The lazy `foldl` on Map/Set/IntMap/HashMap
+    # builds up a thunk chain of depth proportional to the container size.
+    - warn: {lhs: Data.Map.Strict.foldl f z m, rhs: Data.Map.Strict.foldl' f z m, name: "Use foldl'"}
+    - warn: {lhs: Data.Map.Lazy.foldl f z m, rhs: Data.Map.Lazy.foldl' f z m, name: "Use foldl'"}
+    - warn: {lhs: Data.Set.foldl f z s, rhs: Data.Set.foldl' f z s, name: "Use foldl'"}
+    - warn: {lhs: Data.IntMap.Strict.foldl f z m, rhs: Data.IntMap.Strict.foldl' f z m, name: "Use foldl'"}
+    - warn: {lhs: Data.IntMap.Lazy.foldl f z m, rhs: Data.IntMap.Lazy.foldl' f z m, name: "Use foldl'"}
+    - warn: {lhs: Data.HashMap.Strict.foldl f z m, rhs: Data.HashMap.Strict.foldl' f z m, name: "Use foldl'"}
+    - warn: {lhs: Data.HashMap.Lazy.foldl f z m, rhs: Data.HashMap.Lazy.foldl' f z m, name: "Use foldl'"}
+
 - group:
     # used for tests, enabled when testing this file
     name: testing

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -65,6 +65,18 @@
     modules:
     - import CodeWorld
 
+- package:
+    name: stm
+    modules:
+    - import Control.Concurrent.STM
+    - import Control.Concurrent.STM.TVar
+    - import Control.Concurrent.STM.TMVar
+    - import Control.Concurrent.STM.TChan
+    - import Control.Concurrent.STM.TQueue
+    - import Control.Concurrent.STM.TBQueue
+    - import Control.Concurrent.STM.TSem
+    - import Control.Concurrent.STM.TArray
+
 - group:
     name: default
     enabled: true
@@ -1475,6 +1487,65 @@
     - warn: {lhs: foldl1 f (reverse x), rhs: foldr1 (flip f) x, note: IncreasesLaziness, name: Use right fold instead of left fold}
     - warn: {lhs: foldr' f c (reverse x), rhs: foldl' (flip f) c x, name: Use left fold instead of right fold}
     - warn: {lhs: foldl' f c (reverse x), rhs: foldr (flip f) c x, note: IncreasesLaziness, name: Use right fold instead of left fold}
+
+- group:
+    name: performance
+    enabled: false
+    imports:
+    - package stm
+    rules:
+
+    # STM transactional variables carry per-access overhead from the
+    # transaction log, commit-time validation, and retry machinery - a
+    # cost that is unjustified when the transaction touches a single
+    # variable and needs no composition. Prefer non-transactional
+    # primitives from Data.IORef / Control.Concurrent.MVar /
+    # Control.Concurrent.Chan, which give you the same operation at a
+    # fraction of the cost.
+
+    # TVar - single-op transactions collapse to IORef
+    - warn: {lhs: atomically (readTVar v), rhs: readIORef v, name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use readIORef."}
+    - warn: {lhs: readTVarIO v, rhs: readIORef v, name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use readIORef."}
+    - warn: {lhs: atomically (writeTVar v x), rhs: atomicWriteIORef v x, name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicWriteIORef."}
+    - warn: {lhs: atomically (modifyTVar v f), rhs: "atomicModifyIORef' v (\\x -> (f x, ()))", name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicModifyIORef'."}
+    - warn: {lhs: atomically (modifyTVar' v f), rhs: "atomicModifyIORef' v (\\x -> (f x, ()))", name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicModifyIORef'."}
+    - warn: {lhs: atomically (swapTVar v x), rhs: "atomicModifyIORef' v (\\old -> (x, old))", name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicModifyIORef'."}
+    - warn: {lhs: atomically (stateTVar v f), rhs: "atomicModifyIORef' v (\\x -> let (a, s) = f x in (s, a))", name: "Avoid STM", note: "TVar with single-variable access - migrate the variable to IORef and use atomicModifyIORef'."}
+    - warn: {lhs: newTVarIO x, rhs: newIORef x, name: "Avoid STM", note: "TVar with single-variable access - migrate to IORef and use newIORef."}
+    - warn: {lhs: atomically (newTVar x), rhs: newIORef x, name: "Avoid STM", note: "TVar with single-variable access - migrate to IORef and use newIORef."}
+
+    # TMVar - MVar is the non-transactional analogue
+    - warn: {lhs: atomically (takeTMVar v), rhs: takeMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use takeMVar."}
+    - warn: {lhs: atomically (putTMVar v x), rhs: putMVar v x, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use putMVar."}
+    - warn: {lhs: atomically (readTMVar v), rhs: readMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use readMVar."}
+    - warn: {lhs: atomically (tryTakeTMVar v), rhs: tryTakeMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use tryTakeMVar."}
+    - warn: {lhs: atomically (tryPutTMVar v x), rhs: tryPutMVar v x, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use tryPutMVar."}
+    - warn: {lhs: atomically (tryReadTMVar v), rhs: tryReadMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use tryReadMVar."}
+    - warn: {lhs: atomically (swapTMVar v x), rhs: swapMVar v x, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use swapMVar."}
+    - warn: {lhs: atomically (isEmptyTMVar v), rhs: isEmptyMVar v, name: "Avoid STM", note: "Migrate the variable from TMVar to MVar and use isEmptyMVar."}
+    - warn: {lhs: newTMVarIO x, rhs: newMVar x, name: "Avoid STM", note: "Migrate to MVar and use newMVar."}
+    - warn: {lhs: newEmptyTMVarIO, rhs: newEmptyMVar, name: "Avoid STM", note: "Migrate to MVar and use newEmptyMVar."}
+    - warn: {lhs: atomically (newTMVar x), rhs: newMVar x, name: "Avoid STM", note: "Migrate to MVar and use newMVar."}
+    - warn: {lhs: atomically newEmptyTMVar, rhs: newEmptyMVar, name: "Avoid STM", note: "Migrate to MVar and use newEmptyMVar."}
+
+    # TChan - Chan is the non-transactional analogue
+    - warn: {lhs: atomically (readTChan c), rhs: readChan c, name: "Avoid STM", note: "Migrate the variable from TChan to Chan (Control.Concurrent.Chan) and use readChan."}
+    - warn: {lhs: atomically (writeTChan c x), rhs: writeChan c x, name: "Avoid STM", note: "Migrate the variable from TChan to Chan (Control.Concurrent.Chan) and use writeChan."}
+    - warn: {lhs: atomically (dupTChan c), rhs: dupChan c, name: "Avoid STM", note: "Migrate the variable from TChan to Chan (Control.Concurrent.Chan) and use dupChan."}
+    - warn: {lhs: newTChanIO, rhs: newChan, name: "Avoid STM", note: "Migrate to Chan (Control.Concurrent.Chan) and use newChan."}
+    - warn: {lhs: atomically newTChan, rhs: newChan, name: "Avoid STM", note: "Migrate to Chan (Control.Concurrent.Chan) and use newChan."}
+
+    # TQueue / TBQueue - prefer Chan (unbounded) or a dedicated bounded
+    # queue (unagi-chan / stm-chans is STM, so not a replacement); for
+    # most uses Chan is the right answer.
+    - warn: {lhs: atomically (readTQueue q), rhs: readChan q, name: "Avoid STM", note: "Migrate the variable from TQueue to Chan (Control.Concurrent.Chan) and use readChan."}
+    - warn: {lhs: atomically (writeTQueue q x), rhs: writeChan q x, name: "Avoid STM", note: "Migrate the variable from TQueue to Chan (Control.Concurrent.Chan) and use writeChan."}
+    - warn: {lhs: newTQueueIO, rhs: newChan, name: "Avoid STM", note: "Migrate to Chan (Control.Concurrent.Chan) and use newChan."}
+
+    # TSem - QSem is the non-transactional analogue
+    - warn: {lhs: atomically (waitTSem s), rhs: waitQSem s, name: "Avoid STM", note: "Migrate the variable from TSem to QSem (Control.Concurrent.QSem) and use waitQSem."}
+    - warn: {lhs: atomically (signalTSem s), rhs: signalQSem s, name: "Avoid STM", note: "Migrate the variable from TSem to QSem (Control.Concurrent.QSem) and use signalQSem."}
+    - warn: {lhs: atomically (newTSem n), rhs: newQSem n, name: "Avoid STM", note: "Migrate to QSem (Control.Concurrent.QSem) and use newQSem."}
 
 - group:
     # used for tests, enabled when testing this file

--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1547,6 +1547,21 @@
     - warn: {lhs: atomically (signalTSem s), rhs: signalQSem s, name: "Avoid STM", note: "Migrate the variable from TSem to QSem (Control.Concurrent.QSem) and use signalQSem."}
     - warn: {lhs: atomically (newTSem n), rhs: newQSem n, name: "Avoid STM", note: "Migrate to QSem (Control.Concurrent.QSem) and use newQSem."}
 
+    # Strictness: lazy left fold and scan build up thunks of depth proportional
+    # to the list length, which blows the stack on forcing. The strict variants
+    # are drop-in replacements whenever the accumulator is strict-amenable,
+    # which it almost always is in practice.
+    #
+    # Match only the list-qualified forms. Unqualified `foldl` in Prelude
+    # is Data.Foldable.foldl (Foldable-polymorphic), where the
+    # Data.List.foldl' rewrite would be ill-typed on non-list containers.
+    # Apply the same safety to scanl against future generalisations.
+    - warn: {lhs: Data.List.foldl f z x, rhs: Data.List.foldl' f z x, name: "Use foldl'", note: "May be stricter"}
+    - warn: {lhs: Data.List.scanl f z x, rhs: Data.List.scanl' f z x, name: "Use scanl'", note: "May be stricter"}
+
+    # Round-tripping through a list is wasted work; Data.Set.map does it in one pass.
+    - warn: {lhs: Data.Set.fromList (map f (Data.Set.toList s)), rhs: Data.Set.map f s, name: "Use Data.Set.map"}
+
 - group:
     # used for tests, enabled when testing this file
     name: testing

--- a/tests/flag-with-group-performance-strict.test
+++ b/tests/flag-with-group-performance-strict.test
@@ -1,0 +1,28 @@
+---------------------------------------------------------------------
+FILE tests/flag-with-group-performance-strict.hs
+import qualified Data.List as L
+import qualified Data.Set as Set
+go f z xs = print (L.foldl f z xs)
+go2 f z xs = print (L.scanl f z xs)
+doubled f s = Set.fromList (map f (Set.toList s))
+RUN "--with-group=performance" tests/flag-with-group-performance-strict.hs
+OUTPUT
+tests/flag-with-group-performance-strict.hs:3:20-33: Warning: Use foldl'
+Found:
+  L.foldl f z xs
+Perhaps:
+  L.foldl' f z xs
+
+tests/flag-with-group-performance-strict.hs:4:21-34: Warning: Use scanl'
+Found:
+  L.scanl f z xs
+Perhaps:
+  L.scanl' f z xs
+
+tests/flag-with-group-performance-strict.hs:5:15-49: Warning: Use Data.Set.map
+Found:
+  Set.fromList (map f (Set.toList s))
+Perhaps:
+  Set.map f s
+
+3 hints

--- a/tests/flag-with-group-performance-strict.test
+++ b/tests/flag-with-group-performance-strict.test
@@ -2,27 +2,81 @@
 FILE tests/flag-with-group-performance-strict.hs
 import qualified Data.List as L
 import qualified Data.Set as Set
+import qualified Data.IORef as IORef
+import qualified Control.Monad.State as State
+import qualified Data.Map.Strict as MS
+import qualified Data.IntMap.Strict as IMS
+import qualified Data.HashMap.Strict as Map
 go f z xs = print (L.foldl f z xs)
 go2 f z xs = print (L.scanl f z xs)
 doubled f s = Set.fromList (map f (Set.toList s))
+mio r f = print (IORef.modifyIORef r f)
+amio r f = print (IORef.atomicModifyIORef r f)
+stm f = print (State.modify f)
+fms f z m = print (MS.foldl f z m)
+fs f z s = print (Set.foldl f z s)
+fims f z m = print (IMS.foldl f z m)
+fhms f z m = print (Map.foldl f z m)
 RUN "--with-group=performance" tests/flag-with-group-performance-strict.hs
 OUTPUT
-tests/flag-with-group-performance-strict.hs:3:20-33: Warning: Use foldl'
+tests/flag-with-group-performance-strict.hs:8:20-33: Warning: Use foldl'
 Found:
   L.foldl f z xs
 Perhaps:
   L.foldl' f z xs
 
-tests/flag-with-group-performance-strict.hs:4:21-34: Warning: Use scanl'
+tests/flag-with-group-performance-strict.hs:9:21-34: Warning: Use scanl'
 Found:
   L.scanl f z xs
 Perhaps:
   L.scanl' f z xs
 
-tests/flag-with-group-performance-strict.hs:5:15-49: Warning: Use Data.Set.map
+tests/flag-with-group-performance-strict.hs:10:15-49: Warning: Use Data.Set.map
 Found:
   Set.fromList (map f (Set.toList s))
 Perhaps:
   Set.map f s
 
-3 hints
+tests/flag-with-group-performance-strict.hs:11:18-38: Warning: Use modifyIORef'
+Found:
+  IORef.modifyIORef r f
+Perhaps:
+  IORef.modifyIORef' r f
+
+tests/flag-with-group-performance-strict.hs:12:19-45: Warning: Use atomicModifyIORef'
+Found:
+  IORef.atomicModifyIORef r f
+Perhaps:
+  IORef.atomicModifyIORef' r f
+
+tests/flag-with-group-performance-strict.hs:13:16-29: Warning: Use modify'
+Found:
+  State.modify f
+Perhaps:
+  State.modify' f
+
+tests/flag-with-group-performance-strict.hs:14:20-33: Warning: Use foldl'
+Found:
+  MS.foldl f z m
+Perhaps:
+  MS.foldl' f z m
+
+tests/flag-with-group-performance-strict.hs:15:19-33: Warning: Use foldl'
+Found:
+  Set.foldl f z s
+Perhaps:
+  Set.foldl' f z s
+
+tests/flag-with-group-performance-strict.hs:16:21-35: Warning: Use foldl'
+Found:
+  IMS.foldl f z m
+Perhaps:
+  IMS.foldl' f z m
+
+tests/flag-with-group-performance-strict.hs:17:21-35: Warning: Use foldl'
+Found:
+  Map.foldl f z m
+Perhaps:
+  Map.foldl' f z m
+
+10 hints

--- a/tests/flag-with-group-performance-strict.test
+++ b/tests/flag-with-group-performance-strict.test
@@ -2,29 +2,83 @@
 FILE tests/flag-with-group-performance-strict.hs
 import qualified Data.List as L
 import qualified Data.Set as Set
+import qualified Data.IORef as IORef
+import qualified Control.Monad.State as State
+import qualified Data.Map.Strict as MS
+import qualified Data.IntMap.Strict as IMS
+import qualified Data.HashMap.Strict as Map
 go f z xs = print (L.foldl f z xs)
 go2 f z xs = print (L.scanl f z xs)
 doubled f s = Set.fromList (map f (Set.toList s))
+mio r f = print (IORef.modifyIORef r f)
+amio r f = print (IORef.atomicModifyIORef r f)
+stm f = print (State.modify f)
+fms f z m = print (MS.foldl f z m)
+fs f z s = print (Set.foldl f z s)
+fims f z m = print (IMS.foldl f z m)
+fhms f z m = print (Map.foldl f z m)
 RUN "--with-group=performance" tests/flag-with-group-performance-strict.hs
 OUTPUT
-tests/flag-with-group-performance-strict.hs:3:20-33: Warning: Use foldl'
+tests/flag-with-group-performance-strict.hs:8:20-33: Warning: Use foldl'
 Found:
   L.foldl f z xs
 Perhaps:
   L.foldl' f z xs
 Note: May be stricter
 
-tests/flag-with-group-performance-strict.hs:4:21-34: Warning: Use scanl'
+tests/flag-with-group-performance-strict.hs:9:21-34: Warning: Use scanl'
 Found:
   L.scanl f z xs
 Perhaps:
   L.scanl' f z xs
 Note: May be stricter
 
-tests/flag-with-group-performance-strict.hs:5:15-49: Warning: Use Data.Set.map
+tests/flag-with-group-performance-strict.hs:10:15-49: Warning: Use Data.Set.map
 Found:
   Set.fromList (map f (Set.toList s))
 Perhaps:
   Set.map f s
 
-3 hints
+tests/flag-with-group-performance-strict.hs:11:18-38: Warning: Use modifyIORef'
+Found:
+  IORef.modifyIORef r f
+Perhaps:
+  IORef.modifyIORef' r f
+
+tests/flag-with-group-performance-strict.hs:12:19-45: Warning: Use atomicModifyIORef'
+Found:
+  IORef.atomicModifyIORef r f
+Perhaps:
+  IORef.atomicModifyIORef' r f
+
+tests/flag-with-group-performance-strict.hs:13:16-29: Warning: Use modify'
+Found:
+  State.modify f
+Perhaps:
+  State.modify' f
+
+tests/flag-with-group-performance-strict.hs:14:20-33: Warning: Use foldl'
+Found:
+  MS.foldl f z m
+Perhaps:
+  MS.foldl' f z m
+
+tests/flag-with-group-performance-strict.hs:15:19-33: Warning: Use foldl'
+Found:
+  Set.foldl f z s
+Perhaps:
+  Set.foldl' f z s
+
+tests/flag-with-group-performance-strict.hs:16:21-35: Warning: Use foldl'
+Found:
+  IMS.foldl f z m
+Perhaps:
+  IMS.foldl' f z m
+
+tests/flag-with-group-performance-strict.hs:17:21-35: Warning: Use foldl'
+Found:
+  Map.foldl f z m
+Perhaps:
+  Map.foldl' f z m
+
+10 hints

--- a/tests/flag-with-group-performance-strict.test
+++ b/tests/flag-with-group-performance-strict.test
@@ -1,0 +1,30 @@
+---------------------------------------------------------------------
+FILE tests/flag-with-group-performance-strict.hs
+import qualified Data.List as L
+import qualified Data.Set as Set
+go f z xs = print (L.foldl f z xs)
+go2 f z xs = print (L.scanl f z xs)
+doubled f s = Set.fromList (map f (Set.toList s))
+RUN "--with-group=performance" tests/flag-with-group-performance-strict.hs
+OUTPUT
+tests/flag-with-group-performance-strict.hs:3:20-33: Warning: Use foldl'
+Found:
+  L.foldl f z xs
+Perhaps:
+  L.foldl' f z xs
+Note: May be stricter
+
+tests/flag-with-group-performance-strict.hs:4:21-34: Warning: Use scanl'
+Found:
+  L.scanl f z xs
+Perhaps:
+  L.scanl' f z xs
+Note: May be stricter
+
+tests/flag-with-group-performance-strict.hs:5:15-49: Warning: Use Data.Set.map
+Found:
+  Set.fromList (map f (Set.toList s))
+Perhaps:
+  Set.map f s
+
+3 hints

--- a/tests/flag-with-group-performance.test
+++ b/tests/flag-with-group-performance.test
@@ -1,0 +1,30 @@
+---------------------------------------------------------------------
+FILE tests/flag-with-group-performance.hs
+import Control.Concurrent.STM
+foo v x = atomically (writeTVar v x)
+bar v = atomically (takeTMVar v)
+baz c x = atomically (writeTChan c x)
+RUN "--with-group=performance" tests/flag-with-group-performance.hs
+OUTPUT
+tests/flag-with-group-performance.hs:2:11-36: Warning: Avoid STM
+Found:
+  atomically (writeTVar v x)
+Perhaps:
+  atomicWriteIORef v x
+Note: TVar with single-variable access - migrate the variable to IORef and use atomicWriteIORef.
+
+tests/flag-with-group-performance.hs:3:9-32: Warning: Avoid STM
+Found:
+  atomically (takeTMVar v)
+Perhaps:
+  takeMVar v
+Note: Migrate the variable from TMVar to MVar and use takeMVar.
+
+tests/flag-with-group-performance.hs:4:11-37: Warning: Avoid STM
+Found:
+  atomically (writeTChan c x)
+Perhaps:
+  writeChan c x
+Note: Migrate the variable from TChan to Chan (Control.Concurrent.Chan) and use writeChan.
+
+3 hints


### PR DESCRIPTION
Layered on top of #1691 (performance-strictness). Merge that one first —
this PR's diff will collapse to its own commit once it lands.

Adds strict-variant rewrites for the remaining high-value targets in
the opt-in `performance` group. All matches use fully-qualified module
names so they fire only on the specific lazy variants users imported
(no risk of hitting polymorphic/Foldable instances).

## Rules added

- `Data.IORef.modifyIORef` / `atomicModifyIORef` → primed forms
- `Control.Monad.State.modify` → `modify'`
- `Data.{Map.Strict, Map.Lazy, Set, IntMap.Strict, IntMap.Lazy, HashMap.Strict, HashMap.Lazy}.foldl` → `foldl'`

## Tests

- [x] `cabal build`
- [x] `hlint --test` — 966 tests pass
- [x] Manual verification: each rule fires on its exact qualified form only