### PR TITLE
#1701, add a "Redundant module qualifier" hint

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Changelog for HLint (* = breaking change)
+    #1701, add a "Redundant module qualifier" hint, suggesting Map instead of Map.Map
     #1660, Allow "Avoid lambda" to trigger in more cases
     #1659, disable f <$> (g <$> x) ==> f . g <$> x, and x <&> g <&> f ==> x <&> f . g
 3.10, released 2024-02-02

--- a/hints.md
+++ b/hints.md
@@ -1487,6 +1487,38 @@ Suggestion:
 </tr>
 </table>
 
+## Builtin Stutter
+
+<table>
+<tr>
+<th>Hint Name</th>
+<th>Hint</th>
+<th>Severity</th>
+</tr>
+<tr>
+<td>Redundant module qualifier</td>
+<td>
+Example: 
+<pre>
+import qualified Data.Map as Map 
+foo :: Map.Map k v
+</pre>
+Found:
+<code>
+Map.Map
+</code>
+<br>
+Suggestion:
+<code>
+Map
+</code>
+<br>
+Does not support refactoring.
+</td>
+<td>Suggestion</td>
+</tr>
+</table>
+
 ## Builtin Unsafe
 
 <table>

--- a/hints.md
+++ b/hints.md
@@ -1500,6 +1500,7 @@ Suggestion:
 <td>
 Example: 
 <pre>
+import Data.Map (Map) 
 import qualified Data.Map as Map 
 foo :: Map.Map k v
 </pre>

--- a/hlint.cabal
+++ b/hlint.cabal
@@ -165,6 +165,7 @@ library
         Hint.Pragma
         Hint.Restrict
         Hint.Smell
+        Hint.Stutter
         Hint.Type
         Hint.Unsafe
         Hint.NumLiteral

--- a/src/GHC/Util/Scope.hs
+++ b/src/GHC/Util/Scope.hs
@@ -4,7 +4,7 @@
 
 module GHC.Util.Scope (
    Scope
-  ,scopeCreate,scopeMatch,scopeMove,possModules
+  ,scopeCreate,scopeMatch,scopeMove,possModules,importedUnqualified
 ) where
 
 import GHC.Hs
@@ -102,6 +102,15 @@ possModules (Scope is) x =
         | otherwise = res0
 
     prelude = mkModuleName "Prelude"
+
+-- Calculate which modules certainly bring 'x' into scope unqualified, namely
+-- those imported with an explicit list naming it. Deliberately narrower than
+-- 'possModules': an open import could bring anything into scope, and
+-- 'scopeCreate' gives every scope an 'import Prelude', so guessing here would
+-- report every name as already taken.
+importedUnqualified :: Scope -> RdrName -> [ModuleName]
+importedUnqualified (Scope is) x =
+    [unLoc $ ideclName $ unLoc i | i <- is, possImport i (noLocA x) == Imported]
 
 data IsImported = Imported | PossiblyImported | NotImported  deriving (Eq)
 

--- a/src/Hint/All.hs
+++ b/src/Hint/All.hs
@@ -34,6 +34,7 @@ import Hint.Unsafe
 import Hint.NewType
 import Hint.Smell
 import Hint.NumLiteral
+import Hint.Stutter
 
 -- | A list of the builtin hints wired into HLint.
 --   This list is likely to grow over time.
@@ -41,7 +42,7 @@ data HintBuiltin =
     HintList | HintListRec | HintMonad | HintLambda | HintFixities | HintNegation |
     HintBracket | HintNaming | HintPattern | HintImport | HintExport |
     HintPragma | HintExtensions | HintUnsafe | HintDuplicate | HintRestrict |
-    HintComment | HintNewType | HintSmell | HintNumLiteral
+    HintComment | HintNewType | HintSmell | HintNumLiteral | HintStutter
     deriving (Show,Eq,Ord,Bounded,Enum)
 
 -- See https://github.com/ndmitchell/hlint/issues/1150 - Duplicate is too slow
@@ -70,6 +71,7 @@ builtin x = case x of
     HintMonad      -> decl monadHint
     HintExtensions -> modu extensionsHint
     HintNumLiteral -> decl numLiteralHint
+    HintStutter    -> decl stutterHint
     where
         wrap = timed "Hint" (drop 4 $ show x) . forceList
         decl f = mempty{hintDecl=const $ \a b c -> wrap $ f a b c}

--- a/src/Hint/Stutter.hs
+++ b/src/Hint/Stutter.hs
@@ -20,6 +20,9 @@ instance C Text.Text -- Text
 foo = undefined :: Map.Map k v -- Map
 import qualified Data.Map as Map \
 foo :: Map.Map k v -- @Note requires importing Data.Map (Map)
+import qualified Data.Map as Map \
+import qualified Data.IntMap as Map \
+foo :: Map.Map k v -- @Note requires importing Map unqualified
 import qualified Data.Map as M \
 foo :: M.Map k v
 foo :: Map k v

--- a/src/Hint/Stutter.hs
+++ b/src/Hint/Stutter.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+
+{-
+    Find type occurrences whose module qualifier repeats the type name,
+    such as 'Map.Map', 'Set.Set' or 'Text.Text'. A module may be imported
+    twice, so the qualified import can stay and a second import can bring
+    just the type into scope unqualified:
+
+    > import Data.Map (Map)
+    > import Data.Map qualified as Map
+
+<TEST>
+foo :: Map.Map k v -- @Suggestion Map
+foo :: Data.Map.Map k v -- Map
+type Foo = Set.Set Int -- Set
+data Foo = Foo Text.Text -- Text
+newtype Foo = Foo {unFoo :: Seq.Seq Int} -- Seq
+instance C Text.Text -- Text
+foo = undefined :: Map.Map k v -- Map
+import qualified Data.Map as Map \
+foo :: Map.Map k v -- @Note requires importing Data.Map (Map)
+import qualified Data.Map as M \
+foo :: M.Map k v
+foo :: Map k v
+foo :: Map.Key k
+foo :: Data.Map.Strict.Map k v
+foo = Map.Map
+foo = Map.empty
+import Data.Map as Map
+</TEST>
+-}
+
+module Hint.Stutter(stutterHint) where
+
+import Hint.Type(DeclHint,Note(..),Severity(..),rawIdea)
+import GHC.Util(Scope,possModules)
+
+import Data.Generics.Uniplate.DataOnly
+import Data.List.Extra
+import Prelude
+
+import GHC.Hs
+import GHC.Types.Name.Occurrence
+import GHC.Types.Name.Reader
+import GHC.Types.SrcLoc
+import Language.Haskell.GhclibParserEx.GHC.Utils.Outputable
+
+stutterHint :: DeclHint
+stutterHint scope _ decl =
+    [ rawIdea Suggestion "Redundant module qualifier" (locA l)
+        (unsafePrettyPrint ty)
+        (Just $ unsafePrettyPrint unqualified)
+        -- Dropping the qualifier only compiles once the type is in scope
+        -- unqualified, which HLint cannot arrange, so offer no refactoring.
+        [Note $ importNote scope lname occ]
+        []
+    | L l ty@(HsTyVar x promoted lname@(L nameLoc name)) <- universeBi decl :: [LHsType GhcPs]
+    , stutters name
+    , let occ = rdrNameOcc name
+    , let unqualified = HsTyVar x promoted (L nameLoc (mkRdrUnqual occ)) :: HsType GhcPs
+    ]
+
+-- | Does the qualifier's final component repeat the name it qualifies, as in
+-- @Map.Map@ or @Data.Map.Map@?
+stutters :: RdrName -> Bool
+stutters (Qual modu occ) =
+    takeWhileEnd (/= '.') (moduleNameString modu) == occNameString occ
+stutters _ = False
+
+-- | Spell out the import that brings the type into scope unqualified whenever
+-- the qualifier resolves to a single module. Deliberately silent on whether it
+-- joins the qualified import or replaces it, since that depends on whether the
+-- qualifier is used elsewhere in the module.
+importNote :: Scope -> LocatedN RdrName -> OccName -> String
+importNote scope name occ = case possModules scope name of
+    [modu] -> "requires importing " ++ moduleNameString modu ++ " (" ++ occNameString occ ++ ")"
+    _ -> "requires importing " ++ occNameString occ ++ " unqualified"

--- a/src/Hint/Stutter.hs
+++ b/src/Hint/Stutter.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE ImportQualifiedPost #-}
-
 {-
-    Find type occurrences whose module qualifier repeats the type name,
-    such as 'Map.Map', 'Set.Set' or 'Text.Text'. A module may be imported
+    Find type occurrences whose one-component module qualifier repeats the type
+    name, such as 'Map.Map', 'Set.Set' or 'Text.Text'. A module may be imported
     twice, so the qualified import can stay and a second import can bring
     just the type into scope unqualified:
 
     > import Data.Map (Map)
     > import Data.Map qualified as Map
 
+    A qualifier that is a full module name, as in 'Data.Map.Map', is left alone.
+    Two modules that both export a 'Map' can only be told apart by their full
+    names, so there the qualifier is carrying its weight.
+
 <TEST>
 foo :: Map.Map k v -- @Suggestion Map
-foo :: Data.Map.Map k v -- Map
 type Foo = Set.Set Int -- Set
 data Foo = Foo Text.Text -- Text
 newtype Foo = Foo {unFoo :: Seq.Seq Int} -- Seq
@@ -23,7 +24,11 @@ import qualified Data.Map as M \
 foo :: M.Map k v
 foo :: Map k v
 foo :: Map.Key k
+foo :: Data.Map.Map k v
 foo :: Data.Map.Strict.Map k v
+import qualified Data.Map \
+import qualified Foo.Map \
+foo :: Data.Map.Map k v -> Foo.Map.Map k v
 foo = Map.Map
 foo = Map.empty
 import Data.Map as Map
@@ -36,7 +41,6 @@ import Hint.Type(DeclHint,Note(..),Severity(..),rawIdea)
 import GHC.Util(Scope,possModules)
 
 import Data.Generics.Uniplate.DataOnly
-import Data.List.Extra
 import Prelude
 
 import GHC.Hs
@@ -60,11 +64,11 @@ stutterHint scope _ decl =
     , let unqualified = HsTyVar x promoted (L nameLoc (mkRdrUnqual occ)) :: HsType GhcPs
     ]
 
--- | Does the qualifier's final component repeat the name it qualifies, as in
--- @Map.Map@ or @Data.Map.Map@?
+-- | Is the qualifier a single component repeating the name it qualifies, as in
+-- @Map.Map@? A qualifier that is a full module name, as in @Data.Map.Map@, is
+-- how you tell two modules' @Map@s apart, so it does not count.
 stutters :: RdrName -> Bool
-stutters (Qual modu occ) =
-    takeWhileEnd (/= '.') (moduleNameString modu) == occNameString occ
+stutters (Qual modu occ) = moduleNameString modu == occNameString occ
 stutters _ = False
 
 -- | Spell out the import that brings the type into scope unqualified whenever

--- a/src/Hint/Stutter.hs
+++ b/src/Hint/Stutter.hs
@@ -23,6 +23,12 @@ foo :: Map.Map k v -- @Note requires importing Data.Map (Map)
 import qualified Data.Map as Map \
 import qualified Data.IntMap as Map \
 foo :: Map.Map k v -- @Note requires importing Map unqualified
+import Data.Map (Map) \
+import qualified Data.Map as Map \
+foo :: Map.Map k v -- @Note Map is already in scope unqualified
+import qualified Data.Map as Map \
+import Foo (Map) \
+foo :: Map.Map k v
 import qualified Data.Map as M \
 foo :: M.Map k v
 foo :: Map k v
@@ -41,7 +47,7 @@ import Data.Map as Map
 module Hint.Stutter(stutterHint) where
 
 import Hint.Type(DeclHint,Note(..),Severity(..),rawIdea)
-import GHC.Util(Scope,possModules)
+import GHC.Util(Scope,possModules,importedUnqualified)
 
 import Data.Generics.Uniplate.DataOnly
 import Prelude
@@ -64,8 +70,16 @@ stutterHint scope _ decl =
     | L l ty@(HsTyVar x promoted lname@(L nameLoc name)) <- universeBi decl :: [LHsType GhcPs]
     , stutters name
     , let occ = rdrNameOcc name
+    , not $ qualifierDisambiguates scope lname occ
     , let unqualified = HsTyVar x promoted (L nameLoc (mkRdrUnqual occ)) :: HsType GhcPs
     ]
+
+-- | Is the qualifier telling two types apart? An import that already binds the
+-- name unqualified to some other module makes it load-bearing: dropping it
+-- would be an ambiguous occurrence, or worse, silently the other type.
+qualifierDisambiguates :: Scope -> LocatedN RdrName -> OccName -> Bool
+qualifierDisambiguates scope name occ =
+    any (`notElem` possModules scope name) $ importedUnqualified scope (mkRdrUnqual occ)
 
 -- | Is the qualifier a single component repeating the name it qualifies, as in
 -- @Map.Map@? A qualifier that is a full module name, as in @Data.Map.Map@, is
@@ -74,11 +88,14 @@ stutters :: RdrName -> Bool
 stutters (Qual modu occ) = moduleNameString modu == occNameString occ
 stutters _ = False
 
--- | Spell out the import that brings the type into scope unqualified whenever
--- the qualifier resolves to a single module. Deliberately silent on whether it
--- joins the qualified import or replaces it, since that depends on whether the
--- qualifier is used elsewhere in the module.
+-- | Spell out what has to change for the qualifier to go away, which is nothing
+-- at all when the type is already in scope unqualified. Where an import is
+-- needed, deliberately silent on whether it joins the qualified one or replaces
+-- it, since that depends on whether the qualifier is used elsewhere.
 importNote :: Scope -> LocatedN RdrName -> OccName -> String
-importNote scope name occ = case possModules scope name of
-    [modu] -> "requires importing " ++ moduleNameString modu ++ " (" ++ occNameString occ ++ ")"
-    _ -> "requires importing " ++ occNameString occ ++ " unqualified"
+importNote scope name occ
+    | not $ null $ importedUnqualified scope (mkRdrUnqual occ) =
+        occNameString occ ++ " is already in scope unqualified"
+    | [modu] <- possModules scope name =
+        "requires importing " ++ moduleNameString modu ++ " (" ++ occNameString occ ++ ")"
+    | otherwise = "requires importing " ++ occNameString occ ++ " unqualified"


### PR DESCRIPTION
Implements #1701.

Type occurrences like `Map.Map`, `Set.Set` or `Text.Text` stutter. A module may be imported twice, so the qualified import can stay and a second one brings just the type into scope unqualified:

```haskell
import Data.Map (Map)
import Data.Map qualified as Map
```

```
Foo.hs:5:15-21: Suggestion: Redundant module qualifier
Found:
  Map.Map
Perhaps:
  Map
Note: requires importing Data.Map (Map)
```

### Scope

Only a one-component qualifier repeating the type name, so `Map.Map` but not `Data.Map.Map`: per @zliu41's review, a full module name is how you tell `Data.Map`'s `Map` from `Foo.Map`'s.

For the same reason it stays quiet when an import already binds the name unqualified to a different module, since dropping the qualifier there is an ambiguous occurrence. Detecting that needs certainty rather than a guess, hence `importedUnqualified` in `GHC.Util.Scope`, which counts only imports with an explicit list naming the type.

Fires in signatures, `data`/`newtype` declarations, type synonyms, instance heads and expression type annotations. Value-level occurrences are untouched. Severity is `Suggestion`, since whether the extra import is worth it is a matter of taste.

The note names the module when the qualifier resolves to one, falls back to "requires importing Map unqualified" when ambiguous, and says "already in scope unqualified" when only the qualifier needs deleting. It deliberately doesn't say whether the new import joins the qualified one or replaces it: that depends on whether the qualifier is used elsewhere.

### No refactoring

Dropping the qualifier only compiles once the type is in scope unqualified, which HLint can't arrange, so the hint offers no `Refactoring` rather than letting `--refactor` produce code that doesn't build.

### What it finds in HLint itself

20 occurrences across 6 files, deliberately not changed here — happy to add a follow-up commit applying them. CI is unaffected, since the `ndmitchell/neil` step lints with a released HLint.

| File | Count |
| --- | --- |
| `src/Hint/Restrict.hs` | 10 |
| `src/Hint/Extensions.hs` | 5 |
| `src/Hint/Duplicate.hs` | 2 |
| `src/GHC/Util/ApiAnnotation.hs` | 1 |
| `src/Hint/Naming.hs` | 1 |
| `src/Hint/Smell.hs` | 1 |

### Testing

`hlint --test` passes. The `<TEST>` block covers positives, all three note forms, and negatives: `Data.Map.Map`, `Data.Map.Strict.Map`, `Map.Key`, a non-stuttering alias, a load-bearing alias, value-level `Map.Map`, and the import declaration itself.

`hints.md` regenerated.

---
Written by Claude, reviewed and signed-off on by @NorfairKing
