### PR TITLE
#1637, add a typeApplications option for restricted functions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Changelog for HLint (* = breaking change)
+    #1637, add a typeApplications option for restricted functions
     #1660, Allow "Avoid lambda" to trigger in more cases
     #1659, disable f <$> (g <$> x) ==> f . g <$> x, and x <&> g <&> f ==> x <&> f . g
 3.10, released 2024-02-02

--- a/README.md
+++ b/README.md
@@ -441,9 +441,21 @@ For restricted functions you can also control visible type applications with `ty
 
 This flags any call to `show` that omits a visible type argument, any call to `fromIntegral` with fewer than two type arguments (both `a` and `b` in `fromIntegral :: (Integral a, Num b) => a -> b` need to be fixed), and any call to `id` that has one. It also works on constructors in patterns.
 
+A type argument of `@_` does not count towards `required`, since it leaves the type just as inferred as writing no type argument at all, so `fromIntegral @_ @_` is still flagged. It does count towards `forbidden`, which asks that no visible type application is written at all.
+
+Only positions that can carry a visible type application are checked, so a name appearing in a type signature, a class method signature, a record field declaration or a binder is never flagged.
+
 You can match on module names using [glob](https://en.wikipedia.org/wiki/Glob_(programming))-style wildcards. Module names are treated like file paths, except that periods in module names are like directory separators in file paths. So `**.*Spec` will match `Spec`, `PreludeSpec`, `Data.ListSpec`, and many more. But `*Spec` won't match `Data.ListSpec` because of the separator. See [the filepattern library](https://hackage.haskell.org/package/filepattern) for a more thorough description of the matching.
 
 Restrictions are unified between wildcard and specific matches. With `asRequired`, `importStyle` and `qualifiedStyle` fields, the more specific option takes precedence. The list fields are merged. With multiple wildcard matches, the precedence between them is not guaranteed (but in practice, names are sorted in the reverse lexicograpic order, and the first one wins -- which hopefully means the more specific one more often than not)
+
+The `typeApplications` field is the exception: when several rules match one name, the last-declared one wins. Merging is no use here, because a name cannot sensibly both require and forbid a type application, so the rules for `fromList` below leave `Data.Map.fromList` forbidden from carrying one:
+
+```yaml
+- functions:
+  - {name: Data.Map.fromList, typeApplications: required}
+  - {name: fromList, typeApplications: forbidden}
+```
 
 If the same module is specified multiple times, for `asRequired`, `importStyle`
 and `qualifiedStyle` fields, only the first definition will take effect.

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ This flags any call to `show` that omits a visible type argument, any call to `f
 
 A type argument of `@_` does not count towards `required`, since it leaves the type just as inferred as writing no type argument at all, so `fromIntegral @_ @_` is still flagged. It does count towards `forbidden`, which asks that no visible type application is written at all.
 
-Only positions that can carry a visible type application are checked, so a name appearing in a type signature, a class method signature, a record field declaration or a binder is never flagged.
+Only positions that can carry a visible type application are checked. A name appearing in a type signature, a class method signature, a record field declaration or a binder is never flagged, and neither is an operator used infix or in a section, or a constructor pattern that is not in prefix form. So ``a `seq` b`` and `Rec{}` are left alone, while `(<+>)` and `Rec a` are checked.
 
 You can match on module names using [glob](https://en.wikipedia.org/wiki/Glob_(programming))-style wildcards. Module names are treated like file paths, except that periods in module names are like directory separators in file paths. So `**.*Spec` will match `Spec`, `PreludeSpec`, `Data.ListSpec`, and many more. But `*Spec` won't match `Data.ListSpec` because of the separator. See [the filepattern library](https://hackage.haskell.org/package/filepattern) for a more thorough description of the matching.
 

--- a/README.md
+++ b/README.md
@@ -430,6 +430,17 @@ This:
 * Requires that `Unsafe` must always be imported qualified, and can't be aliased.
 * Forbids `import qualified Prelude` and `import Prelude qualified` (with or without explicit import list).
 
+For restricted functions you can also control visible type applications with `typeApplications`, set to `'required'`, `'forbidden'`, or an integer giving the minimum number of type arguments required:
+
+```yaml
+- functions:
+  - {name: show, typeApplications: required}
+  - {name: fromIntegral, typeApplications: 2}
+  - {name: id, typeApplications: forbidden}
+```
+
+This flags any call to `show` that omits a visible type argument, any call to `fromIntegral` with fewer than two type arguments (both `a` and `b` in `fromIntegral :: (Integral a, Num b) => a -> b` need to be fixed), and any call to `id` that has one. It also works on constructors in patterns.
+
 You can match on module names using [glob](https://en.wikipedia.org/wiki/Glob_(programming))-style wildcards. Module names are treated like file paths, except that periods in module names are like directory separators in file paths. So `**.*Spec` will match `Spec`, `PreludeSpec`, `Data.ListSpec`, and many more. But `*Spec` won't match `Data.ListSpec` because of the separator. See [the filepattern library](https://hackage.haskell.org/package/filepattern) for a more thorough description of the matching.
 
 Restrictions are unified between wildcard and specific matches. With `asRequired`, `importStyle` and `qualifiedStyle` fields, the more specific option takes precedence. The list fields are merged. With multiple wildcard matches, the precedence between them is not guaranteed (but in practice, names are sorted in the reverse lexicograpic order, and the first one wins -- which hopefully means the more specific one more often than not)

--- a/data/type_applications.yaml
+++ b/data/type_applications.yaml
@@ -1,0 +1,8 @@
+- functions:
+  - {name: show, typeApplications: required}
+  - {name: fromIntegral, typeApplications: 2}
+  - {name: id, typeApplications: forbidden}
+  - {name: Just, typeApplications: required}
+  - {name: Left, typeApplications: forbidden}
+  - {name: Data.Map.fromList, typeApplications: required}
+  - {name: Data.Set.fromList, typeApplications: forbidden}

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -9,7 +9,7 @@
 module Config.Type(
     Severity(..), Classify(..), HintRule(..), Note(..), Setting(..),
     Restrict(..), RestrictType(..), RestrictIdents(..), SmellType(..),
-    RestrictImportStyle(..), QualifiedStyle(..),
+    RestrictImportStyle(..), QualifiedStyle(..), RestrictTypeApp(..),
     defaultHintName, isUnifyVar, showNotes, getSeverity, getRestrictType, getSmellType
     ) where
 
@@ -153,6 +153,19 @@ data QualifiedStyle
   | QualifiedStyleUnrestricted
   deriving Show
 
+data RestrictTypeApp
+  = TypeAppRequired Int -- ^ at least this many visible type applications (>= 1)
+  | TypeAppForbidden -- ^ no visible type applications
+  deriving (Eq, Show)
+
+instance Semigroup RestrictTypeApp where
+  TypeAppRequired a <> TypeAppRequired b = TypeAppRequired (max a b)
+  TypeAppForbidden <> TypeAppForbidden = TypeAppForbidden
+  -- If a function is both required and forbidden to carry a type application
+  -- (e.g. via overlapping rules), requiring one wins.
+  TypeAppRequired a <> TypeAppForbidden = TypeAppRequired a
+  TypeAppForbidden <> TypeAppRequired a = TypeAppRequired a
+
 data Restrict = Restrict
     {restrictType :: RestrictType
     ,restrictDefault :: Bool
@@ -161,6 +174,7 @@ data Restrict = Restrict
     ,restrictAsRequired :: Alt Maybe Bool -- for RestrictModule only
     ,restrictImportStyle :: Alt Maybe RestrictImportStyle -- for RestrictModule only
     ,restrictQualifiedStyle :: Alt Maybe QualifiedStyle -- for RestrictModule only
+    ,restrictTypeApp :: Maybe RestrictTypeApp -- for RestrictFunction only
     ,restrictWithin :: [(String, String)]
     ,restrictIdents :: RestrictIdents -- for RestrictModule only, what identifiers can be imported from it
     ,restrictMessage :: Maybe String

--- a/src/Config/Type.hs
+++ b/src/Config/Type.hs
@@ -156,15 +156,7 @@ data QualifiedStyle
 data RestrictTypeApp
   = TypeAppRequired Int -- ^ at least this many visible type applications (>= 1)
   | TypeAppForbidden -- ^ no visible type applications
-  deriving (Eq, Show)
-
-instance Semigroup RestrictTypeApp where
-  TypeAppRequired a <> TypeAppRequired b = TypeAppRequired (max a b)
-  TypeAppForbidden <> TypeAppForbidden = TypeAppForbidden
-  -- If a function is both required and forbidden to carry a type application
-  -- (e.g. via overlapping rules), requiring one wins.
-  TypeAppRequired a <> TypeAppForbidden = TypeAppRequired a
-  TypeAppForbidden <> TypeAppRequired a = TypeAppRequired a
+  deriving Show
 
 data Restrict = Restrict
     {restrictType :: RestrictType

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -343,7 +343,7 @@ parseRestrict restrictType v = do
         Just def -> do
             b <- parseBool def
             allowFields v ["default"]
-            pure $ Restrict restrictType b [] mempty mempty mempty mempty [] NoRestrictIdents Nothing
+            pure $ Restrict restrictType b [] mempty mempty mempty mempty Nothing [] NoRestrictIdents Nothing
         Nothing -> do
             restrictName <- parseFieldOpt "name" v >>= maybe (pure []) parseArrayString
             restrictWithin <- parseFieldOpt "within" v >>= maybe (pure [("","")]) (parseArray >=> concatMapM parseWithin)
@@ -361,7 +361,15 @@ parseRestrict restrictType v = do
               , ("post"        , QualifiedStylePost)
               , ("unrestricted", QualifiedStyleUnrestricted)
               ]
-
+            restrictTypeApp <- parseFieldOpt "typeApplications" v >>= maybe (pure Nothing) (\val ->
+              let bad = parseFail val "typeApplications must be 'required', 'forbidden', or an integer >= 1" in
+              case getVal val of
+                Number{} -> do
+                  n <- parseInt val
+                  if n < 1 then bad else pure $ Just $ TypeAppRequired n
+                String "required" -> pure $ Just $ TypeAppRequired 1
+                String "forbidden" -> pure $ Just TypeAppForbidden
+                _ -> bad)
 
             restrictBadIdents <- parseFieldOpt "badidents" v
             restrictOnlyAllowedIdents <- parseFieldOpt "only" v
@@ -375,9 +383,10 @@ parseRestrict restrictType v = do
             restrictMessage <- parseFieldOpt "message" v >>= maybeParse parseString
             allowFields v $
                 ["name", "within", "message"] ++
-                if restrictType == RestrictModule
-                    then ["as", "asRequired", "importStyle", "qualifiedStyle", "badidents", "only"]
-                    else []
+                case restrictType of
+                    RestrictModule -> ["as", "asRequired", "importStyle", "qualifiedStyle", "badidents", "only"]
+                    RestrictFunction -> ["typeApplications"]
+                    _ -> []
             pure Restrict{restrictDefault=True,..}
 
 parseWithin :: Val -> Parser [(String, String)] -- (module, decl)

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -32,6 +32,7 @@ import Data.Maybe
 import Data.List.NonEmpty qualified as NE
 import Data.List.Extra
 import Data.Tuple.Extra
+import Control.Applicative
 import Control.Monad.Extra
 import Data.Text qualified as T
 import Data.Vector qualified as V
@@ -364,8 +365,10 @@ parseRestrict restrictType v = do
             restrictTypeApp <- parseFieldOpt "typeApplications" v >>= maybe (pure Nothing) (\val ->
               let bad = parseFail val "typeApplications must be 'required', 'forbidden', or an integer >= 1" in
               case getVal val of
+                -- 'parseInt' rejects a fractional number with a message of its
+                -- own, which does not name the field it came from.
                 Number{} -> do
-                  n <- parseInt val
+                  n <- parseInt val <|> bad
                   if n < 1 then bad else pure $ Just $ TypeAppRequired n
                 String "required" -> pure $ Just $ TypeAppRequired 1
                 String "forbidden" -> pure $ Just TypeAppForbidden

--- a/src/Config/Yaml.hs
+++ b/src/Config/Yaml.hs
@@ -386,7 +386,8 @@ parseRestrict restrictType v = do
                 case restrictType of
                     RestrictModule -> ["as", "asRequired", "importStyle", "qualifiedStyle", "badidents", "only"]
                     RestrictFunction -> ["typeApplications"]
-                    _ -> []
+                    RestrictExtension -> []
+                    RestrictFlag -> []
             pure Restrict{restrictDefault=True,..}
 
 parseWithin :: Val -> Parser [(String, String)] -- (module, decl)

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -91,7 +91,7 @@ instance Semigroup RestrictItem where
 -- distinguish functions with the same name.
 -- For example, this allows us to have separate rules for "Data.Map.fromList" and "Data.Set.fromList".
 -- Using newtype rather than type because we want to define (<>) as 'Map.unionWith (<>)'.
-newtype RestrictFunction = RestrictFun (Map.Map (Maybe String) ([(String, String)], Maybe String))
+newtype RestrictFunction = RestrictFun (Map.Map (Maybe String) ([(String, String)], Maybe String, Maybe RestrictTypeApp))
 
 instance Semigroup RestrictFunction where
     RestrictFun m1 <> RestrictFun m2 = RestrictFun (Map.unionWith (<>) m1 m2)
@@ -104,7 +104,7 @@ restrictions settings = (rFunction, rOthers)
     where
         (map snd -> rfs, ros) = partition ((== RestrictFunction) . fst) [(restrictType x, x) | SettingRestrict x <- settings]
         rFunction = (all restrictDefault rfs, Map.fromListWith (<>) [mkRf s r | r <- rfs, s <- restrictName r])
-        mkRf s Restrict{..} = (name, RestrictFun $ Map.singleton modu (restrictWithin, restrictMessage))
+        mkRf s Restrict{..} = (name, RestrictFun $ Map.singleton modu (restrictWithin, restrictMessage, restrictTypeApp))
           where
             -- Parse module and name from s. module = Nothing if the rule is unqualified.
             (modu, name) = first (fmap NonEmpty.init . NonEmpty.nonEmpty) (breakEnd (== '.') s)
@@ -271,14 +271,72 @@ importListToIdents =
 
 checkFunctions :: Scope -> String -> [LHsDecl GhcPs] -> RestrictFunctions -> [Idea]
 checkFunctions scope modu decls (def, mp) =
-    [ (ideaMessage message $ ideaNoTo $ warn "Avoid restricted function" (reLoc x) (reLoc x) []){ideaDecl = [dname]}
+    [ (ideaMessage message $ ideaNoTo $ warn hint (reLoc x) (reLoc x) []){ideaDecl = [dname]}
     | d <- decls
     , let dname = fromMaybe "" (declName d)
     , x <- universeBi d :: [LocatedN RdrName]
     , let xMods = possModules scope x
-    , let (withins, message) = fromMaybe ([("","") | def], Nothing) (findFunction mp x xMods)
-    , not $ within modu dname withins
+    , let (withins, message, typeApp) = fromMaybe ([("","") | def], Nothing, Nothing) (findFunction mp x xMods)
+    , hint <- maybeToList $ restrictFunctionHint modu dname withins typeApp typeAppCounts bindingSpans x
     ]
+  where
+    typeAppCounts = typeApplicationCounts decls
+    bindingSpans = bindingNameSpans decls
+
+-- | The hint to emit for a use of a (possibly) restricted function, or
+-- 'Nothing' if the use is allowed. A 'within' violation takes precedence over a
+-- visible type application violation.
+restrictFunctionHint
+    :: String -> String -> [(String, String)] -> Maybe RestrictTypeApp
+    -> Map.Map SrcSpanD Int -> Set.Set SrcSpanD -> LocatedN RdrName -> Maybe String
+restrictFunctionHint modu dname withins typeApp typeAppCounts bindingSpans x
+    | not $ within modu dname withins = Just "Avoid restricted function"
+    -- The defining occurrence of a function (e.g. a 'Show' instance's 'show')
+    -- cannot carry a visible type application, so never require one there.
+    | sp `Set.member` bindingSpans = Nothing
+    | otherwise = case typeApp of
+        Just (TypeAppRequired n) | count < n -> Just "Use visible type application"
+        Just TypeAppForbidden    | count > 0 -> Just "Avoid visible type application"
+        _ -> Nothing
+  where
+    sp = SrcSpanD (locA (getLoc x))
+    count = Map.findWithDefault 0 sp typeAppCounts
+
+-- | Source spans of the names bound by function bindings (including class and
+-- instance method definitions), so that defining occurrences are not mistaken
+-- for uses by the visible-type-application check.
+bindingNameSpans :: [LHsDecl GhcPs] -> Set.Set SrcSpanD
+bindingNameSpans decls = Set.fromList
+    [ SrcSpanD (locA (getLoc fid))
+    | FunBind{fun_id = fid} <- universeBi decls :: [HsBindLR GhcPs GhcPs]
+    ]
+
+-- | A map from the source span of a name to the number of visible type
+-- applications attached to it. Each @\@T@ is a separate 'HsAppType' node (or an
+-- element of a constructor pattern's type-argument list), and every node in an
+-- application chain shares the head name's source span, so summing gives the
+-- count.
+typeApplicationCounts :: [LHsDecl GhcPs] -> Map.Map SrcSpanD Int
+typeApplicationCounts decls = Map.fromListWith (+) $
+    [ (SrcSpanD (locA (getLoc h)), 1)
+    | L _ (HsAppType _ fun _) <- universeBi decls :: [LHsExpr GhcPs]
+    , Just h <- [typeAppHead fun]
+    ] ++
+    [ (SrcSpanD (locA (getLoc name)), length tyArgs)
+    | L _ (ConPat _ name (PrefixCon tyArgs _)) <- universeBi decls :: [LPat GhcPs]
+    , not $ null tyArgs
+    ]
+
+-- | The head name of an application chain, looking through value and type
+-- applications and parentheses. Only walks the function spine, never into
+-- arguments, so applications of distinct functions don't interfere.
+typeAppHead :: LHsExpr GhcPs -> Maybe (LocatedN RdrName)
+typeAppHead = \case
+    L _ (HsVar _ name)      -> Just name
+    L _ (HsApp _ fun _)     -> typeAppHead fun
+    L _ (HsAppType _ fun _) -> typeAppHead fun
+    L _ (HsPar _ fun)       -> typeAppHead fun
+    _                       -> Nothing
 
 -- Returns Just iff there are rules for x, which are either unqualified, or qualified with a module that is
 -- one of x's possible modules.
@@ -288,7 +346,7 @@ findFunction
     :: Map.Map String RestrictFunction
     -> LocatedN RdrName
     -> [ModuleName]
-    -> Maybe ([(String, String)], Maybe String)
+    -> Maybe ([(String, String)], Maybe String, Maybe RestrictTypeApp)
 findFunction restrictMap (rdrNameStr -> x) (map moduleNameString -> possMods) = do
     (RestrictFun mp) <- Map.lookup x restrictMap
     n <- NonEmpty.nonEmpty . Map.elems $ Map.filterWithKey (const . maybe True (`elem` possMods)) mp

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -91,7 +91,12 @@ instance Semigroup RestrictItem where
 -- distinguish functions with the same name.
 -- For example, this allows us to have separate rules for "Data.Map.fromList" and "Data.Set.fromList".
 -- Using newtype rather than type because we want to define (<>) as 'Map.unionWith (<>)'.
-newtype RestrictFunction = RestrictFun (Map.Map (Maybe String) ([(String, String)], Maybe String, Maybe RestrictTypeApp))
+-- The 'Int' is the position of the rule in the settings, so that when several
+-- rules restrict the type applications of one name, the last-declared one wins
+-- rather than some arbitrary function of the two. Withins and messages still
+-- merge, because a name can sensibly be allowed in the union of two places but
+-- cannot sensibly both require and forbid a type application.
+newtype RestrictFunction = RestrictFun (Map.Map (Maybe String) ([(String, String)], Maybe String, Maybe (Max (Arg Int RestrictTypeApp))))
 
 instance Semigroup RestrictFunction where
     RestrictFun m1 <> RestrictFun m2 = RestrictFun (Map.unionWith (<>) m1 m2)
@@ -103,8 +108,8 @@ restrictions :: [Setting] -> (RestrictFunctions, OtherRestrictItems)
 restrictions settings = (rFunction, rOthers)
     where
         (map snd -> rfs, ros) = partition ((== RestrictFunction) . fst) [(restrictType x, x) | SettingRestrict x <- settings]
-        rFunction = (all restrictDefault rfs, Map.fromListWith (<>) [mkRf s r | r <- rfs, s <- restrictName r])
-        mkRf s Restrict{..} = (name, RestrictFun $ Map.singleton modu (restrictWithin, restrictMessage, restrictTypeApp))
+        rFunction = (all restrictDefault rfs, Map.fromListWith (<>) [mkRf i s r | (i, r) <- zipFrom 0 rfs, s <- restrictName r])
+        mkRf i s Restrict{..} = (name, RestrictFun $ Map.singleton modu (restrictWithin, restrictMessage, Max . Arg i <$> restrictTypeApp))
           where
             -- Parse module and name from s. module = Nothing if the rule is unqualified.
             (modu, name) = first (fmap NonEmpty.init . NonEmpty.nonEmpty) (breakEnd (== '.') s)
@@ -277,55 +282,92 @@ checkFunctions scope modu decls (def, mp) =
     , x <- universeBi d :: [LocatedN RdrName]
     , let xMods = possModules scope x
     , let (withins, message, typeApp) = fromMaybe ([("","") | def], Nothing, Nothing) (findFunction mp x xMods)
-    , hint <- maybeToList $ restrictFunctionHint modu dname withins typeApp typeAppCounts bindingSpans x
+    , hint <- maybeToList $ restrictFunctionHint modu dname withins typeApp typeAppCounts typeAppSites x
     ]
   where
     typeAppCounts = typeApplicationCounts decls
-    bindingSpans = bindingNameSpans decls
+    typeAppSites = typeApplicationSites decls
+
+-- | How many visible type applications a name carries. A wildcard argument is
+-- still a visible type application, but it fixes nothing, so the two numbers
+-- differ for @fromIntegral \@_ \@_@ and the two restrictions ask about
+-- different ones.
+data TypeAppCount = TypeAppCount
+    {typeAppWritten :: !Int -- ^ every @\@T@, wildcards included
+    ,typeAppFixed :: !Int -- ^ only those that actually fix a type
+    }
+
+noTypeApps :: TypeAppCount
+noTypeApps = TypeAppCount {typeAppWritten = 0, typeAppFixed = 0}
+
+addTypeAppCounts :: TypeAppCount -> TypeAppCount -> TypeAppCount
+addTypeAppCounts c1 c2 = TypeAppCount
+    {typeAppWritten = typeAppWritten c1 + typeAppWritten c2
+    ,typeAppFixed = typeAppFixed c1 + typeAppFixed c2
+    }
 
 -- | The hint to emit for a use of a (possibly) restricted function, or
 -- 'Nothing' if the use is allowed. A 'within' violation takes precedence over a
 -- visible type application violation.
 restrictFunctionHint
     :: String -> String -> [(String, String)] -> Maybe RestrictTypeApp
-    -> Map.Map SrcSpanD Int -> Set.Set SrcSpanD -> LocatedN RdrName -> Maybe String
-restrictFunctionHint modu dname withins typeApp typeAppCounts bindingSpans x
+    -> Map.Map SrcSpanD TypeAppCount -> Set.Set SrcSpanD -> LocatedN RdrName -> Maybe String
+restrictFunctionHint modu dname withins typeApp typeAppCounts typeAppSites x
     | not $ within modu dname withins = Just "Avoid restricted function"
-    -- The defining occurrence of a function (e.g. a 'Show' instance's 'show')
-    -- cannot carry a visible type application, so never require one there.
-    | sp `Set.member` bindingSpans = Nothing
+    | not $ sp `Set.member` typeAppSites = Nothing
     | otherwise = case typeApp of
-        Just (TypeAppRequired n) | count < n -> Just "Use visible type application"
-        Just TypeAppForbidden    | count > 0 -> Just "Avoid visible type application"
+        Just (TypeAppRequired n) | typeAppFixed count < n -> Just "Use visible type application"
+        Just TypeAppForbidden | typeAppWritten count > 0 -> Just "Avoid visible type application"
         _ -> Nothing
   where
     sp = SrcSpanD (locA (getLoc x))
-    count = Map.findWithDefault 0 sp typeAppCounts
+    count = Map.findWithDefault noTypeApps sp typeAppCounts
 
--- | Source spans of the names bound by function bindings (including class and
--- instance method definitions), so that defining occurrences are not mistaken
--- for uses by the visible-type-application check.
-bindingNameSpans :: [LHsDecl GhcPs] -> Set.Set SrcSpanD
-bindingNameSpans decls = Set.fromList
-    [ SrcSpanD (locA (getLoc fid))
-    | FunBind{fun_id = fid} <- universeBi decls :: [HsBindLR GhcPs GhcPs]
+-- | Source spans of the names that can carry a visible type application: the
+-- head of an expression, and a constructor in a pattern. Every other occurrence
+-- of a name -- a type signature, a class method signature, a record field, a
+-- binder -- is somewhere no type application can be written, so demanding one
+-- there would be advice that cannot be followed.
+--
+-- Note that this does not resolve local binders, so a locally bound name that
+-- shadows a restricted one is still treated as a use of it.
+typeApplicationSites :: [LHsDecl GhcPs] -> Set.Set SrcSpanD
+typeApplicationSites decls = Set.fromList $
+    [ SrcSpanD (locA (getLoc name))
+    | L _ (HsVar _ name) <- universeBi decls :: [LHsExpr GhcPs]
+    ] ++
+    [ SrcSpanD (locA (getLoc name))
+    | L _ (ConPat _ name _) <- universeBi decls :: [LPat GhcPs]
     ]
 
--- | A map from the source span of a name to the number of visible type
--- applications attached to it. Each @\@T@ is a separate 'HsAppType' node (or an
--- element of a constructor pattern's type-argument list), and every node in an
--- application chain shares the head name's source span, so summing gives the
--- count.
-typeApplicationCounts :: [LHsDecl GhcPs] -> Map.Map SrcSpanD Int
-typeApplicationCounts decls = Map.fromListWith (+) $
-    [ (SrcSpanD (locA (getLoc h)), 1)
-    | L _ (HsAppType _ fun _) <- universeBi decls :: [LHsExpr GhcPs]
+-- | A map from the source span of a name to the visible type applications
+-- attached to it. Each @\@T@ is a separate 'HsAppType' node (or an element of a
+-- constructor pattern's type-argument list), and every node in an application
+-- chain shares the head name's source span, so summing gives the count.
+typeApplicationCounts :: [LHsDecl GhcPs] -> Map.Map SrcSpanD TypeAppCount
+typeApplicationCounts decls = Map.fromListWith addTypeAppCounts $
+    [ (SrcSpanD (locA (getLoc h)), countTypeApps [ty])
+    | L _ (HsAppType _ fun (HsWC _ ty)) <- universeBi decls :: [LHsExpr GhcPs]
     , Just h <- [typeAppHead fun]
     ] ++
-    [ (SrcSpanD (locA (getLoc name)), length tyArgs)
+    [ (SrcSpanD (locA (getLoc name)), countTypeApps [t | HsConPatTyArg _ (HsTP _ t) <- tyArgs])
     | L _ (ConPat _ name (PrefixCon tyArgs _)) <- universeBi decls :: [LPat GhcPs]
     , not $ null tyArgs
     ]
+
+-- | A wildcard argument, as in @fromIntegral \@_ \@_@, leaves the type just as
+-- inferred as writing no type argument at all, so it is written but fixes
+-- nothing.
+countTypeApps :: [LHsType GhcPs] -> TypeAppCount
+countTypeApps tys = TypeAppCount
+    {typeAppWritten = length tys
+    ,typeAppFixed = length $ filter (not . isWildcardTy) tys
+    }
+  where
+    isWildcardTy :: LHsType GhcPs -> Bool
+    isWildcardTy = \case
+        L _ HsWildCardTy{} -> True
+        _ -> False
 
 -- | The head name of an application chain, looking through value and type
 -- applications and parentheses. Only walks the function spine, never into
@@ -341,7 +383,7 @@ typeAppHead = \case
 -- Returns Just iff there are rules for x, which are either unqualified, or qualified with a module that is
 -- one of x's possible modules.
 -- If there are multiple matching rules (e.g., there's both an unqualified version and a qualified version), their
--- withins and messages are concatenated with (<>).
+-- withins and messages are concatenated with (<>), and the last-declared type application restriction wins.
 findFunction
     :: Map.Map String RestrictFunction
     -> LocatedN RdrName
@@ -350,4 +392,5 @@ findFunction
 findFunction restrictMap (rdrNameStr -> x) (map moduleNameString -> possMods) = do
     (RestrictFun mp) <- Map.lookup x restrictMap
     n <- NonEmpty.nonEmpty . Map.elems $ Map.filterWithKey (const . maybe True (`elem` possMods)) mp
-    pure (sconcat n)
+    let (withins, message, typeApp) = sconcat n
+    pure (withins, message, (\(Max (Arg _ restrictTypeApp)) -> restrictTypeApp) <$> typeApp)

--- a/src/Hint/Restrict.hs
+++ b/src/Hint/Restrict.hs
@@ -324,21 +324,43 @@ restrictFunctionHint modu dname withins typeApp typeAppCounts typeAppSites x
     count = Map.findWithDefault noTypeApps sp typeAppCounts
 
 -- | Source spans of the names that can carry a visible type application: the
--- head of an expression, and a constructor in a pattern. Every other occurrence
--- of a name -- a type signature, a class method signature, a record field, a
--- binder -- is somewhere no type application can be written, so demanding one
--- there would be advice that cannot be followed.
+-- head of an expression, and a constructor in a prefix pattern. Every other
+-- occurrence of a name -- a type signature, a class method signature, a record
+-- field, a binder -- is somewhere no type application can be written, so
+-- demanding one there would be advice that cannot be followed.
+--
+-- An operator in infix position or in a section is excluded for the same
+-- reason: @a \`seq\` b@ can only carry one after being restructured into
+-- @seq \@T a b@, and a hint asking for that is asking for the wrong thing.
+-- Parenthesised, as in @(\<+\>)@, the operator is back in prefix position and
+-- does count.
 --
 -- Note that this does not resolve local binders, so a locally bound name that
 -- shadows a restricted one is still treated as a use of it.
 typeApplicationSites :: [LHsDecl GhcPs] -> Set.Set SrcSpanD
-typeApplicationSites decls = Set.fromList $
-    [ SrcSpanD (locA (getLoc name))
-    | L _ (HsVar _ name) <- universeBi decls :: [LHsExpr GhcPs]
-    ] ++
-    [ SrcSpanD (locA (getLoc name))
-    | L _ (ConPat _ name _) <- universeBi decls :: [LPat GhcPs]
-    ]
+typeApplicationSites decls = Set.difference sites infixOperators
+  where
+    sites :: Set.Set SrcSpanD
+    sites = Set.fromList $
+        [ SrcSpanD (locA (getLoc name))
+        | L _ (HsVar _ name) <- universeBi decls :: [LHsExpr GhcPs]
+        ] ++
+        [ SrcSpanD (locA (getLoc name))
+        | L _ (ConPat _ name PrefixCon{}) <- universeBi decls :: [LPat GhcPs]
+        ]
+
+    infixOperators :: Set.Set SrcSpanD
+    infixOperators = Set.fromList
+        [ SrcSpanD (locA (getLoc name))
+        | L _ (HsVar _ name) <- concatMap operator (universeBi decls :: [LHsExpr GhcPs])
+        ]
+
+    operator :: LHsExpr GhcPs -> [LHsExpr GhcPs]
+    operator = \case
+        L _ (OpApp _ _ op _) -> [op]
+        L _ (SectionL _ _ op) -> [op]
+        L _ (SectionR _ op _) -> [op]
+        _ -> []
 
 -- | A map from the source span of a name to the visible type applications
 -- attached to it. Each @\@T@ is a separate 'HsAppType' node (or an element of a

--- a/tests/type_applications.test
+++ b/tests/type_applications.test
@@ -97,17 +97,209 @@ Note: may break the code
 
 1 hint
 ---------------------------------------------------------------------
-RUN tests/typeAppsConflict.hs --hint=data/type_applications.yaml --only="Use visible type application"
-FILE tests/typeAppsConflict.hs
+RUN tests/typeAppsForbiddenLast.hs --hint=tests/typeAppsForbiddenLast.yaml --only="Use visible type application" --only="Avoid visible type application"
+FILE tests/typeAppsForbiddenLast.yaml
+- functions:
+  - {name: Data.Map.fromList, typeApplications: required}
+  - {name: Data.Set.fromList, typeApplications: forbidden}
+FILE tests/typeAppsForbiddenLast.hs
 {-# LANGUAGE TypeApplications #-}
-module TypeAppsConflict where
+module TypeAppsForbiddenLast where
 import Data.Map
 import Data.Set
 x = fromList [(1, 2)]
+y = fromList @Int [1]
 OUTPUT
-tests/typeAppsConflict.hs:5:5-12: Warning: Use visible type application
+tests/typeAppsForbiddenLast.hs:6:5-12: Warning: Avoid visible type application
 Found:
   fromList
 Note: may break the code
 
 1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsRequiredLast.hs --hint=tests/typeAppsRequiredLast.yaml --only="Use visible type application" --only="Avoid visible type application"
+FILE tests/typeAppsRequiredLast.yaml
+- functions:
+  - {name: Data.Set.fromList, typeApplications: forbidden}
+  - {name: Data.Map.fromList, typeApplications: required}
+FILE tests/typeAppsRequiredLast.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsRequiredLast where
+import Data.Map
+import Data.Set
+x = fromList [(1, 2)]
+y = fromList @Int [1]
+OUTPUT
+tests/typeAppsRequiredLast.hs:5:5-12: Warning: Use visible type application
+Found:
+  fromList
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsUnqualifiedLast.hs --hint=tests/typeAppsUnqualifiedLast.yaml --only="Use visible type application" --only="Avoid visible type application"
+FILE tests/typeAppsUnqualifiedLast.yaml
+- functions:
+  - {name: Data.Map.fromList, typeApplications: required}
+  - {name: fromList, typeApplications: forbidden}
+FILE tests/typeAppsUnqualifiedLast.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsUnqualifiedLast where
+import Data.Map
+x = fromList [(1, 2)]
+y = fromList @Int [1]
+OUTPUT
+tests/typeAppsUnqualifiedLast.hs:5:5-12: Warning: Avoid visible type application
+Found:
+  fromList
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsQualifiedLast.hs --hint=tests/typeAppsQualifiedLast.yaml --only="Use visible type application" --only="Avoid visible type application"
+FILE tests/typeAppsQualifiedLast.yaml
+- functions:
+  - {name: fromList, typeApplications: forbidden}
+  - {name: Data.Map.fromList, typeApplications: required}
+FILE tests/typeAppsQualifiedLast.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsQualifiedLast where
+import Data.Map
+x = fromList [(1, 2)]
+y = fromList @Int [1]
+OUTPUT
+tests/typeAppsQualifiedLast.hs:4:5-12: Warning: Use visible type application
+Found:
+  fromList
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsWildcards.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsWildcards.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsWildcards where
+
+-- A wildcard leaves the type just as inferred as writing no type argument at
+-- all, so it does not count towards the two that 'fromIntegral' requires.
+a = fromIntegral @_ @_ (1 :: Int)
+b = fromIntegral @Int @_ (1 :: Int)
+c = fromIntegral @Int @Integer (1 :: Int)
+OUTPUT
+tests/typeAppsWildcards.hs:6:5-16: Warning: Use visible type application
+Found:
+  fromIntegral
+Note: may break the code
+
+tests/typeAppsWildcards.hs:7:5-16: Warning: Use visible type application
+Found:
+  fromIntegral
+Note: may break the code
+
+2 hints
+---------------------------------------------------------------------
+RUN tests/typeAppsWildcardPattern.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsWildcardPattern.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsWildcardPattern where
+
+f (Just @_ x) = x
+g (Just @Int x) = x
+OUTPUT
+tests/typeAppsWildcardPattern.hs:4:4-7: Warning: Use visible type application
+Found:
+  Just
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsWildcardForbidden.hs --hint=data/type_applications.yaml --only="Avoid visible type application"
+FILE tests/typeAppsWildcardForbidden.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsWildcardForbidden where
+
+-- '@_' is still a visible type application, so 'forbidden' still flags it.
+d = id @_ (1 :: Int)
+OUTPUT
+tests/typeAppsWildcardForbidden.hs:5:5-6: Warning: Avoid visible type application
+Found:
+  id
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsDeclSites.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsDeclSites.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsDeclSites where
+
+-- A visible type application cannot be written in any of these positions, so
+-- requiring one here would be advice that cannot be followed.
+data Wrap = Wrap {show :: Int}
+
+class C a where
+  show :: a -> String
+
+show :: Int -> String
+show = undefined
+OUTPUT
+No hints
+---------------------------------------------------------------------
+RUN tests/typeAppsLists.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsLists.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsLists (show, Wrap(show)) where
+import Prelude (show)
+
+data Wrap = Wrap {show :: Int}
+OUTPUT
+No hints
+---------------------------------------------------------------------
+RUN tests/typeAppsBinder.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsBinder.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsBinder where
+
+-- The binder is not a use. The 'show' in the body is the locally bound one, but
+-- HLint does not resolve local binders, so it is still flagged, exactly as the
+-- pre-existing "Avoid restricted function" check flags it.
+f show = show (1 :: Int)
+OUTPUT
+tests/typeAppsBinder.hs:7:10-13: Warning: Use visible type application
+Found:
+  show
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsUses.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsUses.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsUses where
+
+a = show
+b = map show [1 :: Int]
+c = (. show)
+d x = x `seq` show x
+OUTPUT
+tests/typeAppsUses.hs:4:5-8: Warning: Use visible type application
+Found:
+  show
+Note: may break the code
+
+tests/typeAppsUses.hs:5:9-12: Warning: Use visible type application
+Found:
+  show
+Note: may break the code
+
+tests/typeAppsUses.hs:6:8-11: Warning: Use visible type application
+Found:
+  show
+Note: may break the code
+
+tests/typeAppsUses.hs:7:15-18: Warning: Use visible type application
+Found:
+  show
+Note: may break the code
+
+4 hints

--- a/tests/type_applications.test
+++ b/tests/type_applications.test
@@ -343,3 +343,20 @@ Found:
 Note: may break the code
 
 2 hints
+---------------------------------------------------------------------
+RUN tests/typeAppsBadInt.hs --hint=tests/typeAppsBadInt.yaml
+FILE tests/typeAppsBadInt.yaml
+- functions:
+  - {name: show, typeApplications: 2.5}
+FILE tests/typeAppsBadInt.hs
+module TypeAppsBadInt where
+OUTPUT
+user error (Failed to read YAML configuration file tests/typeAppsBadInt.yaml
+  Aeson exception:
+Error in $: Error when decoding YAML, typeApplications must be 'required', 'forbidden', or an integer >= 1
+Along path: root 0 functions 0 typeApplications
+When at: Number
+- functions:
+  - name: show
+    typeApplications: 2.5
+)

--- a/tests/type_applications.test
+++ b/tests/type_applications.test
@@ -303,3 +303,43 @@ Found:
 Note: may break the code
 
 4 hints
+---------------------------------------------------------------------
+RUN tests/typeAppsInfix.hs --hint=tests/typeAppsInfix.yaml --only="Use visible type application"
+FILE tests/typeAppsInfix.yaml
+- functions:
+  - {name: seq, typeApplications: required}
+  - {name: "<+>", typeApplications: required}
+  - {name: ":+", typeApplications: required}
+  - {name: Rec, typeApplications: required}
+FILE tests/typeAppsInfix.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsInfix where
+
+data Rec = Rec {recA :: Int}
+data Pair = Int :+ Int
+
+-- An operator used infix or in a section, and a constructor pattern that is not
+-- in prefix form, cannot carry a visible type application. Writing one means
+-- restructuring the expression, which is not what the hint is asking for.
+f a b = a `seq` b
+g a b = a <+> b
+h a = (a <+>)
+i a = (<+> a)
+j (x :+ y) = x
+k Rec{} = 1
+
+-- Parenthesised, the operator is back in prefix position and can carry one.
+l = (<+>)
+m (Rec a) = a
+OUTPUT
+tests/typeAppsInfix.hs:18:5-9: Warning: Use visible type application
+Found:
+  <+>
+Note: may break the code
+
+tests/typeAppsInfix.hs:19:4-6: Warning: Use visible type application
+Found:
+  Rec
+Note: may break the code
+
+2 hints

--- a/tests/type_applications.test
+++ b/tests/type_applications.test
@@ -1,0 +1,113 @@
+---------------------------------------------------------------------
+RUN tests/typeAppsShow.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsShow.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsShow where
+
+a x = show x
+b x = show @Int x
+OUTPUT
+tests/typeAppsShow.hs:4:7-10: Warning: Use visible type application
+Found:
+  show
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsFromIntegral.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsFromIntegral.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsFromIntegral where
+
+a = fromIntegral (1 :: Int)
+b = fromIntegral @Int (1 :: Int)
+c = fromIntegral @Int @Integer (1 :: Int)
+OUTPUT
+tests/typeAppsFromIntegral.hs:4:5-16: Warning: Use visible type application
+Found:
+  fromIntegral
+Note: may break the code
+
+tests/typeAppsFromIntegral.hs:5:5-16: Warning: Use visible type application
+Found:
+  fromIntegral
+Note: may break the code
+
+2 hints
+---------------------------------------------------------------------
+RUN tests/typeAppsForbidden.hs --hint=data/type_applications.yaml --only="Avoid visible type application"
+FILE tests/typeAppsForbidden.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsForbidden where
+
+a x = id @Int x
+b x = id x
+OUTPUT
+tests/typeAppsForbidden.hs:4:7-8: Warning: Avoid visible type application
+Found:
+  id
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsRequiredPattern.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsRequiredPattern.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsRequiredPattern where
+
+f (Just x) = x
+g (Just @Int x) = x
+OUTPUT
+tests/typeAppsRequiredPattern.hs:4:4-7: Warning: Use visible type application
+Found:
+  Just
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsForbiddenPattern.hs --hint=data/type_applications.yaml --only="Avoid visible type application"
+FILE tests/typeAppsForbiddenPattern.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsForbiddenPattern where
+
+f (Left @Int x) = x
+g (Left x) = x
+OUTPUT
+tests/typeAppsForbiddenPattern.hs:4:4-7: Warning: Avoid visible type application
+Found:
+  Left
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsShowInstance.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsShowInstance.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsShowInstance where
+
+newtype Secret = Secret String
+instance Show Secret where
+  show _ = show @String "<secret>"
+f x = show x
+OUTPUT
+tests/typeAppsShowInstance.hs:7:7-10: Warning: Use visible type application
+Found:
+  show
+Note: may break the code
+
+1 hint
+---------------------------------------------------------------------
+RUN tests/typeAppsConflict.hs --hint=data/type_applications.yaml --only="Use visible type application"
+FILE tests/typeAppsConflict.hs
+{-# LANGUAGE TypeApplications #-}
+module TypeAppsConflict where
+import Data.Map
+import Data.Set
+x = fromList [(1, 2)]
+OUTPUT
+tests/typeAppsConflict.hs:5:5-12: Warning: Use visible type application
+Found:
+  fromList
+Note: may break the code
+
+1 hint


### PR DESCRIPTION
Revives #1667 (closed stale), addressing #1637.

Function restrictions gain a `typeApplications` field, so a silent change to an inferred type can't change behaviour unnoticed:

```yaml
- functions:
  - {name: show, typeApplications: required}     # >= 1 type argument
  - {name: fromIntegral, typeApplications: 2}    # >= N type arguments
  - {name: id, typeApplications: forbidden}      # none
```

Also applies to constructors in prefix patterns (`Just @Int x`).

### Semantics

- Only positions that can carry a type application are checked: expression heads and prefix constructor patterns. Type signatures, class method signatures, record fields, binders, infix operators and sections are never flagged, since the advice couldn't be followed there.
- `@_` doesn't count towards `required`, since it leaves the type as inferred as writing nothing — `fromIntegral @_ @_` is still flagged. It does count towards `forbidden`.
- When several rules match one name the last-declared wins. Merging is no use: a name can't both require and forbid a type application.

### Testing

`hlint --test` passes. `tests/type_applications.test` covers required/forbidden/count, constructor patterns, each non-call position above, wildcards in both modes, and conflicting rules in both declaration orders.

### Changes since review

Per @zliu41's review:

- the check no longer fires in positions that can't carry a type application (type signatures, class method signatures, record fields, binders, infix operators, sections)
- `@_` no longer counts towards `required`, so `fromIntegral @_ @_` is flagged
- overlapping rules resolve by last-declared, rather than an arbitrary merge
- tests for each of the above, including the qualified/unqualified `fromList` case in both declaration orders

---
Written by Claude, reviewed and signed-off on by @NorfairKing
