### PR TITLE
Extend performance group with list-length anti-pattern hints

### DIFF
--- a/data/hlint.yaml
+++ b/data/hlint.yaml
@@ -1477,6 +1477,34 @@
     - warn: {lhs: foldl' f c (reverse x), rhs: foldr (flip f) c x, note: IncreasesLaziness, name: Use right fold instead of left fold}
 
 - group:
+    name: performance
+    enabled: false
+    imports:
+    - package base
+    rules:
+
+    # Lazy-list O(n) spine-forcing anti-patterns. On a lazy list, walking
+    # the full cons spine just to compute a cheaper property (or build
+    # an intermediate list we then discard) is wasteful and fails to
+    # terminate on infinite inputs. The `length x == 0 / > 0 / <= 0 / ...`
+    # family is already covered in the default group; the rules below
+    # cover the remaining list-spine anti-patterns.
+
+    # `map f (reverse x)` builds the reversed cons spine first, then
+    # walks it again under `map`. Swapping the order keeps the same
+    # result but lets `reverse` traverse the already-mapped spine,
+    # matching the existing "Move reverse out" family in the default
+    # group (filter, mapMaybe, catMaybes, lefts, rights).
+    - warn: {lhs: map f (reverse x), rhs: reverse (map f x), name: "Move reverse out"}
+
+    # `head (map f xs)` and `last (map f xs)` allocate the whole mapped
+    # cons spine even though only one element is ever consumed.
+    # Applying `f` directly to the chosen element sidesteps the
+    # intermediate list and its cons cells.
+    - warn: {lhs: head (map f x), rhs: f (head x), name: "Avoid building intermediate list"}
+    - warn: {lhs: last (map f x), rhs: f (last x), name: "Avoid building intermediate list"}
+
+- group:
     # used for tests, enabled when testing this file
     name: testing
     enabled: false

--- a/tests/flag-with-group-performance-length.test
+++ b/tests/flag-with-group-performance-length.test
@@ -1,0 +1,27 @@
+---------------------------------------------------------------------
+FILE tests/flag-with-group-performance-length.hs
+module Verify (a, b, c) where
+a fn xs = map fn (reverse xs)
+b fn xs = head (map fn xs)
+c fn xs = last (map fn xs)
+RUN "--with-group=performance" tests/flag-with-group-performance-length.hs
+OUTPUT
+tests/flag-with-group-performance-length.hs:2:11-29: Warning: Move reverse out
+Found:
+  map fn (reverse xs)
+Perhaps:
+  reverse (map fn xs)
+
+tests/flag-with-group-performance-length.hs:3:11-26: Warning: Avoid building intermediate list
+Found:
+  head (map fn xs)
+Perhaps:
+  fn (head xs)
+
+tests/flag-with-group-performance-length.hs:4:11-26: Warning: Avoid building intermediate list
+Found:
+  last (map fn xs)
+Perhaps:
+  fn (last xs)
+
+3 hints


### PR DESCRIPTION
Three new opt-in warnings in the `performance` group targeting lazy-list
O(n) spine-forcing anti-patterns that are not covered by the existing
default-group length/null hints.

## Summary

- `map f (reverse x)` -> `reverse (map f x)` -- extends the existing
  "Move reverse out" family (filter, mapMaybe, catMaybes, lefts,
  rights) to cover `map`, avoiding one intermediate cons spine.
- `head (map f x)` -> `f (head x)` -- drops the fully-allocated mapped
  cons spine when only the first element is consumed.
- `last (map f x)` -> `f (last x)` -- same idea for the last element.

The default group already covers `length x {==,>,>=,<,<=,/=} {0,1}` and
`reverse (reverse x)`; these three hints address the remaining common
spine-forcing patterns.

## Independence

This PR is intentionally independent of other in-flight `performance`
group proposals (STM-avoidance, strictness/roundtrip, IORef/State/
container folds). If one of those merges first, this branch simply
extends the existing `performance` group rather than introducing it; if
it merges first, those branches extend the group introduced here. The
three rules added here do not overlap in name, LHS, or RHS with any
rule in those other branches.

## Activation

```
hlint --with-group=performance FILE.hs
```

## Test plan

- [x] `cabal build` succeeds
- [x] `hlint --test` passes (965 hints, up from 964)
- [x] New test file `tests/flag-with-group-performance-length.test`
      covers all three rules; exact column ranges verified
- [x] Rules do not fire without `--with-group=performance` (opt-in)
- [x] No conflict with existing default-group rules on length/null/reverse
